### PR TITLE
Possibly wrong negation instead of comparison

### DIFF
--- a/src/pl-init.c
+++ b/src/pl-init.c
@@ -1444,7 +1444,7 @@ vwarning(const char *fm, va_list args)
 
     if ( !GD->bootsession && GD->initialised &&
 	 !LD->outofstack &&		/* cannot call Prolog */
-	 !fm[0] == '$')			/* explicit: don't call Prolog */
+	 fm[0] != '$')			/* explicit: don't call Prolog */
     { char message[LINESIZ];
       char *s = message;
       fid_t cid;


### PR DESCRIPTION
The surrounding code is too much to comprehend at the moment but you should be able to judge if this was indeed a mistake.

This is the warning that gcc gave me when trying to compile:

```
pl-init.c: In function ‘vwarning’:
pl-init.c:1447:10: warning: comparison of constant ‘36’ with boolean expression is always false [-Wbool-compare]
   !fm[0] == '$')   /* explicit: don't call Prolog */
          ^
pl-init.c:1447:10: warning: logical not is only applied to the left hand side of comparison [-Wlogical-not-parentheses]
```
