### PR TITLE
ADDED: Prolog flag `functional_notation` to disable functional notation.

### DIFF
--- a/boot/expand.pl
+++ b/boot/expand.pl
@@ -915,6 +915,7 @@ expand_functions(G0, P0, G, P, M, MList, Term) :-
 %   @tbd: make functions module-local
 
 expand_functional_notation(G0, P0, G, P, M, _MList, _Term) :-
+    current_prolog_flag(M:functional_notation, true),
     contains_functions(G0),
     replace_functions(G0, P0, Eval, EvalPos, G1, G1Pos, M),
     Eval \== true,

--- a/man/overview.doc
+++ b/man/overview.doc
@@ -1347,6 +1347,10 @@ search result satisfies the conditions. Default is 10 seconds, which
 typically avoids most repetitive searches for (library) files during
 compilation. Setting this value to 0 (zero) disables the cache.
 
+    \prologflagitem{functional_notation}{bool}{rw}
+If \const{true} (default) the functional notation ./2 is expanded. If false,
+./2 can be used for other purposes. This flag must be set on a per-module basis.
+
     \prologflagitem{gc}{bool}{rw}
 If true (default), the garbage collector is active.  If false, neither
 garbage collection, nor stack shifts will take place, even not on

--- a/src/os/pl-prologflag.c
+++ b/src/os/pl-prologflag.c
@@ -1373,6 +1373,7 @@ initPrologFlags(void)
 		ALLOW_VARNAME_FUNCTOR);
   setPrologFlag("allow_dot_in_atom", FT_BOOL, FALSE,
 		PLFLAG_DOT_IN_ATOM);
+  setPrologFlag("functional_notation", FT_BOOL, TRUE, 0);
   setPrologFlag("toplevel_var_size", FT_INTEGER, 1000);
   setPrologFlag("toplevel_print_anon", FT_BOOL, TRUE, 0);
   setPrologFlag("toplevel_prompt", FT_ATOM, "~m~d~l~! ?- ");


### PR DESCRIPTION
Resolves #229