### PR TITLE
INSTALL: create tmp_dir if it does not exist

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -464,6 +464,11 @@ else()
   set(LIBSWIPL_DIR ${SWIPL_INSTALL_ARCH_LIB})
 endif()
 
+#Make sure tmp directory exists
+if(NOT IS_DIRECTORY ${SWIPL_TMP_DIR})
+install(DIRECTORY DESTINATION ${SWIPL_TMP_DIR})
+endif()
+
 install(TARGETS swipl libswipl
 	RUNTIME DESTINATION ${SWIPL_INSTALL_ARCH_EXE}
         LIBRARY DESTINATION ${LIBSWIPL_DIR}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -465,6 +465,10 @@ else()
 endif()
 
 #Make sure tmp directory exists
+#This is primarily used for Android, where
+#the TMP directory is not shared with any 
+#other users, since on Android every application
+#is its own user.
 if(NOT IS_DIRECTORY ${SWIPL_TMP_DIR})
 install(DIRECTORY DESTINATION ${SWIPL_TMP_DIR})
 endif()


### PR DESCRIPTION
Make sure the SWIPL_TMP_DIR directory exists.
Part of #358.