### PR TITLE
DOC: typo in string_predicate/1 usage example

### DIFF
--- a/man/extensions.doc
+++ b/man/extensions.doc
@@ -459,7 +459,7 @@ list_strings/0 from complaining:
 \begin{code}
 :- multifile check:string_predicate/1.
 
-string_predicate(user:help_info/2).
+check:string_predicate(user:help_info/2).
 \end{code}
 
     \predicate{check:valid_string_goal}{1}{:Goal}


### PR DESCRIPTION
it seems there is a typo in the documentation of  string_predicate/1 (module name omitted)