### PR TITLE
PORT: Various minor fixes for the Android port

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,8 +53,7 @@ endif()
 set(CMAKE_INSTALL_MESSAGE NEVER)
 
 # Installation locations
-string(TOLOWER ${CMAKE_HOST_SYSTEM_PROCESSOR}-${CMAKE_HOST_SYSTEM_NAME}
-       SWIPL_ARCH)
+# SWIPL_ARCH is set in Ports.cmake
 
 ################
 # Installation directories

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,9 @@ option(SWIPL_VERSIONED_DIR
 option(INSTALL_DOCUMENTATION
        "Install the HTML documentation files"
        ON)
+option(SWIPL_INSTALL_IN_LIB
+       "Install library in ${CMAKE_INSTALL_PREFIX}/lib"
+       OFF)
 option(BUILD_PDF_DOCUMENTATION
        "Build the PDF manuals from source"
        OFF)

--- a/cmake/FindGMP.cmake
+++ b/cmake/FindGMP.cmake
@@ -8,13 +8,13 @@
 # GMP_LIBRARY_DLL    - library DLL to install. Only available on WIN32.
 # GMP_LIBRARIES_DIR - the directory the library we link with is found in.
 
-if (ANDROID)
+if (ANDROID AND (NOT $ENV{TERMUX_CMAKE_BUILD}))
 set( GMP_ROOT ${CMAKE_SOURCE_DIR}/../gmp/${ANDROID_ABI} )
   set (GMP_FOUND ON)
   set (GMP_INCLUDE_DIRS ${GMP_ROOT})
   set (GMP_LIBRARIES ${GMP_ROOT}/libgmp.so)
   set (GMP_LIBRARIES_DIR ${GMP_ROOT})
-else(ANDROID)
+else(ANDROID AND (NOT $ENV{TERMUX_CMAKE_BUILD}))
 if(MSVC)
    find_library(GMP_LIBRARIES NAMES mpir mpird
                 PATHS
@@ -88,7 +88,7 @@ get_filename_component(GMP_LIBRARIES_DIR "${GMP_LIBRARIES}" PATH CACHE)
 
 
 endif(MSVC)
-endif(ANDROID)
+endif(ANDROID AND (NOT $ENV{TERMUX_CMAKE_BUILD}))
 
 # handle the QUIET and REQUIRED arguments and set GMP_FOUND to TRUE if
 # all listed variables are true

--- a/cmake/Ports.cmake
+++ b/cmake/Ports.cmake
@@ -1,6 +1,10 @@
 # Architecture ID
-string(TOLOWER ${CMAKE_HOST_SYSTEM_PROCESSOR}-${CMAKE_HOST_SYSTEM_NAME}
-       SWIPL_ARCH)
+if(ANDROID)
+   set(SWIPL_ARCH ${CMAKE_ANDROID_ARCH}-linux)
+else(ANDROID)
+   string(TOLOWER ${CMAKE_HOST_SYSTEM_PROCESSOR}-${CMAKE_HOST_SYSTEM_NAME}
+          SWIPL_ARCH)
+endif(ANDROID)
 
 if(APPLE)
   include(port/Darwin)

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -32,7 +32,7 @@ FUNCTION(ILINK from to)
   get_filename_component(LNTDIR ${to} DIRECTORY)
   get_filename_component(LNTNAME ${from} NAME)
   file(RELATIVE_PATH LNLNK ${LNTDIR} ${from})
-  install(CODE "EXECUTE_PROCESS(COMMAND ln -sf ./${LNLNK} ./${LNTNAME}
+  install(CODE "EXECUTE_PROCESS(COMMAND ln -sf ${LNLNK} ./${LNTNAME}
 				WORKING_DIRECTORY \$ENV{DESTDIR}${LNTDIR})")
 ENDFUNCTION(ILINK)
 

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -32,7 +32,7 @@ FUNCTION(ILINK from to)
   get_filename_component(LNTDIR ${to} DIRECTORY)
   get_filename_component(LNTNAME ${from} NAME)
   file(RELATIVE_PATH LNLNK ${LNTDIR} ${from})
-  install(CODE "EXECUTE_PROCESS(COMMAND ln -sf ${LNLNK} ./${LNTNAME}
+  install(CODE "EXECUTE_PROCESS(COMMAND ln -sf ./${LNLNK} ./${LNTNAME}
 				WORKING_DIRECTORY \$ENV{DESTDIR}${LNTDIR})")
 ENDFUNCTION(ILINK)
 

--- a/packages/cmake/PrologPackage.cmake
+++ b/packages/cmake/PrologPackage.cmake
@@ -45,7 +45,7 @@ include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR})
 # here.
 
 if(ANDROID)
-  set(SWIPL_LIBRARIES libswipl m)
+  set(SWIPL_LIBRARIES libswipl m log)
 else()
   if(CMAKE_EXECUTABLE_FORMAT STREQUAL "ELF")
     set(SWIPL_LIBRARIES "")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -458,11 +458,24 @@ configure_file(parms.h.cmake parms.h)
 # Installation
 ################
 
+if(SWIPL_INSTALL_IN_LIB)
+install(DIRECTORY DESTINATION lib)
+install(TARGETS swipl
+	     RUNTIME DESTINATION ${SWIPL_INSTALL_ARCH_EXE}
+)
+install(TARGETS libswipl
+	     RUNTIME DESTINATION ${SWIPL_INSTALL_ARCH_EXE}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+)
+else(SWIPL_INSTALL_IN_LIB)
 install(TARGETS swipl libswipl
-	RUNTIME DESTINATION ${SWIPL_INSTALL_ARCH_EXE}
+	     RUNTIME DESTINATION ${SWIPL_INSTALL_ARCH_EXE}
         LIBRARY DESTINATION ${SWIPL_INSTALL_ARCH_LIB}
         ARCHIVE DESTINATION ${SWIPL_INSTALL_ARCH_LIB}
 )
+endif(SWIPL_INSTALL_IN_LIB)
+
 install(FILES ${SWIPL_BOOT_FILE}
 	DESTINATION ${SWIPL_INSTALL_PREFIX}
 )
@@ -535,10 +548,3 @@ endif()
 
 endif(WIN32)
 
-# Create symbolic link to lib directory, since rpath is broken
-# in many android versions
-if(ANDROID)
-install(DIRECTORY DESTINATION lib)
-ilink(${CMAKE_INSTALL_PREFIX}/${SWIPL_INSTALL_ARCH_LIB}/libswipl.so
-      ${CMAKE_INSTALL_PREFIX}/lib/libswipl.so)
-endif(ANDROID)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -534,3 +534,11 @@ ilink(${CMAKE_INSTALL_PREFIX}/${SWIPL_INSTALL_ARCH_EXE}/swipl-ld
 endif()
 
 endif(WIN32)
+
+# Create symbolic link to lib directory, since rpath is broken
+# in many android versions
+if(ANDROID)
+install(DIRECTORY DESTINATION lib)
+ilink(${CMAKE_INSTALL_PREFIX}/${SWIPL_INSTALL_ARCH_LIB}/libswipl.so
+      ${CMAKE_INSTALL_PREFIX}/lib/libswipl.so)
+endif(ANDROID)


### PR DESCRIPTION
* Use the termux provided `gmp` if compiling under termux
* Set the android architecture properly
* Link to android's `liblog.so` so that symbols are visible for packages that print to syslog
* Add symlink to `libswipl.so` since `rpath` is broken in many android versions

As always, I welcome changes/comments. 
Part of #358