### PR TITLE
PORT: calculate alignment at compile time

### DIFF
--- a/cmake/AlignOf.cmake
+++ b/cmake/AlignOf.cmake
@@ -1,42 +1,49 @@
 # Define variables for alignment of int64, void*, and double
 
 function(alignof VAR_ALIGNOF_INT64_T VAR_ALIGNOF_VOIDP VAR_ALIGNOF_DOUBLE)
-   # Compile alignment checker source
-   set(alignof_checker_target ${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/CheckAlignOf.bin)
-   set(alignof_checker_source_dir ${CMAKE_CURRENT_LIST_DIR})
-   try_compile(alignof_checker_ok
-               ${CMAKE_BINARY_DIR}
-               ${alignof_checker_source_dir}/CheckAlignment.cpp
-               COPY_FILE ${alignof_checker_target})
+   if(NOT DEFINED ${VAR_ALIGNOF_DOUBLE})
+      # Compile alignment checker source
+      set(alignof_checker_target ${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/CheckAlignOf.bin)
+      set(alignof_checker_source_dir ${CMAKE_CURRENT_LIST_DIR})
+      try_compile(alignof_checker_ok
+         ${CMAKE_BINARY_DIR}
+         ${alignof_checker_source_dir}/CheckAlignment.cpp
+         COPY_FILE ${alignof_checker_target})
 
-   if(alignof_checker_ok)
-      # Match 1,4, 8,16,32 or 64 alignments
-      set(alignof_pat_regex "(1|4|8|16|32|64)")
+      if(alignof_checker_ok)
+         # Match 1,4, 8,16,32 or 64 alignments
+         set(alignof_pat_regex "(1|4|8|16|32|64)")
 
-      # Read patterns from compiled executable
-      FILE(STRINGS ${alignof_checker_target} alignof_int64_pat
-           REGEX "^INT64_ALIGNMENT=${alignof_pat_regex}" LIMIT_COUNT 1)
+         # Read patterns from compiled executable
+         FILE(STRINGS ${alignof_checker_target} alignof_int64_pat
+            REGEX "^INT64_ALIGNMENT=${alignof_pat_regex}" LIMIT_COUNT 1)
 
-      FILE(STRINGS ${alignof_checker_target} alignof_voidp_pat
-           REGEX "^VOIDP_ALIGNMENT=${alignof_pat_regex}" LIMIT_COUNT 1)
+         FILE(STRINGS ${alignof_checker_target} alignof_voidp_pat
+            REGEX "^VOIDP_ALIGNMENT=${alignof_pat_regex}" LIMIT_COUNT 1)
 
-      FILE(STRINGS ${alignof_checker_target} alignof_double_pat
-           REGEX "^DOUBLE_ALIGNMENT=${alignof_pat_regex}" LIMIT_COUNT 1)
+         FILE(STRINGS ${alignof_checker_target} alignof_double_pat
+            REGEX "^DOUBLE_ALIGNMENT=${alignof_pat_regex}" LIMIT_COUNT 1)
 
-      # Extract alignments from patterns and assign them to the variables
-      string(REGEX MATCH "${alignof_pat_regex}$" ${VAR_ALIGNOF_INT64_T} ${alignof_int64_pat})
-      string(REGEX MATCH "${alignof_pat_regex}$" ${VAR_ALIGNOF_DOUBLE} ${alignof_double_pat})
-      string(REGEX MATCH "${alignof_pat_regex}$" ${VAR_ALIGNOF_VOIDP} ${alignof_voidp_pat})
+         # Extract alignments from patterns and assign them to the variables
+         string(REGEX MATCH "${alignof_pat_regex}$" int64_alignment ${alignof_int64_pat})
+         string(REGEX MATCH "${alignof_pat_regex}$" double_alignment ${alignof_double_pat})
+         string(REGEX MATCH "${alignof_pat_regex}$" voidp_alignment ${alignof_voidp_pat})
 
-      # Report the results
-      foreach(alignof_type INT64_T DOUBLE VOIDP)
-         MESSAGE(STATUS "Check alignment of ${alignof_type}: ${${VAR_ALIGNOF_${alignof_type}}}")
-      endforeach(alignof_type)
-   else()
-      MESSAGE(FATAL_ERROR "Check alignment: unable to compile test program.")
-   endif(alignof_checker_ok)
+         # Cache the results
+         set(${VAR_ALIGNOF_INT64_T} ${int64_alignment} CACHE STRING "Alignment of int64_t")
+         set(${VAR_ALIGNOF_DOUBLE} ${double_alignment} CACHE STRING "Alignment of double")
+         set(${VAR_ALIGNOF_VOIDP} ${voidp_alignment} CACHE STRING "Alignment of void*")
 
-   if(NOT DEFINED ${VAR_ALIGNOF_INT64_T})
+         # Report the results
+         foreach(alignof_type INT64_T DOUBLE VOIDP)
+            MESSAGE(STATUS "Check alignment of ${alignof_type}: ${${VAR_ALIGNOF_${alignof_type}}}")
+         endforeach(alignof_type)
+      else()
+         MESSAGE(FATAL_ERROR "Check alignment: unable to compile test program.")
+      endif(alignof_checker_ok)
+
+      if(NOT DEFINED ${VAR_ALIGNOF_INT64_T})
          MESSAGE(FATAL_ERROR "Check alignment: unable to determine void*, double and int64_t alignment.")
-   endif()
+      endif()
+   endif(NOT DEFINED ${VAR_ALIGNOF_DOUBLE})
 endfunction()

--- a/cmake/CheckAlignment.cpp
+++ b/cmake/CheckAlignment.cpp
@@ -1,0 +1,61 @@
+                      /*******************************************************
+                       * Create ascii pattern to match in order to find
+                       *         alignment at compile time
+                       *******************************************************/
+
+// Compile this program and match
+// the produced executable against:
+// INT64_ALIGNMENT=<code>
+// VOIDP_ALIGNMENT=<code>
+// DOUBLE_ALIGNMENT=<code>
+//
+// to get the alignment used by the (cross)compiler.
+//
+// <code> is the alignment as an ascii digit.
+
+#include <stdint.h>
+
+#if __cplusplus >= 201103L
+#define ALIGNOF(type) (alignof(type) + 48) // Ascii '1' for 1, '4' for 4, '8' for 8
+#else
+#define ALIGNOF(type) (sizeof(type) + 48) // Safe fallback
+#endif
+
+int prevent_optimization(unsigned char*p, int size) {
+   unsigned char *d;
+
+   //Prevent optimizer from eliminating the constants in main()
+   unsigned char dummy[size];
+   d = dummy;
+   for (int i = 0; i < size; ++i) {
+     *d++ = *p++;
+   }
+   return dummy[size-1];
+}
+
+
+int main() {
+   const int int64_pat_sz = 18;
+   const int voidp_pat_sz = 18;
+   const int double_pat_sz = 19;
+
+   static const unsigned char int64_alignment[int64_pat_sz] = {
+         'I', 'N','T','6','4','_','A','L','I','G','N','M','E','N','T','=',
+         ALIGNOF(int64_t), 0x0
+   };
+
+   static const unsigned char voidp_alignment[voidp_pat_sz] = {
+         'V', 'O','I','D','P','_','A','L','I','G','N','M','E','N','T','=',
+         ALIGNOF(void*), 0x0
+   };
+
+   static const unsigned char double_alignment[double_pat_sz] = {
+         'D', 'O','U','B','L','E','_','A','L','I','G','N','M','E','N','T','=',
+         ALIGNOF(double), 0x0
+   };
+
+   //Not used, prevent optimization
+   return prevent_optimization((unsigned char*)int64_alignment, int64_pat_sz) +
+          prevent_optimization((unsigned char*)voidp_alignment, voidp_pat_sz) +
+          prevent_optimization((unsigned char*)double_alignment, double_pat_sz);
+}

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -94,9 +94,8 @@ if(NOT SIZEOF_MP_BITCNT_T STREQUAL "")
   set(HAVE_MP_BITCNT_T 1)
 endif()
 
-alignof(int64_t c ALIGNOF_INT64_T)
-alignof(double c ALIGNOF_DOUBLE)
-alignof("void*" c ALIGNOF_VOIDP)
+include(AlignOf)
+alignof(ALIGNOF_INT64_T ALIGNOF_VOIDP ALIGNOF_DOUBLE)
 
 
 ################


### PR DESCRIPTION
Fix for #382 
It calculates the alignment of `void*`, `double` and `int64_t` at compile time. Which means it can be used when cross-compiling without the need for an emulator.