### PR TITLE
thread_get_message with timeout can block forever on Windows

### DIFF
--- a/src/pl-thread.c
+++ b/src/pl-thread.c
@@ -3414,7 +3414,7 @@ win32_cond_wait(win32_cond_t *cv,
     dwMilliseconds = 1000*(DWORD)(deadline->tv_sec - now.tv_sec)
                      + (deadline->tv_nsec - now.tv_nsec)/1000000;
 
-     if ( dwMilliseconds <= 0 )
+     if ( (int)dwMilliseconds <= 0 )
       return ETIMEDOUT;
   } else
   { dwMilliseconds = INFINITE;


### PR DESCRIPTION
dwMilliseconds is a DWORD, which is unsigned. This means the check to… see whether the timeout has already occurred will only succeed if the deadline is precisely now; otherwise we will wait up to 7 weeks for the deadline in the case where it has already passed

Here's a simple test case that reproduces (note that it depends on the speed of your computer)

```
go:-
        message_queue_create(Queue),
        forall(between(0, 1000000, T),
               thread_send_message(Queue, a(T))),
        writeln(reading),
        thread_get_message(Queue, a(9999999), [timeout(0)]).
```