### PR TITLE
Point submodules to public URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,111 +1,111 @@
 [submodule "packages/chr"]
 	path = packages/chr
-	url = ../packages-chr.git
+	url = https://github.com/SWI-Prolog/packages-chr.git
 [submodule "packages/jpl"]
 	path = packages/jpl
-	url = ../packages-jpl.git
+	url = https://github.com/SWI-Prolog/packages-jpl.git
 [submodule "packages/clpqr"]
 	path = packages/clpqr
-	url = ../packages-clpqr.git
+	url = https://github.com/SWI-Prolog/packages-clpqr.git
 [submodule "packages/inclpr"]
 	path = packages/inclpr
-	url = ../packages-inclpr.git
+	url = https://github.com/SWI-Prolog/packages-inclpr.git
 [submodule "packages/space"]
 	path = packages/space
-	url = ../contrib-space.git
+	url = https://github.com/SWI-Prolog/contrib-space.git
 [submodule "bench"]
 	path = bench
-	url = ../bench.git
+	url = https://github.com/SWI-Prolog/bench.git
 [submodule "packages/utf8proc"]
 	path = packages/utf8proc
-	url = ../packages-utf8proc.git
+	url = https://github.com/SWI-Prolog/packages-utf8proc.git
 [submodule "packages/protobufs"]
 	path = packages/protobufs
-	url = ../contrib-protobufs.git
+	url = https://github.com/SWI-Prolog/contrib-protobufs.git
 [submodule "packages/xpce"]
 	path = packages/xpce
-	url = ../packages-xpce.git
+	url = https://github.com/SWI-Prolog/packages-xpce.git
 [submodule "packages/odbc"]
 	path = packages/odbc
-	url = ../packages-odbc.git
+	url = https://github.com/SWI-Prolog/packages-odbc.git
 [submodule "packages/sgml"]
 	path = packages/sgml
-	url = ../packages-sgml.git
+	url = https://github.com/SWI-Prolog/packages-sgml.git
 [submodule "packages/clib"]
 	path = packages/clib
-	url = ../packages-clib.git
+	url = https://github.com/SWI-Prolog/packages-clib.git
 [submodule "packages/http"]
 	path = packages/http
-	url = ../packages-http.git
+	url = https://github.com/SWI-Prolog/packages-http.git
 [submodule "packages/plunit"]
 	path = packages/plunit
-	url = ../packages-plunit.git
+	url = https://github.com/SWI-Prolog/packages-plunit.git
 [submodule "packages/pldoc"]
 	path = packages/pldoc
-	url = ../packages-pldoc.git
+	url = https://github.com/SWI-Prolog/packages-pldoc.git
 [submodule "packages/RDF"]
 	path = packages/RDF
-	url = ../packages-RDF.git
+	url = https://github.com/SWI-Prolog/packages-RDF.git
 [submodule "packages/semweb"]
 	path = packages/semweb
-	url = ../packages-semweb.git
+	url = https://github.com/SWI-Prolog/packages-semweb.git
 [submodule "packages/ssl"]
 	path = packages/ssl
-	url = ../packages-ssl.git
+	url = https://github.com/SWI-Prolog/packages-ssl.git
 [submodule "packages/zlib"]
 	path = packages/zlib
-	url = ../packages-zlib.git
+	url = https://github.com/SWI-Prolog/packages-zlib.git
 [submodule "packages/tipc"]
 	path = packages/tipc
-	url = ../contrib-tipc.git
+	url = https://github.com/SWI-Prolog/contrib-tipc.git
 [submodule "packages/table"]
 	path = packages/table
-	url = ../packages-table.git
+	url = https://github.com/SWI-Prolog/packages-table.git
 [submodule "packages/nlp"]
 	path = packages/nlp
-	url = ../packages-nlp.git
+	url = https://github.com/SWI-Prolog/packages-nlp.git
 [submodule "packages/bdb"]
 	path = packages/bdb
-	url = ../packages-bdb.git
+	url = https://github.com/SWI-Prolog/packages-bdb.git
 [submodule "packages/jasmine"]
 	path = packages/jasmine
-	url = ../packages-jasmine.git
+	url = https://github.com/SWI-Prolog/packages-jasmine.git
 [submodule "packages/cpp"]
 	path = packages/cpp
-	url = ../packages-cpp.git
+	url = https://github.com/SWI-Prolog/packages-cpp.git
 [submodule "packages/cppproxy"]
 	path = packages/cppproxy
-	url = ../packages-cppproxy.git
+	url = https://github.com/SWI-Prolog/packages-cppproxy.git
 [submodule "packages/ltx2htm"]
 	path = packages/ltx2htm
-	url = ../packages-ltx2htm.git
+	url = https://github.com/SWI-Prolog/packages-ltx2htm.git
 [submodule "packages/windows"]
 	path = packages/windows
-	url = ../packages-windows.git
+	url = https://github.com/SWI-Prolog/packages-windows.git
 [submodule "packages/PDT"]
 	path = packages/PDT
-	url = ../packages-PDT.git
+	url = https://github.com/SWI-Prolog/packages-PDT.git
 [submodule "packages/archive"]
 	path = packages/archive
-	url = ../packages-archive.git
+	url = https://github.com/SWI-Prolog/packages-archive.git
 [submodule "debian"]
 	path = debian
-	url = ../distro-debian.git
+	url = https://github.com/SWI-Prolog/distro-debian.git
 [submodule "packages/swipl-win"]
 	path = packages/swipl-win
-	url = ../packages-swipl-win.git
+	url = https://github.com/SWI-Prolog/packages-swipl-win.git
 [submodule "packages/pengines"]
 	path = packages/pengines
-	url = ../packages-pengines.git
+	url = https://github.com/SWI-Prolog/packages-pengines.git
 [submodule "packages/cql"]
 	path = packages/cql
-	url = ../packages-cql.git
+	url = https://github.com/SWI-Prolog/packages-cql.git
 [submodule "packages/readline"]
 	path = packages/readline
-	url = ../packages-readline.git
+	url = https://github.com/SWI-Prolog/packages-readline.git
 [submodule "packages/libedit"]
 	path = packages/libedit
-	url = ../packages-libedit.git
+	url = https://github.com/SWI-Prolog/packages-libedit.git
 [submodule "packages/pcre"]
 	path = packages/pcre
-	url = ../packages-pcre.git
+	url = https://github.com/SWI-Prolog/packages-pcre.git


### PR DESCRIPTION
This patch changes the submodules from relative to absolute URLs, e.g. `../bench.git` becomes `https://github.com/SWI-Prolog/bench.git`.

As a result, cloning the project is easier and clicking on a submodule in GitHub takes you to the corresponding repository.