### PR TITLE
FIXED: Make pack locations volatile

### DIFF
--- a/boot/packs.pl
+++ b/boot/packs.pl
@@ -41,6 +41,9 @@
 :- dynamic
 	pack_dir/3,				% Pack, Type, Dir
 	pack/2.					% Pack, BaseDir
+:- volatile
+	pack_dir/3,
+	pack/2.
 
 
 user:file_search_path(pack, app_data(pack)).


### PR DESCRIPTION
A machine that runs a saved state may have a different file system
layout than the one which built the saved state.