### PR TITLE
fixed bug preventing long options from containing underscore

### DIFF
--- a/library/optparse.pl
+++ b/library/optparse.pl
@@ -845,6 +845,7 @@ name_rest([]) --> [].
 name_rest([C|Cs]) --> [C], {name_char(C)}, name_rest(Cs).
 name_1st(C) :- char_type(C, alpha).
 name_char(C) :- char_type(C, alpha).
+name_char( 0'_ ). 
 name_char( 0'- ). %}}}
 
 


### PR DESCRIPTION
cf comment 2018-06-15T14:39:55 on http://www.swi-prolog.org/pldoc/man?section=optparse 