### PR TITLE
Add shell prolog flag

### DIFF
--- a/library/qsave.pl
+++ b/library/qsave.pl
@@ -194,7 +194,7 @@ make_header(Out, SaveClass, _Options) :-
     current_prolog_flag(unix, true),
     !,
     current_prolog_flag(executable, Executable),
-    current_prolog_flag(shell, Shell),
+    current_prolog_flag(posix_shell, Shell),
     format(Out, '#!~w~n', [Shell]),
     format(Out, '# SWI-Prolog saved state~n', []),
     (   SaveClass == runtime

--- a/library/qsave.pl
+++ b/library/qsave.pl
@@ -194,7 +194,8 @@ make_header(Out, SaveClass, _Options) :-
     current_prolog_flag(unix, true),
     !,
     current_prolog_flag(executable, Executable),
-    format(Out, '#!/bin/sh~n', []),
+    current_prolog_flag(shell, Shell),
+    format(Out, '#!~w~n', [Shell]),
     format(Out, '# SWI-Prolog saved state~n', []),
     (   SaveClass == runtime
     ->  ArgSep = ' -- '

--- a/library/shell.pl
+++ b/library/shell.pl
@@ -66,19 +66,16 @@ the amount of available memory.
 %!  shell
 %
 %   Execute an interactive shell. The executed   shell is defined by
-%   the environment =SHELL= or =comspec=   (Windows).  If neither is
-%   defined, =|/bin/sh|= is used.
+%   the environment variable =SHELL= or =comspec=  for (Windows).
+%   If neither is defined, the prolog flag =|shell|= is used.
 
-shell :-
-    getenv('SHELL', Shell),        % Unix, also Cygwin
-    !,
-    shell(Shell).
 shell :-
     getenv(comspec, ComSpec),      % Windows
     !,
     shell(ComSpec).
 shell :-
-    shell('/bin/sh').
+    current_prolog_flag(posix_shell,Shell),
+    shell(Shell).
 
 %!  cd.
 %!  cd(Dir).

--- a/src/os/pl-prologflag.c
+++ b/src/os/pl-prologflag.c
@@ -1455,6 +1455,15 @@ initPrologFlags(void)
   setPrologFlag("mitigate_spectre", FT_BOOL, FALSE, PLFLAG_MITIGATE_SPECTRE);
 #endif
 
+#if defined(__unix__)
+  const char* env_shell = getenv("SHELL");
+  if (env_shell != NULL) {
+     setPrologFlag("posix_shell", FT_ATOM, env_shell);
+  } else {
+     setPrologFlag("posix_shell", FT_ATOM, UNIX_SHELL);
+  }
+#endif
+
   setTZPrologFlag();
   setOSPrologFlags();
   setVersionPrologFlag();


### PR DESCRIPTION
Add prolog flag to point to the current shell.
As discussed in #366 