### PR TITLE
PORT: Link packages to libswipl.so and libm.so on Android

### DIFF
--- a/packages/cmake/PrologPackage.cmake
+++ b/packages/cmake/PrologPackage.cmake
@@ -34,15 +34,23 @@ if(WIN32)
 endif()
 include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR})
 
+
 # On ELF systems there is no need for   the  modules to link against the
 # core system. Dropping this has two advantages: the result is easier to
 # relocate and building  the  packages  can   for  a  large  part happen
 # concurrently with the main system.
+#
+# The Android linker does not make symbols globally visibly (unless the
+# library is loaded using LD_PRELOAD) so we are linking the libraries here.
 
-if(CMAKE_EXECUTABLE_FORMAT STREQUAL "ELF")
+if(NOT ANDROID AND (CMAKE_EXECUTABLE_FORMAT STREQUAL "ELF"))
   set(SWIPL_LIBRARIES "")
 else()
-  set(SWIPL_LIBRARIES libswipl)
+  if(ANDROID)
+    set(SWIPL_LIBRARIES libswipl m)
+  else()
+    set(SWIPL_LIBRARIES libswipl)
+  endif(ANDROID)
 endif()
 
 # swipl_plugin(name


### PR DESCRIPTION
The Android dynamic linker does not make symbols globally visible unless the symbols come from the main file or from a library loaded by `LD_PRELOAD`.
So we need to link each package with `libswipl.so`
As discussed in #358 and #366.