### PR TITLE
Updated listing/1  to show the proper defining module

### DIFF
--- a/library/listing.pl
+++ b/library/listing.pl
@@ -169,7 +169,9 @@ list_predicates(PIs, Context:X) :-
 	pi_to_head(PI, Pred),
 	unify_args(Pred, X),
 	'$define_predicate'(Pred),
-	strip_module(Pred, Module, Head),
+	strip_module(Pred, _, Head),
+	current_predicate(_,Module:Head),
+	\+ predicate_property(Module:Head,imported_from(_)),
         list_predicate(Module:Head, Context),
 	nl,
         fail.


### PR DESCRIPTION
This fixes the issue with autoloaded predicates displaying the defining module incorrectly the first time you type 

?- listing(ls).

(the second calling to listing was correct before this patch, and continues to correct after this patch)