### PR TITLE
ENHANCED: Allow reproducible builds by using the SOURCE_DATE_EPOCH variable

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -166,6 +166,15 @@ COMMON= README
 UNICODE=blocks.pl unicode_data.pl
 builddirs=../lib ../lib/$(PLARCH) os
 
+# For reproducible builds
+DATE_FMT = "%b %e %Y"
+TIME_FMT = "%R"
+ifdef SOURCE_DATE_EPOCH
+BUILD_DATE ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "+$(DATE_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "+$(DATE_FMT)" 2>/dev/null || date -u "+$(DATE_FMT)")
+BUILD_TIME ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "+$(TIME_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "+$(TIME_FMT)" 2>/dev/null || date -u "+$(DATE_FMT)")
+CFLAGS += -DBUILD_DATE=\"${BUILD_DATE}\" -DBUILD_TIME=\"${BUILD_TIME}\"
+endif
+
 # OPTIMISE=noprof: normal build; prof: build twice, using profiling
 # information to optimise branches.  Normally set through
 # configure --enable-useprofile

--- a/src/os/pl-prologflag.c
+++ b/src/os/pl-prologflag.c
@@ -1396,7 +1396,9 @@ initPrologFlags(void)
   setPrologFlag("kernel_compile_mode", FT_ATOM|FF_READONLY, "debug");
 #endif
 
-#if defined(__DATE__) && defined(__TIME__)
+#if defined(BUILD_TIME) && defined(BUILD_DATE)
+  setPrologFlag("compiled_at", FT_ATOM|FF_READONLY, BUILD_DATE ", " BUILD_TIME);
+#elif defined(__DATE__) && defined(__TIME__)
   setPrologFlag("compiled_at", FT_ATOM|FF_READONLY, __DATE__ ", " __TIME__);
 #endif
 


### PR DESCRIPTION
To allow [reproducible builds](https://reproducible-builds.org/) (same source results in same binary) replace
`__DATE__` and `__TIME__` with system provided values.

This is used e.g. by [debian](https://wiki.debian.org/ReproducibleBuilds), openSUSE also recommends to patch usage of `__DATE__` and `__TIME__` as leads to a lot of rebuilds even when source did not change, for more information: https://reproducible-builds.org/specs/source-date-epoch/