### PR TITLE
FIXED: make --without-* work

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -6,6 +6,7 @@
 
 BUILDARCH=@BUILDARCH@
 CONFIG_OPTIONS=@CONFIG_OPTIONS@
+PACKAGES_CONFIG_OPTIONS=@PACKAGES_CONFIG_OPTIONS@
 
 .PHONY:	lite world packages
 
@@ -66,7 +67,7 @@ world:	packages
 ln-world: world
 
 packages: lite
-	cd packages && ./configure $(CONFIG_OPTIONS)
+	cd packages && ./configure $(CONFIG_OPTIONS) $(PACKAGES_CONFIG_OPTIONS)
 	cd packages && $(MAKE)
 
 install-world::

--- a/configure
+++ b/configure
@@ -9,6 +9,7 @@
 
 TARGET=lite
 configoptions=""
+packagesconfigoptions=""
 kerneloptions=""
 
 usage()
@@ -34,9 +35,7 @@ while [ "$1" != "" ]; do
     --with-world)	TARGET=world
 			shift
 			;;
-    --without-*)	pkg=`echo $1 | sed 's/--without-//'`
-			DISABLE_PKGS="$DISABLE_PKGS $pkg"
-			export DISABLE_PKGS
+    --without-*)	packagesconfigoptions="$packagesconfigoptions $1"
 			shift
 			;;
     --link)		TARGET="ln-$TARGET"
@@ -64,6 +63,7 @@ if [ ! -d "$BUILDARCH" ]; then mkdir "$BUILDARCH"; fi
 sed -e "s/@BUILDARCH@/$BUILDARCH/" \
     -e "s/@TARGET@/$TARGET/" \
     -e "s%@CONFIG_OPTIONS@%$configoptions%" \
+    -e "s%@PACKAGES_CONFIG_OPTIONS@%$packagesconfigoptions%" \
 	Makefile.in > Makefile
 
 if [ -d .git ]; then


### PR DESCRIPTION
Commit 8257acd doesn't work any more with current build structure
because packages are configured during make and hence `DISABLE_PKGS`
is not visible to `packages/configure` script.

The fix is simply passing `--without-*` to `packages/configure`
without touching at the top level.