### PR TITLE
Make pack_install stop with error when pack is already installed

### DIFF
--- a/library/prolog_pack.pl
+++ b/library/prolog_pack.pl
@@ -573,10 +573,10 @@ pack_install_dir(_, _) :-
 
 pack_install(Name, _, Options) :-
 	current_pack(Name),
-	option(update(true), Options, false),
+	option(upgrade(false), Options, false),
 	print_message(error, pack(already_installed(Name))),
 	pack_info(Name),
-	print_message(information, pack(remove_with(Name))),
+	print_message(information, pack(remove_with(Name))), !,
 	fail.
 pack_install(Name, PackDir, Options) :-
 	option(url(URL), Options),


### PR DESCRIPTION
This makes pack_install stop with error message when pack is already installed unless `upgrade(true)` option is set. I believe this was the original intent but the code used `update` option with inverted value and cut was missing which made the pack installed despite the error message.