### PR TITLE
ENHANCED: Allow compile time specification of unix shell

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -97,6 +97,7 @@ if(WIN32)
   set(SRC_SWIPL_LD ${SRC_SWIPL_LD} os/windows/uxnt.c)
 endif()
 
+set(UNIX_SHELL "/bin/sh" CACHE STRING "Full path to Unix shell")
 
 ################
 # Prolog data files

--- a/src/config.h.cmake
+++ b/src/config.h.cmake
@@ -267,3 +267,5 @@
 
 #cmakedefine HAVE_PTHREAD_GETCPUCLOCKID
 #cmakedefine HAVE_F_SETLKW
+
+#cmakedefine UNIX_SHELL "@UNIX_SHELL@"

--- a/src/os/pl-os.c
+++ b/src/os/pl-os.c
@@ -116,6 +116,8 @@ is supposed to give the POSIX standard one.
 static double initial_time;
 #endif /* OS2 */
 
+#include "config.h"     /* Generated from config.h.cmake */
+
 static void	initExpand(void);
 static void	cleanupExpand(void);
 static void	initEnviron(void);
@@ -2496,7 +2498,7 @@ int
 System(char *cmd)
 { GET_LD
   int pid;
-  char *shell = "/bin/sh";
+  char *shell = UNIX_SHELL;
   int rval;
   void (*old_int)();
   void (*old_stop)();


### PR DESCRIPTION
As discussed in #358, to allow flexible specification of Unix shell (specially needed in Android targets).