### PR TITLE
ENHANCED: Rewriting min/max Witness templates to use constant space.

### DIFF
--- a/library/aggregate.pl
+++ b/library/aggregate.pl
@@ -196,6 +196,60 @@ aggregate_all(min(X), Goal, Min) :- !,
 	;  arg(1, State, Min),
 	   nonvar(Min)
 	).
+aggregate_all(min(X,W), Goal, min(Min,Witness)) :- !,
+	State = state(X,W,Flag,Solutions),
+	Flag = false,
+	Solutions = false,
+	(  call(Goal),
+	   (  call(Flag),
+	      arg(1, State, M)
+	   ->
+	      X < M,
+	      nb_setarg(1, State, X),
+	      nb_setarg(2, State, W),
+	      fail
+	   ;
+	      nb_setarg(1, State, X),
+	      nb_setarg(2, State, W),
+	      (  nonvar(X)
+	      -> nb_setarg(3, State, true),
+		 nb_setarg(4, State, true)
+	      ;  instantiation_error(X)
+	      ),
+	      fail
+	   )
+	;
+	   arg(4, State, true),
+	   arg(1, State, Min),
+	   arg(2, State, Witness)
+	).
+aggregate_all(max(X,W), Goal, max(Max,Witness)) :- !,
+	State = state(X,W,Flag,Solutions),
+	Flag = false,
+	Solutions = false,
+	(  call(Goal),
+	   (  call(Flag),
+	      arg(1, State, M)
+	   ->
+	      X > M,
+	      nb_setarg(1, State, X),
+	      nb_setarg(2, State, W),
+	      fail
+	   ;
+	      nb_setarg(1, State, X),
+	      nb_setarg(2, State, W),
+	      (  nonvar(X)
+	      -> nb_setarg(3, State, true),
+		 nb_setarg(4, State, true)
+	      ;  instantiation_error(X)
+	      ),
+	      fail
+	   )
+	;
+	   arg(4, State, true),
+	   arg(1, State, Max),
+	   arg(2, State, Witness)
+	).
 aggregate_all(Template, Goal0, Result) :-
 	template_to_pattern(all, Template, Pattern, Goal0, Goal, Aggregate),
 	findall(Pattern, Goal, List),


### PR DESCRIPTION
I chose to use this "heavier looking code" for several reasons. Here are some alternatives that I attempted:
```
agg_all_1(min(X,W), Goal, min(Min,Witness)) :- !,
  State = state(X,W),
  (  call(Goal),
     arg(1, State, M0),
     M is min(M0,X),
     nb_setarg(1, State, M),
     M \== M0,
     nb_setarg(2, State, W),
     fail
  ;
     arg(1, State, Min),
     arg(2, State, Witness)
  ).
```
In this variation you will see it is clearly shorter than the implementation I chose. However, you'll also notice that the minimum is calculated, set as the state, and then checked again with respect to equality of the last minimum. This is necessary, because we don't want the wrong witness being bound to a repeat X in a solution. So here, although the code "looks cleaner", there is twice the amount of checks in this algorithm.

Also:
```
agg_all_2(min(X,W), Goal, min(Min,Witness)) :- !,
  State = state(X,W,LastMin),
  (  call(Goal),
     arg(1, State, M),
     (  X \== LastMin,
	X < M
     -> true
     ;  nb_setarg(1, State, X),
	nb_setarg(3, State, X),
	fail
     ),
     nb_setarg(1, State, X),
     nb_setarg(2, State, W),
     nb_setarg(3, State, X),
     fail
  ;
     arg(1, State, Min),
     arg(2, State, Witness)
  ).
```
In this version there is not too much of an improvement either. There is the possibility of avoiding writes alltogether, however we still have the possibility of reundant checks. Furthermore, the implementation that I eventually chose accounts for the odd mode variations in `Goal` (i.e. the ground, and mixed mode bound variations). These alternatives do not account for maintaining the behavior of the original. So if these variations were chosen, the final versions would most likely not be pristine. Ultimately, the version I chose to implement does this, and utilizes no redundant checks. It introduces two more state variables: `Flag` and `Solutions`. `Flag` checks whether or not we are passed the first solution (hence behavior changes once changed to true). `Solutions` checks to make sure that `Goal` actually has solutions in the first place. This acts as a check for questionable results returned in mode variations other than `(-,-)`.