### PR TITLE
MODIFIED: read_pending_[chars|codes]/3 -> get_pending_[chars|codes]/3.

### DIFF
--- a/library/backcomp.pl
+++ b/library/backcomp.pl
@@ -253,10 +253,10 @@ read_variables(Stream, Term, Vars) :-
 
 %%	read_pending_input(+Stream, -Codes, ?Tail) is det.
 %
-%	@deprecated Use read_pending_codes/3.
+%	@deprecated Use get_pending_codes/3.
 
 read_pending_input(Stream, Codes, Tail) :-
-	read_pending_codes(Stream, Codes, Tail).
+	get_pending_codes(Stream, Codes, Tail).
 
 %%	feature(?Key, ?Value) is nondet.
 %%	set_feature(+Key, @Term) is det.

--- a/man/builtin.doc
+++ b/man/builtin.doc
@@ -4496,7 +4496,7 @@ between two text files.  See \secref{encoding}.
 Copy all (remaining) data from \arg{StreamIn} to
 \arg{StreamOut}.
 
-    \predicate{read_pending_codes}{3}{+StreamIn, -Codes, ?Tail}
+    \predicate{get_pending_codes}{3}{+StreamIn, -Codes, ?Tail}
 Read input pending in the input buffer of \arg{StreamIn} and return
 it in the difference list \arg{Codes}-\arg{Tail}. That is, the
 available characters codes are used to create the list \arg{Codes}
@@ -4517,15 +4517,15 @@ copy(In, Out) :-
 	repeat,
 	    (	at_end_of_stream(In)
 	    ->	!
-	    ;	read_pending_codes(In, Chars, []),
+	    ;	get_pending_codes(In, Chars, []),
 		format(Out, '~s', [Chars]),
 		flush_output(Out),
 		fail
 	    ).
 \end{code}
 
-    \predicate{read_pending_chars}{3}{+StreamIn, -Chars, ?Tail}
-As read_pending_codes/3, but returns a difference list of one-character
+    \predicate{get_pending_chars}{3}{+StreamIn, -Chars, ?Tail}
+As get_pending_codes/3, but returns a difference list of one-character
 atoms.
 \end{description}
 

--- a/man/summary.doc
+++ b/man/summary.doc
@@ -518,8 +518,8 @@ suggest predicates from a keyword.
 \predicatesummary{read_clause}{3}{Read clause from stream}
 \predicatesummary{read_history}{6}{Read using history substitution}
 \predicatesummary{read_link}{3}{Read a symbolic link}
-\predicatesummary{read_pending_codes}{3}{Fetch buffered input from a stream}
-\predicatesummary{read_pending_chars}{3}{Fetch buffered input from a stream}
+\predicatesummary{get_pending_codes}{3}{Fetch buffered input from a stream}
+\predicatesummary{get_pending_chars}{3}{Fetch buffered input from a stream}
 \predicatesummary{read_string}{3}{Read a number of characters into a string}
 \predicatesummary{read_string}{5}{Read string upto a delimiter}
 \predicatesummary{read_term}{2}{Read term with options}

--- a/src/os/pl-file.c
+++ b/src/os/pl-file.c
@@ -2628,7 +2628,7 @@ read_pending_input(term_t input, term_t list, term_t tail, int chars ARG_LD)
 
 
 static
-PRED_IMPL("read_pending_codes", 3, read_pending_codes, 0)
+PRED_IMPL("get_pending_codes", 3, get_pending_codes, 0)
 { PRED_LD
 
   return read_pending_input(A1, A2, A3, FALSE PASS_LD);
@@ -2636,7 +2636,7 @@ PRED_IMPL("read_pending_codes", 3, read_pending_codes, 0)
 
 
 static
-PRED_IMPL("read_pending_chars", 3, read_pending_chars, 0)
+PRED_IMPL("get_pending_chars", 3, get_pending_chars, 0)
 { PRED_LD
 
   return read_pending_input(A1, A2, A3, TRUE PASS_LD);
@@ -5249,8 +5249,8 @@ BeginPredDefs(file)
   PRED_DEF("wait_for_input", 3, wait_for_input, 0)
 #endif
   PRED_DEF("get_single_char", 1, get_single_char, 0)
-  PRED_DEF("read_pending_codes", 3, read_pending_codes, 0)
-  PRED_DEF("read_pending_chars", 3, read_pending_chars, 0)
+  PRED_DEF("get_pending_codes", 3, get_pending_codes, 0)
+  PRED_DEF("get_pending_chars", 3, get_pending_chars, 0)
   PRED_DEF("source_location", 2, source_location, 0)
   PRED_DEF("copy_stream_data", 3, copy_stream_data3, 0)
   PRED_DEF("copy_stream_data", 2, copy_stream_data2, 0)


### PR DESCRIPTION
The rational is that "read" is always used for full Prolog terms, while
"get" is used for other I/O, like get_char/1 and get_code/1.

Please consider merging this pull request. If you apply it, then `read_pending_codes/3` needs to be replaced by `get_pending_codes/3` in the modules. I have sent pull requests for the packages too.
