### PR TITLE
Raise the GLOBAL_OVERFLOW (if that is really happening)

### DIFF
--- a/src/pl-attvar.c
+++ b/src/pl-attvar.c
@@ -1387,6 +1387,8 @@ PRED_IMPL("$attvar_assign", 2, dattvar_assign, 0)
   deRef(av);
   if ( isAttVar(*av) )
   { deRef2(valTermRef(A2), value);
+    /* FALSE on the next line isn't a hiding of trouble it will still raise the GLOBAL_OVERFLOW */
+    if(!allocGlobal(0)) return FALSE;
     assignAttVar(av, value, ATT_ASSIGNONLY PASS_LD);
   } else
   { unify_vp(av,valTermRef(A2) PASS_LD);


### PR DESCRIPTION
https://github.com/SWI-Prolog/swipl-devel/issues/106

@triska  Hi Markus, this should be helpful.    

Notes:   Old code used to perform this check in do_unify() .. But since then we have split the responsibility of assignment out of do_unify() the right thing would be to remove the checks for there .  Might include that into this patch