### PR TITLE
ls/1 fails if a filename without wildcards does not exist

### DIFF
--- a/library/shell.pl
+++ b/library/shell.pl
@@ -174,7 +174,8 @@ tagged_file_in_dir(File, Result) :-
 tag_file(File, Dir) :-
 	exists_directory(File),	!,
 	atom_concat(File, /, Dir).
-tag_file(File, File).
+tag_file(File, File) :-
+        exists_file(File), !.
 
 %%	mv(+From, +To) is det.
 %


### PR DESCRIPTION
This fixes the following unexpected behavior of ls/1:

~~~~
?- ls('foobar*').
Warning: No match: foobar*
false.

?- ls('foobar').
% foobar   
true.
~~~~