### PR TITLE
Fix potential infinite timeout in thread_get_message in win32

### DIFF
--- a/src/pl-thread.c
+++ b/src/pl-thread.c
@@ -3399,11 +3399,11 @@ win32_cond_wait(win32_cond_t *cv,
   { struct timespec now;
 
     get_current_timespec(&now);
+    if (now.tv_sec > deadline->tv_sec ||
+        ( now.tv_sec == deadline->tv_sec && now.tv_nsec > deadline->tv_nsec))
+      return ETIMEDOUT;
     dwMilliseconds = 1000*(DWORD)(deadline->tv_sec - now.tv_sec)
                      + (deadline->tv_nsec - now.tv_nsec)/1000000;
-
-     if ( dwMilliseconds <= 0 )
-      return ETIMEDOUT;
   } else
   { dwMilliseconds = INFINITE;
   }


### PR DESCRIPTION
Note that this is a rewrite, based on Jan's suggestions, of #233, which I will now close.

dwMilliseconds is a DWORD, which is unsigned. This means the check to see whether the timeout has already occurred will only succeed if the deadline is precisely now; otherwise we will wait up to 7 weeks for the deadline in the case where it has already passed