### PR TITLE
Fix pack installation for GitHub releases

### DIFF
--- a/library/prolog_pack.pl
+++ b/library/prolog_pack.pl
@@ -756,6 +756,12 @@ download_file(URL, Pack, File, Options) :-
 	atom_version(VersionA, Version),
 	file_name_extension(_, Ext, URL),
 	format(atom(File), '~w-~w.~w', [Pack, VersionA, Ext]).
+download_file(URL, Pack, File, _) :-
+	file_base_name(URL,Basename),
+	file_name_extension(Tag,Ext,Basename),
+	tag_version(Tag,Version), !,
+	atom_version(VersionA,Version),
+	format(atom(File), '~w-~w.~w', [Pack, VersionA, Ext]).
 download_file(URL, _, File, _) :-
 	file_base_name(URL, File).
 


### PR DESCRIPTION
Trying to install a pack whose releases are hosted on GitHub was failing
with errors like "ERROR: V0.9.0.zip: A package archive must be
named <pack>-<version>.<ext>"  When downloading a release from GitHub,
store it locally using the proscribed naming convention.

This fixes issue mndrix/julian#8