### PR TITLE
MANPAGE: Document "swipl file1 ..." invocation, as in swipl --help.

### DIFF
--- a/src/swipl.1.in
+++ b/src/swipl.1.in
@@ -11,6 +11,10 @@
 .br
 .B @PL@
 [options]
+.I "prolog-file ... [-- arg ...]"
+.br
+.B @PL@
+[options]
 .RB [ "\-o \fIoutput" ]
 .BI \-c " file ..."
 .br


### PR DESCRIPTION
This documents the important

    swipl file1 file2 ...

invocation method of SWI-Prolog in the manpage. This also aligns the manpage with the `swipl --help` message a bit better.