### PR TITLE
Minor optimization to permutation/2.

### DIFF
--- a/library/lists.pl
+++ b/library/lists.pl
@@ -444,9 +444,32 @@ permutation(Xs, Ys) :-
 	perm(Xs, Ys).
 
 perm([], []).
-perm(List, [First|Perm]) :-
-        select(First, List, Rest),
-        perm(Rest, Perm).
+perm([Y|Ys], Xs) :-
+        permute(Xs, Z),
+	shift(Z, [Y|Ys]).
+
+permute([], []).
+permute([X|Xs], [X|Rest]) :-
+        (
+	   Xs = []
+	->
+	   Rest = Xs
+	;
+	   permute(Xs, P),
+	   shift(P, Rest)
+	).
+
+shift(Xs, S) :-
+        (  S = Xs
+	;  shift_(Xs, S)
+	).
+
+shift_([], []).
+shift_([X,Y|Rest], [Y|Tail]) :-
+        (  Tail = [X|Rest]
+	;  shift_([X|Rest], Tail)
+	).
+
 
 %%	flatten(+NestedList, -FlatList) is det.
 %


### PR DESCRIPTION
Hello, please consider my pull request for a slight performance enhancement to permutation/2.
I ran a few test benchmarks using the following template:
```
findall(X, between(1,10,X), Xs), 
time(aggregate_all(count, permutation(P, Xs), Ps)).
```

My results:
%% 10 elements
%
% 15,742,564 inferences, 2.631 CPU in 2.666 seconds (99% CPU, 5983191 Lips)
%  33,221,113 inferences, 5.607 CPU in 5.685 seconds (99% CPU, 5925066 Lips)

%% 11 elements
%
% 171,780,962 inferences, 34.496 CPU in 35.068 seconds (98% CPU, 4979795 Lips)
% 365,432,145 inferences, 67.407 CPU in 68.436 seconds (98% CPU, 5421259 Lips)

%% 12 elements
%
% 2,047,870,563 inferences, 456.695 CPU in 464.363 seconds (98% CPU, 4484110 Lips)
% 4,385,185,644 inferences, 866.261 CPU in 879.988 seconds (98% CPU, 5062200 Lips)