### PR TITLE
FIXED - Listing no longer removes meta_predicate/1s and module_transp…

### DIFF
--- a/library/listing.pl
+++ b/library/listing.pl
@@ -234,7 +234,7 @@ declaration(Pred, Source, Decl) :-
 	predicate_property(Pred, Prop),
 	decl_term(Pred, Source, Funct),
 	Decl =.. [ Declname, Funct ].
-declaration(Pred, Source, Decl) :- !,
+declaration(Pred, Source, Decl) :-
 	predicate_property(Pred, meta_predicate(Head)),
 	strip_module(Pred, Module, _),
 	(   (Module == system; Source == Module)


### PR DESCRIPTION
FIXED - Listing no longer removes meta_predicate/1s and module_transarent/1s

I know secretly meta_predicate/1 one day might only work if put right after the module exports but for now it'd be good to leave in the listing.