### PR TITLE
PL_TRY(M): MACRO

### DIFF
--- a/src/pl-builtin.h
+++ b/src/pl-builtin.h
@@ -207,6 +207,14 @@ is also printed if stdio is not available.
 #define SECURE(g) ((void)0)
 #endif
 
+/* If PL_func fail, exit */
+#define PL_TRY(M) do { if(0==((int)(M)))\
+                       {\
+                         DEBUG(1, Sdprintf("[PL_TRY fail file:%s line:%d]\n", __FILE__, __LINE__));\
+                         exit(EXIT_FAILURE);\
+                       }\
+                     } while(0)
+
 
 		 /*******************************
 		 *   NON-DET PREDICATE CONTEXT	*


### PR DESCRIPTION
To keep code clean while testing return values and doing proper debug/exit in case of problems.

This is a new approach to the -Wunused-result I did in other rejected pull, for good reasons.

Now, this MACRO can be used safely to keep an eye in middle results that are not so important to code, but still can cause crashs if not taken care of.
