### PR TITLE
Fix option:select_option/4; only delete an option if found

### DIFF
--- a/library/option.pl
+++ b/library/option.pl
@@ -193,11 +193,11 @@ select_option(Option, Options, RestOptions, Default) :-
     !,
     functor(Option, Name, 1),
     (   get_dict(Name, Options, Val)
-    ->  true
-    ;   Val = Default
+    ->  del_dict(Name, Options, _, RestOptions)
+    ;   Val = Default,
+        RestOptions = Options
     ),
-    arg(1, Option, Val),
-    del_dict(Name, Options, _, RestOptions).
+    arg(1, Option, Val).
 select_option(Option, Options, RestOptions, Default) :-
     functor(Option, Name, Arity),
     functor(GenOpt, Name, Arity),


### PR DESCRIPTION
`del_dict/4` fails when defaulting, and therefore `select_option/4` also fails even though a default exists. Yet the predicate is deterministic. This fix only deletes the key-value if found, and unifies `RestOptions` with `Options` unchanged otherwise.