### PR TITLE
Handling of new answers in mode directed tabling

### DIFF
--- a/src/pl-tabling.c
+++ b/src/pl-tabling.c
@@ -700,7 +700,7 @@ PRED_IMPL("$tbl_wkl_mode_add_answer", 4, tbl_wkl_mode_add_answer, 0)
 	       set_trie_value(node, av+3 PASS_LD)) )
 	  return FALSE;
 
-	return TRUE;
+	return wkl_add_answer(wl, node PASS_LD);
       } else
       { if ( !set_trie_value(node, A3 PASS_LD) )
 	  return FALSE;


### PR DESCRIPTION


Hi Jan,
I am proposing this change because when an answer is updated by mode directed tabling, it must be added to the worklist to be considered for further processing. This solves the problem I was writing about. Unfortunately it adds redundant answers, so I guess one should check that the updated answer is different from the one already in the trie but I don't know how to do it.

On the test case below I now get
?- path(a,e,T).
T = or(or(e(a, e), and(e(a, b), e(b, e))), and(e(a, b), e(b, e))).
instead of
T = e(a, e).

/** <examples>

?-path(a,e,T).

*/

:- use_module(library(tabling)).

:- table path(_,_,lattice(or/3)), edge(_,_,lattice(or/3)).

path(X,X,one):-
  format('exit(~p)~n',path(X,X,one)).

path(X,Y,C):-
  format('calling(~p)~n',[path(X,Y)]),
  edge(X,Z,A),
  format('called(~p),calling(~p)~n',[edge(X,Z,A), path(Z,Y,B)]),
  print_table(path(Z,Y)),
  path(Z,Y,B),
  format('called(~p,~p)~n',[edge(X,Z,A),path(Z,Y,B)]),
  print_table(path(Z,Y)),
  and(A,B,C),
  format('exit(~p)~n',path(X,Y,C)),
  print_table(path(X,Y)).




path(A,B,zero):-nonvar(A),nonvar(B),
  format('exit(~p)~n',[path(A,B,zero)]).

print_table(G):-
  findall(T1,(current_table(user:G,T),trie_lookup(T,user:G,T1)),L),
  format('answers in table for ~p: ~p~n',[G,L]).
edge(a,b,e(a,b)).
edge(b,e,e(b,e)).
edge(a,e,e(a,e)).

edge(A,B,zero):-nonvar(A),nonvar(B),
  format('exit(~p)~n',[edge(A,B,zero)]).

or(A,B,C) :-
    format('~p or ~p~n', [A, B]),
    or2(A,B,C),
    format('~p or ~p = ~p~n', [A, B, C]).

or2(zero, B, B) :- !.
or2(B, zero, B) :- !.
or2(one, one, one) :- !.
or2(A,A,A):-!.
or2(A, B, or(A,B)).

and(A,B,C) :-
    format('~p and ~p~n', [A, B]),
    and2(A,B,C),
    format('~p and ~p = ~p~n', [A, B, C]).

and2(zero, _, _) :- !, fail.
and2(_, zero, _) :- !, fail.
and2(one, B, B) :- !.
and2(B, one, B) :- !.
and2(A,A,A):-!.
and2(A, B, and(A,B)).

