### PR TITLE
Fixed missing cuts after has_type/2

### DIFF
--- a/library/error.pl
+++ b/library/error.pl
@@ -287,7 +287,7 @@ not_a_rational(X) :-
 
 is_of_type(Type, Term) :-
 	nonvar(Term), !,
-	has_type(Type, Term).
+	has_type(Type, Term), !.
 is_of_type(Type, _) :-
 	instantiation_error(Type).
 
@@ -365,7 +365,7 @@ element_types(_List, Type) :-
 
 element_types_([], _).
 element_types_([H|T], Type) :-
-	has_type(Type, H),
+	has_type(Type, H), !,
 	element_types_(T, Type).
 
 is_list_or_partial_list(L0) :-


### PR DESCRIPTION
Since has_type/2 is semidet but also multifile, the code is not safe at the moment in a couple of places, i.e. where has_type is called without a cut following.  (A cut is present in the other two places where has_type is called.)  I have fixed this by adding the cuts.