### PR TITLE
Remove unused getwd() definition

### DIFF
--- a/src/pl-funcs.h
+++ b/src/pl-funcs.h
@@ -395,7 +395,6 @@ COMMON(void)		setOSPrologFlags(void);
 COMMON(void)		RemoveTemporaryFiles(void);
 COMMON(bool)		OpenStream(int fd);
 COMMON(char *)		expandVars(const char *pattern, char *expanded, int len);
-COMMON(char *)		getwd(char *buf);
 COMMON(char *)		AbsoluteFile(const char *spec, char *path);
 COMMON(int)		IsAbsolutePath(const char *spec);
 COMMON(char *)		BaseName(const char *f, char *buf);


### PR DESCRIPTION
getwd() is no longer implemented and at least on NetBSD during the
build the following warnings are printed:

````
    In file included from .../swipl-devel/src/pl-incl.h:2439:0,
                     from .../swipl-devel/src/pl-atom.c:37:
    .../swipl-devel/src/pl-funcs.h:398:17: warning: redeclaration of ‘getwd’ with different visibility (old visibility preserved)
     COMMON(char *)  getwd(char *buf);
                     ^~~~~
    In file included from .../swipl-devel/src/os/SWI-Stream.h:68:0,
                     from .../swipl-devel/src/pl-builtin.h:68,
                     from .../swipl-devel/src/pl-incl.h:86,
                     from .../swipl-devel/src/pl-atom.c:37:
    /usr/include/unistd.h:291:7: note: previous declaration of ‘getwd’ was here
     char *getwd(char *);    /* obsoleted by getcwd() */
           ^~~~~
````

(According inspecting the `git log` it seems that the implementation was moved
in the `xpce` package but also there then it was removed probably by commit
d3887ec9f1c3eadf0a86b071c2392b9a8137d633 on Wed Aug 23 11:56:04 2017.)