### PR TITLE
FIXED: qsave_program/2 failed with autoload(false)

### DIFF
--- a/library/qsave.pl
+++ b/library/qsave.pl
@@ -333,6 +333,7 @@ save_autoload(Options) :-
 	define_toplevel_goal(Options),
 	option(autoload(true),  Options, true), !,
 	autoload(Options).
+save_autoload(_).
 
 
 		 /*******************************


### PR DESCRIPTION
The cleanup in commit 8f6a3ee28795c0bed893974ad07d0122be67b81c caused
qsave_program/2 to fail anytime the autoload option was set to false.
This restores the intended behavior of skipping autoload/0 in that case.
