### PR TITLE
DELETED: clause prolog:message_location(file(..., in prolog_codewalk.…

### DIFF
--- a/library/prolog_codewalk.pl
+++ b/library/prolog_codewalk.pl
@@ -949,8 +949,6 @@ prolog:message_location(clause(ClauseRef)) -->
 	[ '~w: '-[Name] ].
 prolog:message_location(file_term_position(Path, TermPos)) -->
 	message_location_file_term_position(Path, TermPos).
-prolog:message_location(file(Path, Line, _, _)) -->
-	[ '~w:~d: '-[Path, Line] ].
 prolog:message(codewalk(reiterate(New, Iteration, CPU))) -->
 	[ 'Found new meta-predicates in iteration ~w (~3f sec)'-
 	  [Iteration, CPU], nl ],


### PR DESCRIPTION
…pl, it is

	 already defined in messages.pl, clause swi_location(file(... which is
	 a better implementation.

Hi Jan,
Notice that the clauses in swi_location can handle file(Path, Line, Pos, _), when Pos is defined and positive, while the one in prolog_codewalk.pl can not, that was causing me differences in messages after loading prolog_codewalk,pl and loose of precision in the source location (Pos was ignored).