### PR TITLE
FIXED:  existence_error(variable,'$variable_names')  In var_property/…

### DIFF
--- a/boot/expand.pl
+++ b/boot/expand.pl
@@ -365,7 +365,7 @@ prop_var(fresh(Fresh), Var) :-
 	 ;   Fresh = true
 	 ).
 prop_var(name(Name), Var) :-
-	(   b_getval('$variable_names', Bindings),
+	(   nb_current('$variable_names', Bindings),
 	    '$member'(Name0=Var0, Bindings),
 	    Var0 == Var
 	->  Name = Name0


### PR DESCRIPTION
FIXED:  existence_error(variable,'$variable_names')  In var_property/2   for newly created threads

Perhaps new threads should create it if its missing? 

% [Thread 21] Got exception existence_error(variable,'$variable_names') (Ctx0=system:b_getval/2, Catcher=system:'<meta-call>'/1)