### PR TITLE
ENHANCED: In gen_assoc/3, automatically use get_assoc/3 if Key is ground.

### DIFF
--- a/library/assoc.pl
+++ b/library/assoc.pl
@@ -161,11 +161,17 @@ balance(>,>).
 %
 %   @see get_assoc/3.
 
-gen_assoc(Key, t(_,_,_,L,_), Val) :-
-    gen_assoc(Key, L, Val).
-gen_assoc(Key, t(Key,Val,_,_,_), Val).
-gen_assoc(Key, t(_,_,_,_,R), Val) :-
-    gen_assoc(Key, R, Val).
+gen_assoc(Key, Assoc, Value) :-
+    (   ground(Key)
+    ->  get_assoc(Key, Assoc, Value)
+    ;   gen_assoc_(Key, Assoc, Value)
+    ).
+
+gen_assoc_(Key, t(_,_,_,L,_), Val) :-
+    gen_assoc_(Key, L, Val).
+gen_assoc_(Key, t(Key,Val,_,_,_), Val).
+gen_assoc_(Key, t(_,_,_,_,R), Val) :-
+    gen_assoc_(Key, R, Val).
 
 
 %!  get_assoc(+Key, +Assoc, -Value) is semidet.


### PR DESCRIPTION
This can significantly improve efficiency in cases users use
gen_assoc/3 instead of get_assoc/3. Importantly, this also improves
determinism and retains full generality. A motivating example was
recently provided by Boris Vassilev when implementing a DFA that can
both parse and generate lists. The transition table can be modeled via
nested association lists, associating states to further associations
that map characters from the alphabet to subsequent states. With this
patch, using gen_assoc/3 for the latter ensures determinsm if possible
and still lets you generate all solutions for more general queries.