### PR TITLE
Define {fopen,ftello,fseeko}64 functions for NetBSD

### DIFF
--- a/src/minizip/ioapi.h
+++ b/src/minizip/ioapi.h
@@ -50,7 +50,7 @@
 #define ftello64 ftell
 #define fseeko64 fseek
 #else
-#if defined(__FreeBSD__) || defined(__OpenBSD__)
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
 #define fopen64 fopen
 #define ftello64 ftello
 #define fseeko64 fseeko


### PR DESCRIPTION
Similar to FreeBSD and OpenBSD, NetBSD does not have
{fopen,ftello,fseeko}64 functions.