### PR TITLE
Allows unset MACRO Wunused-result with gcc -DWUNUSED=""

### DIFF
--- a/src/SWI-Prolog.h
+++ b/src/SWI-Prolog.h
@@ -117,12 +117,14 @@ duplicated this stuff.
 		 *	  GCC ATTRIBUTES	*
 		 *******************************/
 
-#ifndef WUNUSED
-#if __GNUC__ >= 4
-#define WUNUSED __attribute__((warn_unused_result))
-#else
-#define WUNUSED
+#ifndef WNOUNUSED
+#  if __GNUC__ >= 4
+#    define WUNUSED __attribute__((warn_unused_result))
+#  endif
 #endif
+
+#ifndef WUNUSED
+#  define WUNUSED
 #endif
 
 

--- a/src/SWI-Prolog.h
+++ b/src/SWI-Prolog.h
@@ -117,10 +117,12 @@ duplicated this stuff.
 		 *	  GCC ATTRIBUTES	*
 		 *******************************/
 
+#ifndef WUNUSED
 #if __GNUC__ >= 4
 #define WUNUSED __attribute__((warn_unused_result))
 #else
 #define WUNUSED
+#endif
 #endif
 
 


### PR DESCRIPTION
This would allow a temporary (or permanent if so desired) disable of GCC -Wunsused-result, for functions that have __attribute__ ((warn_unsused_result)) set.

A GCC command line would add -DWUNUSED=""

This can allow a developer to keep the warn ON (no need to add -Wno-unused-result) for the entire project, without receiving warnings from SWI-Prolog.
