### PR TITLE
FIXED: Variable reference in is_of_type/2.

### DIFF
--- a/library/error.pl
+++ b/library/error.pl
@@ -286,7 +286,7 @@ not_a_rational(X) :-
 %	True if Term satisfies Type.
 
 is_of_type(Type, Term) :-
-	nonvar(Term), !,
+	nonvar(Type), !,
 	has_type(Type, Term), !.
 is_of_type(Type, _) :-
 	instantiation_error(Type).


### PR DESCRIPTION
In the 1st clause of is_of_type/2, nonvar(Term) is called instead of nonvar(Type).  I have fixed the variable reference.