### PR TITLE
DOC: Mention crypto_n_random_bytes/2 in the documentation of random/1.

### DIFF
--- a/man/builtin.doc
+++ b/man/builtin.doc
@@ -6731,6 +6731,12 @@ numbers are shared between threads and the seed is initialised from the
 clock when SWI-Prolog was started. The predicate set_random/1 can be
 used to control the random number generator.
 
+\textbf{Warning!} This method does \textit{not} produce
+cryptographically secure random numbers! To generate cryptographically
+secure random numbers, use \verb$crypto_n_random_bytes/2$
+from~\verb$library(crypto)$ in the \verb$ssl$ package. See its
+documentation for more information.
+
     \function{random_float}{0}{}
 Evaluate to a random float $I$ for which $0.0 < i < 1.0$. This function
 shares the random state with \funcref{random}{1}. All remarks with the


### PR DESCRIPTION
I think a warning and pointer to the newly available cryptographically secure generation of random numbers is highly warranted at this point. Please merge as you see fit.