### PR TITLE
PORT: Android minizip USE_FILE32API only in 32 bit targets

### DIFF
--- a/cmake/AndroidTargets.cmake
+++ b/cmake/AndroidTargets.cmake
@@ -1,3 +1,8 @@
 # Set target options for Android
 
-target_compile_definitions(libswipl PRIVATE USE_FILE32API=1)
+message(STATUS "Crosscompiling for Android: ${CMAKE_ANDROID_ARCH}")
+
+# Minizip needs USE_FILE32API set in 32-bit architectures
+if($(CMAKE_ANDROID_ARCH) MATCHES "arm$|mips$|x86$")
+   target_compile_definitions(libswipl PRIVATE USE_FILE32API=1)
+endif()


### PR DESCRIPTION
See issue #358 for more information.