### PR TITLE
Fix expand term

### DIFF
--- a/boot/dcg.pl
+++ b/boot/dcg.pl
@@ -319,9 +319,9 @@ dcg_terminal_pos(Pos, _) :-
     var(Pos),
     !.
 dcg_terminal_pos(list_position(F,T,_Elms,_Tail),
-                 term_position(F,T,_,_,_)).
+                 term_position(F,T,_,_,_)) :- !.
 dcg_terminal_pos(F-T,
-                 term_position(F,T,_,_,_)).
+                 term_position(F,T,_,_,_)) :- !.
 dcg_terminal_pos(Pos, _) :-
     expected_layout(terminal, Pos).
 

--- a/boot/dcg.pl
+++ b/boot/dcg.pl
@@ -36,6 +36,7 @@
 :- module('$dcg',
           [ dcg_translate_rule/2,       % +Rule, -Clause
             dcg_translate_rule/4,       % +Rule, ?Pos0, -Clause, -Pos
+            dcg_translate_rule/5,       % +Rule, ?Pos0, -Clause, -Pos, +Module
             phrase/2,                   % :Rule, ?Input
             phrase/3,                   % :Rule, ?Input, ?Rest
             call_dcg/3                  % :Rule, ?State0, ?State
@@ -62,21 +63,23 @@ resulting code is simply the same), I've removed that.
 dcg_translate_rule(Rule, Clause) :-
     dcg_translate_rule(Rule, _, Clause, _).
 
-dcg_translate_rule(((LP,MNT)-->RP), Pos0, (H:-B), Pos) :-
+dcg_translate_rule(Rule, Pos0, Clause, Pos) :-
+    '$current_source_module'(M),
+    dcg_translate_rule(Rule, Pos0, Clause, Pos, M).
+
+dcg_translate_rule(((LP,MNT)-->RP), Pos0, (H:-B), Pos, M) :-
     !,
     f2_pos(Pos0, PosH0, PosRP0, Pos, PosH, PosRP),
     f2_pos(PosH0, PosLP0, PosMNT0, PosH, PosLP, PosMNT),
-    '$current_source_module'(M),
     Qualify = q(M,M,_),
     dcg_extend(LP, PosLP0, S0, SR, H, PosLP),
     dcg_body(RP, PosRP0, Qualify, S0, S1, B0, PosRP),
     dcg_body(MNT, PosMNT0, Qualify, SR, S1, B1, PosMNT),
     dcg_optimise((B0,B1),B2,S0),
     dcg_optimise(B2,B,SR).
-dcg_translate_rule((LP-->RP), Pos0, (H:-B), Pos) :-
+dcg_translate_rule((LP-->RP), Pos0, (H:-B), Pos, M) :-
     f2_pos(Pos0, PosLP0, PosRP0, Pos, PosLP, PosRP),
     dcg_extend(LP, PosLP0, S0, S, H, PosLP),
-    '$current_source_module'(M),
     Qualify = q(M,M,_),
     dcg_body(RP, PosRP0, Qualify, S0, S, B0, PosRP),
     dcg_optimise(B0,B,S0).

--- a/boot/expand.pl
+++ b/boot/expand.pl
@@ -145,7 +145,7 @@ extend_expansion(Sandbox, M-Preds, E1, E2) :-
 
 expand_one(Context, TermL, Exp2) :-
     (   TermL = (L:Clause1)-Pos1,
-        L = '$source_location'(_,_)
+        L = '$source_location'(_,_),
         call_term_expansion(Context, Clause1-Pos1, Exp1)
     ->  maplist(add_source_location(L), Exp1, Exp2)
     ;   call_term_expansion(Context, TermL, Exp2)
@@ -176,7 +176,6 @@ normalise_expansion([T|Ts], Pos, Exp) :-
     maplist(nonvar,[T|Ts]),
     maplist(normalise_term, [T|Ts], Terms),
     maplist(pair, Terms, Pos1, Exp).
-% !!! should we allow '$source_location'(_,_):List ?
 normalise_expansion(Term, Pos, [Term1-Pos]) :-
     normalise_term(Term, Term1).
 
@@ -192,7 +191,7 @@ normalise_term(QClause, QClause) :-
 
 valid_qclause(QClause) :-
     (   QClause = M:Clause
-    ->  nonvar(M),
+    ->  atom(M),
         nonvar(Clause),
         valid_qclause(Clause)
     ;   valid_clause(QClause)
@@ -202,7 +201,7 @@ valid_clause(QHead :- _)  :- !, nonvar(QHead), valid_qhead(QHead).
 valid_clause(QHead --> _) :- !, nonvar(QHead), valid_qhead(QHead).
 valid_clause(Head)        :- valid_qhead(Head).
 
-valid_qhead(M:Head) :- !, nonvar(M), nonvar(Head).
+valid_qhead(M:Head) :- !, atom(M), nonvar(Head).
 valid_qhead(_).
 
 normalise_list_pos(Var, _) :- var(Var), !.

--- a/boot/expand.pl
+++ b/boot/expand.pl
@@ -198,7 +198,6 @@ valid_qclause(QClause) :-
     ).
 
 valid_clause(QHead :- _)  :- !, nonvar(QHead), valid_qhead(QHead).
-valid_clause(QHead --> _) :- !, nonvar(QHead), valid_qhead(QHead).
 valid_clause(Head)        :- valid_qhead(Head).
 
 valid_qhead(M:Head) :- !, atom(M), nonvar(Head).
@@ -260,7 +259,7 @@ pair(X,Y,X-Y).
                  *      DCG EXPANSION           *
                  *******************************/
 
-% structural recursion on (head | rule | dcg_rule) type (see notes.txt)
+% structural recursion on (head | rule) type (see notes.txt)
 ex_dcg_clause(_, (Head :- Body), (Head :- Body), Pos, Pos) :- !.
 ex_dcg_clause(M, (Head --> Body), Clause, Pos1, Pos2) :- !,
     dcg_translate_rule((Head --> Body), Pos1, Clause, Pos2, M).

--- a/boot/expand.pl
+++ b/boot/expand.pl
@@ -173,14 +173,16 @@ normalise_expansion([T|Ts], Pos, Exp) :-
     !,
     is_list(Ts),
     normalise_list_pos(Pos, Pos1),
-    maplist(nonvar,[T|Ts]),
-    maplist(normalise_term, [T|Ts], Terms),
-    maplist(pair, Terms, Pos1, Exp).
+    maplist(normalise_and_pair, [T|Ts], Pos1, Exp).
 normalise_expansion(Term, Pos, [Term1-Pos]) :-
     normalise_term(Term, Term1).
 
+normalise_and_pair(T1, Pos, T2-Pos) :-
+    nonvar(T1),
+    normalise_term(T1, T2).
+
 normalise_term(end_of_file, end_of_file) :- !.
-normalise_term((?- Dir), (:- Dir)) :- !, nonvar(Dir). % NB convert to :-
+normalise_term((?- Dir), (:- Dir)) :- !, nonvar(Dir). % convert ?- to :-
 normalise_term((:- Dir), (:- Dir)) :- !, nonvar(Dir).
 normalise_term(L:QClause, L:QClause) :-
     nonvar(L),
@@ -191,13 +193,12 @@ normalise_term(QClause, QClause) :-
 
 valid_qclause(QClause) :-
     (   QClause = M:Clause
-    ->  atom(M),
-        nonvar(Clause),
+    ->  atom(M), % NB if QClause was a variable, it will fail here
         valid_qclause(Clause)
     ;   valid_clause(QClause)
     ).
 
-valid_clause(QHead :- _)  :- !, nonvar(QHead), valid_qhead(QHead).
+valid_clause(QHead :- _)  :- !, valid_qhead(QHead).
 valid_clause(Head)        :- valid_qhead(Head).
 
 valid_qhead(M:Head) :- !, atom(M), nonvar(Head).

--- a/boot/expand.pl
+++ b/boot/expand.pl
@@ -146,9 +146,9 @@ extend_expansion(Sandbox, M-Preds, E1, E2) :-
 expand_one(Context, TermL, Exp2) :-
     (   TermL = (L:Clause1)-Pos1,
         L = '$source_location'(_,_)
-    ->  once(term_expansion_in(Context, Clause1-Pos1, Exp1)),
+    ->  once(call_term_expansion(Context, Clause1-Pos1, Exp1)),
         maplist(add_source_location(L), Exp1, Exp2)
-    ;   once(term_expansion_in(Context, TermL, Exp2))
+    ;   once(call_term_expansion(Context, TermL, Exp2))
     ).
 
 add_source_location(_, (L1:Term)-Pos, (L1:Term)-Pos) :-
@@ -182,7 +182,7 @@ map_qual(P, M:QC1, M:QC2, Pos1, Pos2) :-
 map_qual(P, Clause1, Clause2, Pos1, Pos2) :-
     call(P, Clause1, Clause2, Pos1, Pos2).
 
-term_expansion_in(c(M,Preds,Sandbox), Term1-Pos1, Exp) :-
+call_term_expansion(c(M,Preds,Sandbox), Term1-Pos1, Exp) :-
     '$member'(term_expansion/N, Preds),
     (   N = 2 -> Goal = term_expansion(Term1, Term2)
     ;   N = 4 -> Goal = term_expansion(Term1, Pos1, Term2, Pos2)
@@ -192,7 +192,7 @@ term_expansion_in(c(M,Preds,Sandbox), Term1-Pos1, Exp) :-
     (   nonvar(Term2), normalise_expansion(Term2, Pos2, Exp) ->  true
     ;   throw(error(bad_term_expansion(M:Goal)))
     ).
-term_expansion_in(_, TermL, [TermL]).
+call_term_expansion(_, TermL, [TermL]).
 
 normalise_expansion([], _, []) :- !.
 normalise_expansion([T|Ts], Pos, Exp) :-

--- a/boot/init.pl
+++ b/boot/init.pl
@@ -1524,8 +1524,11 @@ compiling :-
 '$read_clause_option'(process_comment(_)).
 
 '$expanded_term'(In, RawL, ReadL, TermL, Stream, Parents, Options) :-
-    catch('$expand_term'(RawL, Expanded), E,
-          '$print_message_fail'(E)),
+    (   catch('$expand_term'(RawL, Expanded), E,
+              '$print_message_fail'(E))
+    ->  true
+    ;   throw(unexpected_failure('$expand_term'(RawL,Expanded)))
+    ),
     (   Expanded = []
     ->  '$empty_expansion'(RawL,TermL),
         ReadL = RawL, Stream = In

--- a/boot/init.pl
+++ b/boot/init.pl
@@ -1524,11 +1524,9 @@ compiling :-
 '$read_clause_option'(process_comment(_)).
 
 '$expanded_term'(In, RawL, ReadL, TermL, Stream, Parents, Options) :-
-    (   catch('$expand_term'(RawL, Expanded), E,
-              '$print_message_fail'(E))
-    ->  true
-    ;   throw(unexpected_failure('$expand_term'(RawL,Expanded)))
-    ),
+    catch(( '$expand_term'(RawL, Expanded) -> true
+          ; throw(unexpected_failure('$expand_term'(RawL,Expanded)))
+          ), E, '$print_message_fail'(E)),
     (   Expanded = []
     ->  '$empty_expansion'(RawL,TermL),
         ReadL = RawL, Stream = In

--- a/boot/init.pl
+++ b/boot/init.pl
@@ -1411,7 +1411,7 @@ compiling :-
 '$source_term'(From, Read, RLayout, Term, TLayout, Stream, Options) :-
     '$source_term'(From, Options, Read-RLayout, Term-TLayout, Stream, []).
 
-'$source_term'(Input, _,_,_,_) :-
+'$source_term'(Input, _,_,_,_,_) :-
     \+ ground(Input),
     !,
     '$instantiation_error'(Input).
@@ -1545,7 +1545,7 @@ compiling :-
 '$directive_action'(encoding(Enc), In, _, '$set_stream_encoding'(In, Enc)).
 '$directive_action'(include(File), In, Options, '$source_term'(File, Options1)) :-
     '$current_source_module'(Module),
-    '$valid_directive'(Module:include(File)), !,  % !!! what should happen if directive is invalid?
+    '$valid_directive'(Module:include(File)), !,
     stream_property(In, encoding(Enc)),
     '$add_encoding'(Enc, Options, Options1).
 

--- a/boot/load.pl
+++ b/boot/load.pl
@@ -36,7 +36,7 @@
 % Load the rest of the system as modules, so we can write a bit more
 % readable code.  First we need to load term-expansion, etc. because
 % this gives us DCGs.  Then we need to replace the dummy clauses for
-% '$expand_term'/4 and '$expand_goal'/2 with links to the real thing.
+% '$expand_term'/2 and '$expand_goal'/2 with links to the real thing.
 
 :- consult([ gc,
              expand,
@@ -45,13 +45,13 @@
 
 :- abolish('$expand_goal'/2),
    asserta(('$expand_goal'(In, Out) :- expand_goal(In, Out))),
-   abolish('$expand_term'/4),
-   asserta(('$expand_term'(In, P0, Out, P) :- expand_term(In, P0, Out, P))),
-   compile_predicates(['$expand_goal'/2, '$expand_term'/4]),
+   abolish('$expand_term'/2),
+   asserta(('$expand_term'(In, Out) :- expand_term_to_terms(In, Out))),
+   compile_predicates(['$expand_goal'/2, '$expand_term'/2]),
    '$set_predicate_attribute'(system:'$expand_goal'(_,_), system, true),
-   '$set_predicate_attribute'(system:'$expand_term'(_,_,_,_), system, true),
+   '$set_predicate_attribute'(system:'$expand_term'(_,_), system, true),
    '$set_predicate_attribute'(system:'$expand_goal'(_,_), hide_childs, true),
-   '$set_predicate_attribute'(system:'$expand_term'(_,_,_,_), hide_childs, true).
+   '$set_predicate_attribute'(system:'$expand_term'(_,_), hide_childs, true).
 
 :- consult([ license,                   % requires DCG
              syspred,

--- a/boot/notes.txt
+++ b/boot/notes.txt
@@ -1,0 +1,42 @@
+   Position and layout type:
+
+      % NB: A | B denotes an UNTAGGED union 
+      %     {X,Y,...} is type containing exactly terms X, Y etc
+      
+      pos == int. % position in a stream
+      key == atom | small_int.
+      layout ---> pos-pos
+                ; string_position(pos, pos)
+                ; brace_term_position(pos, pos, layout)
+                ; parentheses_term_position(pos, pos, layout)
+                ; term_position(pos, pos, pos, pos, list(layout))
+                ; list_position(pos, pos, list(layout), (layout|{none}))
+                ; dict_position(pos, pos, pos, pos, list(key_value_pos))
+                ; quasi_quotation_position(pos, pos, pos, pos, layout).
+
+      key_value_pos ---> key_value_position(pos, pos, pos, pos, key, layout, layout).
+
+    Terms that can be expanded or result from expansion:
+    [Question: can any term be located, or just clauses?]
+
+        (these are defaulty untagged unions)
+            raw_term == {end_of_file} | directive | q(head | rule | dcg_rule).
+            term(A)  == {end_of_file} | directive | q(A) | located(q(A)).
+            q(A)    == A | qualified(q(A)).
+            head    == excluding([(:)/2, (?-)/1, (:-)/1, (:-)/2]).
+
+        (these are fine)
+            directive       ---> (:- body).
+            rule            ---> (q(head) :- body).
+            dcg_rule        ---> (q(head) --> body).
+            qualified(A)    ---> module:A.
+            located(A)      ---> source_location:A.
+            source_location ---> '$source_location'(filename, int).
+
+    Terms that can result from term_expansion hooks
+
+            term_out == term(head | rule | dcg_rule) 
+            exp_out == pair(term_out, layout)
+                     | pair(list(term_out), layout)
+                     | pair(list(term)out), list(layout)).
+

--- a/boot/notes.txt
+++ b/boot/notes.txt
@@ -1,22 +1,20 @@
     Terms that can be expanded or result from expansion:
 
         (these are defaulty untagged unions)
-            raw_term == {end_of_file} | directive | q(head | rule | dcg_rule).
-            term(A)  == {end_of_file} | directive | q(A) | located(q(A)).
+            term(A) == {end_of_file} | directive | q(A) | located(q(A)).
             q(A)    == A | qualified(q(A)).
             head    == excluding([(:)/2, (?-)/1, (:-)/1, (:-)/2]).
 
         (these are fine)
             directive       ---> (:- body).
             rule            ---> (q(head) :- body).
-            dcg_rule        ---> (q(head) --> body).
             qualified(A)    ---> module:A.
             located(A)      ---> source_location:A.
             source_location ---> '$source_location'(filename, int).
 
-    Terms that can result from term_expansion hooks
+    Terms that can result from term_expansion hooks (can include (?-)/2 Directives)
 
-            term_out == term(head | rule | dcg_rule) 
+            term_out == term(head | rule) 
             term_layout_out == pair(term_out, layout)
-                             | pair(list(term_out), layout) % must be list_position/4
+                             | pair(list(term_out), layout) % layout must be list_position/4
                              | pair(list(term_out), list(layout)).

--- a/boot/notes.txt
+++ b/boot/notes.txt
@@ -2,7 +2,7 @@
 
         (these are defaulty untagged unions)
             term(A) == {end_of_file} | directive | q(A) | located(q(A)).
-            q(A)    == A | qualified(q(A)).
+            q(A)    == A | qualified(A).
             head    == excluding([(:)/2, (?-)/1, (:-)/1, (:-)/2]).
 
         (these are fine)

--- a/boot/notes.txt
+++ b/boot/notes.txt
@@ -1,23 +1,4 @@
-   Position and layout type:
-
-      % NB: A | B denotes an UNTAGGED union 
-      %     {X,Y,...} is type containing exactly terms X, Y etc
-      
-      pos == int. % position in a stream
-      key == atom | small_int.
-      layout ---> pos-pos
-                ; string_position(pos, pos)
-                ; brace_term_position(pos, pos, layout)
-                ; parentheses_term_position(pos, pos, layout)
-                ; term_position(pos, pos, pos, pos, list(layout))
-                ; list_position(pos, pos, list(layout), (layout|{none}))
-                ; dict_position(pos, pos, pos, pos, list(key_value_pos))
-                ; quasi_quotation_position(pos, pos, pos, pos, layout).
-
-      key_value_pos ---> key_value_position(pos, pos, pos, pos, key, layout, layout).
-
     Terms that can be expanded or result from expansion:
-    [Question: can any term be located, or just clauses?]
 
         (these are defaulty untagged unions)
             raw_term == {end_of_file} | directive | q(head | rule | dcg_rule).
@@ -36,7 +17,6 @@
     Terms that can result from term_expansion hooks
 
             term_out == term(head | rule | dcg_rule) 
-            exp_out == pair(term_out, layout)
-                     | pair(list(term_out), layout)
-                     | pair(list(term)out), list(layout)).
-
+            term_layout_out == pair(term_out, layout)
+                             | pair(list(term_out), layout) % must be list_position/4
+                             | pair(list(term_out), list(layout)).


### PR DESCRIPTION
This PR refactors the term expansion system to provide a more consistent and complete processing of expanded terms, while, in the process, fixing a bug that meant that if a term expansion rule produces a DCG clause (`Head --> Body`) as part of a _sequence_ of expanded terms, then the DCG clause is not expanded using `dcg_translate_rule` but instead ends up in the database as a clause of `(-->)/2`. 

The expansion pipeline consists of an initial phase of one-to-many term mapping using the `term_expansion/{2,4}` hooks in several modules, followed by three stages of one-to-one mappings to implement DCG expansions, function expansions in clause heads, body goal expansions and predicate renamings. 

The one-to-many mappings are handled consistently by (a) immediately normalising the results of `term_expansion` to a _list_ of term-layout pairs and (b) using `extend/3` to lift any mapping of type `A -> list(A)` to `list(A) -> list(A)`. (This is equivalent to the `bind` operation of the list monad, which is called `extend` when the arguments are flipped--hence the name.)
The one-to-one mappings are handled using `maplist/3`. Together, this means that all the lower level expansion predicates never have to deal with lists.

The system is based on a type specification for terms (see `boot/notes.txt`) which all transformations respect. DCG expansion, goal expansion, and predicate renaming are all implemented using `map_term/3` and `map_qual/5`, which are basically a strict structural over the term type. This ensures consistency in all term transformations and localises the specification of the term type.

The interface presented to `init.pl` is now `expand_term_to_terms/2`, which uses `expand_term_to_terms/4` and _always_ produces a list of term-layout pairs. The whole
system should be strictly deterministic. The old `expand_term/{2,4}` interface is preserved (not least for `library/prolog_source.pl' to use).

[Additional note]
The last commit introduced the `map_term/3` and `map_qual/4` predicates to factor out the common structural recursion patterns that were used in DCG expansion, body expansion and predicate renaming. If these and the other high-order predicates are too slow, they could be re-expanded by partial evaluation, but I've left the meta-predicates in for now as they make it clear that the same thing is happening in each case.