### PR TITLE
Replace linux/unistd.h with syscall.h for MUSL compatibility

### DIFF
--- a/src/pl-thread.c
+++ b/src/pl-thread.c
@@ -105,7 +105,7 @@ APPROACH
 
 #include <errno.h>
 #if defined(__linux__)
-#include <linux/unistd.h>
+#include <syscall.h>
 #ifdef HAVE_GETTID_MACRO
 _syscall0(pid_t,gettid)
 #endif


### PR DESCRIPTION
Building a swipl static binary using musl libc fails due to use of `linux/unistd.h` which doesn't exist.

MUSL libc doesn't have `linux/unistd.h` but instead has `syscall.h` which pulls in the required syscall definitions. `syscall.h` also exists on Linux systems - on my Ubuntu install at least - and it pulls in the same definitions as `linux/unitstd.h`.

I tested the build on Ubuntu defaults and with musl libc - the latter following instructions [in this gist](https://gist.github.com/doublec/672e40ca0a74c26c2e85f2722cdd8c9f).