### PR TITLE
ENHANCED: group_pairs_by_key/2 now also works for variable keys.

### DIFF
--- a/library/pairs.pl
+++ b/library/pairs.pl
@@ -123,7 +123,8 @@ group_pairs_by_key([M-N|T0], [M-[N|TN]|T]) :-
 	same_key(M, T0, TN, T1),
 	group_pairs_by_key(T1, T).
 
-same_key(M, [M-N|T0], [N|TN], T) :- !,
+same_key(M0, [M-N|T0], [N|TN], T) :-
+	M0 == M, !,
 	same_key(M, T0, TN, T).
 same_key(_, L, [], L).
 


### PR DESCRIPTION
Please consider this patch for inclusion in master. There is nothing else in library(pairs) or keysort/2 that prevents the use of variables as keys, so group_pairs_by_keys/2 should support it too. A use case for this is to group and sum up coefficients of the same variable in linear constraints. Thank you!
