### PR TITLE
Non fresh variables

### DIFF
--- a/boot/expand.pl
+++ b/boot/expand.pl
@@ -564,6 +564,8 @@ expand_goal(call(A), P0, call(EA), P, M, MList, Term) :-
 expand_goal(G0, P0, G, P, M, MList, Term) :-
     is_meta_call(G0, M, Head),
     !,
+    term_variables(G0, Vars),
+    mark_vars_non_fresh(Vars),
     expand_meta(Head, G0, P0, G, P, M, MList, Term).
 expand_goal(G0, P0, G, P, M, MList, Term) :-
     term_variables(G0, Vars),
@@ -691,6 +693,7 @@ expand_meta_arg(N, A0, P0, true, A, P, M, MList, Term) :-
     replace_functions(A0, true, _, M),
     !,
     length(Ex, N),
+    mark_vars_non_fresh(Ex),
     extend_arg_pos(A0, P0, Ex, A1, PA1),
     expand_goal(A1, PA1, A2, PA2, M, MList, Term),
     compile_meta_call(A2, A3, M, Term),

--- a/library/prolog_clause.pl
+++ b/library/prolog_clause.pl
@@ -450,6 +450,9 @@ ubody(B, C, _, P, P) :-
     B =@= C, B = C,
     does_not_dcg_after_binding(B, P),
     !.
+ubody(X0, X, M, parentheses_term_position(_, _, P0), P) :-
+    !,
+    ubody(X0, X, M, P0, P).
 ubody(X, call(X), _,                    % X = call(X)
       Pos,
       term_position(From, To, From, To, [Pos])) :-


### PR DESCRIPTION
Hi Jan,
I notice that some variables where not marked as non-fresh, when they first appeared in a predicate with a meta_predicate declaration, but also on the extended arguments of a meta-argument (greater than zero).
I don't have a short example, I saw such inconsistency while I was trying to use such information in a static analysis tool, but may be this will also fix the parts of the compiler that use that.
The second change in ubody/5 is simply that probably you forgot to add a clause to process parentheses_term_position/3.
Best Regards