### PR TITLE
Use NODERAWFS during wasm build

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -109,11 +109,6 @@ EXPORTS=$(INCLUDEDIR)/SWI-Exports
 CINCLUDE=$(INCLUDEDIR)/SWI-Prolog.h
 STREAMH=$(INCLUDEDIR)/SWI-Stream.h
 STARTUPPATH=$(PL).prc
-ifeq (@WASM@,true)
-STARTUPPATH_OUT=/swipl-devel/src/$(PL).prc
-else
-STARTUPPATH_OUT=$(STARTUPPATH)
-endif
 RUNTIMEDIR=../lib/$(PLARCH)
 PLLIB=@PLLIB@
 LNLIBS=@LNLIBS@
@@ -158,11 +153,6 @@ PLOBJ=	pl-main.o
 ALLOBJ= $(OBJ) $(PLOBJ) $(XOBJ)
 
 PLINIT=	$(PB)/init.pl
-ifeq (@WASM@,true)
-PLINIT_IN= /swipl-devel/boot/init.pl
-else
-PLINIT_IN= $(PLINIT)
-endif
 ifeq ($(MINGW),true)
 PLSRC+= ../boot/menu.pl
 PLOSLIBS=dde.pl progman.pl
@@ -247,7 +237,7 @@ endif
 
 # Emscripten .js generation for node to create the boot file
 swipl.js:	swipl.bc
-		$(CC) swipl.bc -o swipl.js -s NO_EXIT_RUNTIME=0 --pre-js wasm/boot_pre.js
+		$(CC) swipl.bc -o swipl.js -s NODERAWFS=1 -s NO_EXIT_RUNTIME=0
 
 swipl-web.js:	swipl.bc $(STARTUPPATH)
 		mkdir -p wasm-preload/library
@@ -261,7 +251,7 @@ swipl-web.js:	swipl.bc $(STARTUPPATH)
 
 $(STARTUPPATH):	$(PLINIT) $(PLSRC) $(PL)$(EXEEXT) $(DEVPL)
 		rm -f $(STARTUPPATH)
-		$(CROSSRUNNER) $(DEVPL) -O -o $(STARTUPPATH_OUT) -b $(PLINIT_IN)
+		$(CROSSRUNNER) $(DEVPL) -O -o $(STARTUPPATH) -b $(PLINIT)
 		ls -l $(STARTUPPATH)
 
 .PHONY: dirs

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -470,6 +470,7 @@ case "$PLARCH" in
 	;;
     *wasm*)
 	ax_cv_c_float_words_bigendian=no
+	ac_cv_func_mmap=no
 	;;
 esac
 

--- a/src/wasm/boot_pre.js
+++ b/src/wasm/boot_pre.js
@@ -1,6 +1,0 @@
-// Emscripten pre-js to mount the actual
-// filesystem as NODEFS.
-Module.onRuntimeInitialized = () => {
-  FS.mkdir('/swipl-devel');
-  FS.mount(NODEFS, { root: '..' }, '/swipl-devel');
-};


### PR DESCRIPTION
This removes src/Makefile.in hacks to remap file paths for the boot file creation introduced in:
<https://github.com/SWI-Prolog/swipl-devel/pull/310>

It also disables MMAP for wasm build.

Issue reference: <https://github.com/SWI-Prolog/swipl-wasm/issues/3>.

It is one step closer for automated tests for the better swi-js term interface.