### PR TITLE
correct redirection of Unix-users

### DIFF
--- a/man/overview.doc
+++ b/man/overview.doc
@@ -43,7 +43,7 @@ Welcome to SWI-Prolog ...
 \end{code}
 
 After this point, Unix and Windows users unite, so if you are using
-Unix please continue at \secref{execquery}.
+Unix please continue at \secref{consultuser}.
 
 \subsubsection{Starting SWI-Prolog on Windows}
 \label{sec:startwin}


### PR DESCRIPTION
Unix-users at the end of [§2.1.1.1 Starting SWI-Prolog on Unix](http://www.swi-prolog.org/pldoc/man?section=startunix) are redirected to [§2.1.3 Executing a query](http://www.swi-prolog.org/pldoc/man?section=execquery) but this skips [§2.1.1 Adding rules from the console](http://www.swi-prolog.org/pldoc/man?section=consultuser) which is equally relevant to them.