### PR TITLE
Initialisation function from memory 

### DIFF
--- a/src/SWI-Prolog.h
+++ b/src/SWI-Prolog.h
@@ -880,7 +880,7 @@ PL_EXPORT(int)	PL_wchars_to_term(const pl_wchar_t *chars,
 		 *	    EMBEDDING		*
 		 *******************************/
 
-PL_EXPORT(int)		PL_initialise(int argc, char **argv);
+PL_EXPORT(int)		PL_is_initialised(int *argc, char ***argv);
 PL_EXPORT(int)		PL_initialise(int argc, char **argv);
 PL_EXPORT(int)		PL_initialise_mem(int argc, char **argv, char *mem_data, long int mem_size);
 #ifdef __CYGWIN__

--- a/src/SWI-Prolog.h
+++ b/src/SWI-Prolog.h
@@ -882,7 +882,7 @@ PL_EXPORT(int)	PL_wchars_to_term(const pl_wchar_t *chars,
 
 PL_EXPORT(int)		PL_is_initialised(int *argc, char ***argv);
 PL_EXPORT(int)		PL_initialise(int argc, char **argv);
-PL_EXPORT(int)		PL_boot_from_memory(int argc, char **argv, char *mem_data, long int mem_size);
+PL_EXPORT(int)		PL_boot_from_memory(int argc, char **argv, char *mem_data, size_t mem_size);
 #ifdef __CYGWIN__
 PL_EXPORT(void)		PL_install_readline(void);
 #else

--- a/src/SWI-Prolog.h
+++ b/src/SWI-Prolog.h
@@ -881,7 +881,8 @@ PL_EXPORT(int)	PL_wchars_to_term(const pl_wchar_t *chars,
 		 *******************************/
 
 PL_EXPORT(int)		PL_initialise(int argc, char **argv);
-PL_EXPORT(int)		PL_is_initialised(int *argc, char ***argv);
+PL_EXPORT(int)		PL_initialise(int argc, char **argv);
+PL_EXPORT(int)		PL_initialise_mem(int argc, char **argv, char *mem_data, long int mem_size);
 #ifdef __CYGWIN__
 PL_EXPORT(void)		PL_install_readline(void);
 #else

--- a/src/SWI-Prolog.h
+++ b/src/SWI-Prolog.h
@@ -882,7 +882,7 @@ PL_EXPORT(int)	PL_wchars_to_term(const pl_wchar_t *chars,
 
 PL_EXPORT(int)		PL_is_initialised(int *argc, char ***argv);
 PL_EXPORT(int)		PL_initialise(int argc, char **argv);
-PL_EXPORT(int)		PL_initialise_mem(int argc, char **argv, char *mem_data, long int mem_size);
+PL_EXPORT(int)		PL_boot_from_memory(int argc, char **argv, char *mem_data, long int mem_size);
 #ifdef __CYGWIN__
 PL_EXPORT(void)		PL_install_readline(void);
 #else

--- a/src/pl-init.c
+++ b/src/pl-init.c
@@ -917,7 +917,7 @@ PL_initialise_int(int argc, char **argv, char *mem_data, long int mem_size)
 
 // init prolog from memory
 int
-PL_boot_from_memory(int argc, char **argv, char *mem_data, long int mem_size)
+PL_boot_from_memory(int argc, char **argv, char *mem_data, size_t mem_size)
 {
 
 

--- a/src/pl-init.c
+++ b/src/pl-init.c
@@ -784,41 +784,18 @@ PL_initialise_int(int argc, char **argv, char *mem_data, long int mem_size)
   setPrologFlagMask(PLFLAG_SIGNALS);	/* default: handle signals */
 #endif
 
-/*********************************************************************************
-  if (    (GD->resourceDB = rc_open_archive(GD->paths.executable, RC_RDONLY))
+  // if resourceDB is present -- skip  rc_open_archive call (case for PL_boot_from_xxx calls)
+  if ( !GD->resourceDB) {
+    if (    (GD->resourceDB = rc_open_archive(GD->paths.executable, RC_RDONLY))
 #ifdef __WINDOWS__
-       || (GD->resourceDB = rc_open_archive(GD->paths.module, RC_RDONLY))
+         || (GD->resourceDB = rc_open_archive(GD->paths.module, RC_RDONLY))
 #endif
-     )
-  { rcpath = ((RcArchive)GD->resourceDB)->path;
-    initDefaultOptions();
+       )
+    { rcpath = ((RcArchive)GD->resourceDB)->path;
+      initDefaultOptions();
+    }
   }
-*********************************************************************************/
-
-  if (mem_size != 0 && mem_data != NULL) {
-	if (    (GD->resourceDB = rc_open_archive_mem(GD->paths.executable, mem_data, mem_size, RC_RDONLY))
-#ifdef __WINDOWS__
-			|| (GD->resourceDB = rc_open_archive_mem(GD->paths.module, mem_data, mem_size, RC_RDONLY))
-#endif
-	)
-	{ rcpath = ((RcArchive)GD->resourceDB)->path;
-	initDefaultOptions();
-	}
-
-  } else {
   
-	if (    (GD->resourceDB = rc_open_archive(GD->paths.executable, RC_RDONLY))
-#ifdef __WINDOWS__
-			|| (GD->resourceDB = rc_open_archive(GD->paths.module, RC_RDONLY))
-#endif
-	)
-	{ rcpath = ((RcArchive)GD->resourceDB)->path;
-	initDefaultOptions();
-	}
-  }
-
-
-
   if ( !GD->resourceDB ||
        !streq(GD->options.saveclass, "runtime") )
   { int done;
@@ -937,17 +914,26 @@ PL_initialise_int(int argc, char **argv, char *mem_data, long int mem_size)
 
 /* MOD-OL olsky OL-2013 patch for mem init */
 
+
+// init prolog from memory
 int
-PL_initialise(int argc, char **argv)
+PL_boot_from_memory(int argc, char **argv, char *mem_data, long int mem_size)
 {
-   return PL_initialise_int(argc, argv, NULL, 0);
+
+
+	if (mem_size != 0 && mem_data != NULL) {
+		if (    (GD->resourceDB = rc_open_archive_mem(GD->paths.executable, mem_data, mem_size, RC_RDONLY))
+#ifdef __WINDOWS__
+		        || (GD->resourceDB = rc_open_archive_mem(GD->paths.module, mem_data, mem_size, RC_RDONLY))
+#endif
+		   )
+		{	
+			return PL_initialise(argc, argv);
+		}
+	}
+	return FALSE;
 }
 
-int
-PL_initialise_mem(int argc, char **argv, char *mem_data, long int mem_size)
-{
-   return PL_initialise_int(argc, argv, mem_data, mem_size);
-}
 
 
 typedef const char *cline;

--- a/src/pl-init.c
+++ b/src/pl-init.c
@@ -760,7 +760,7 @@ PL_is_initialised(int *argc, char ***argv)
 
 
 int
-PL_initialise(int argc, char **argv)
+PL_initialise_int(int argc, char **argv, char *mem_data, long int mem_size)
 { int n;
   bool compile = FALSE;
   const char *rcpath = "<none>";
@@ -784,6 +784,7 @@ PL_initialise(int argc, char **argv)
   setPrologFlagMask(PLFLAG_SIGNALS);	/* default: handle signals */
 #endif
 
+/*********************************************************************************
   if (    (GD->resourceDB = rc_open_archive(GD->paths.executable, RC_RDONLY))
 #ifdef __WINDOWS__
        || (GD->resourceDB = rc_open_archive(GD->paths.module, RC_RDONLY))
@@ -792,6 +793,31 @@ PL_initialise(int argc, char **argv)
   { rcpath = ((RcArchive)GD->resourceDB)->path;
     initDefaultOptions();
   }
+*********************************************************************************/
+
+  if (mem_size != 0 && mem_data != NULL) {
+	if (    (GD->resourceDB = rc_open_archive_mem(GD->paths.executable, mem_data, mem_size, RC_RDONLY))
+#ifdef __WINDOWS__
+			|| (GD->resourceDB = rc_open_archive_mem(GD->paths.module, mem_data, mem_size, RC_RDONLY))
+#endif
+	)
+	{ rcpath = ((RcArchive)GD->resourceDB)->path;
+	initDefaultOptions();
+	}
+
+  } else {
+  
+	if (    (GD->resourceDB = rc_open_archive(GD->paths.executable, RC_RDONLY))
+#ifdef __WINDOWS__
+			|| (GD->resourceDB = rc_open_archive(GD->paths.module, RC_RDONLY))
+#endif
+	)
+	{ rcpath = ((RcArchive)GD->resourceDB)->path;
+	initDefaultOptions();
+	}
+  }
+
+
 
   if ( !GD->resourceDB ||
        !streq(GD->options.saveclass, "runtime") )
@@ -907,6 +933,20 @@ PL_initialise(int argc, char **argv)
     return status;
   }
   }					/* { GET_LD } */
+}
+
+/* MOD-OL olsky OL-2013 patch for mem init */
+
+int
+PL_initialise(int argc, char **argv)
+{
+   return PL_initialise_int(argc, argv, NULL, 0);
+}
+
+int
+PL_initialise_mem(int argc, char **argv, char *mem_data, long int mem_size)
+{
+   return PL_initialise_int(argc, argv, mem_data, mem_size);
 }
 
 

--- a/src/rc/access.c
+++ b/src/rc/access.c
@@ -54,11 +54,11 @@
 static HtmlTagDef file_tag_def = NULL;
 
 static int attach_archive(RcArchive rca);
-static int attach_archive_mem(RcArchive rca, char *mem, long int mem_size);
+static int attach_archive_mem(RcArchive rca, char *mem, size_t mem_size);
 
 /* MOD-OL olsky OL-2016: patch for mem */
 RcArchive
-rc_open_archive_mem(const char *file, char *mem, long int mem_size, int flags)
+rc_open_archive_mem(const char *file, char *mem, size_t mem_size, int flags)
 { RcArchive rca = malloc(sizeof(rc_archive));
 
   if ( rca )
@@ -454,7 +454,7 @@ scan_archive(RcArchive rca)
 
 /* olsky OL-2016: patch for mem */
 static int
-attach_archive_mem(RcArchive rca, char *mem, long int mem_size)
+attach_archive_mem(RcArchive rca, char *mem, size_t mem_size)
 {
     rca->map_size  = mem_size;
     rca->size      = rca->map_size;


### PR DESCRIPTION
Dear team,

I'd like to checkin the 

`PL_initialise_mem(int argc, char **argv, char *mem_data, long int mem_size)`

 message, which will initialize swipl with the savedsate in memory.

Could you please review and add it to master and next release?

Thank you.
Cheers
Oleh