### PR TITLE
FIXED: string_code/3 1-based index for  -,+,- and +,+,- modes

### DIFF
--- a/src/Tests/eclipse/string_tests.tst
+++ b/src/Tests/eclipse/string_tests.tst
@@ -304,6 +304,7 @@ string_code(1,"abc",C) should_give C==97.
 string_code(2,"abc",C) should_give C==98.
 string_code(3,"abc",C) should_give C==99.
 string_code(-1, "abc",_) should_raise 6.
+string_code(I, "abc", C) should_give I==1, C==97.
 % possible alternative behaviour:
 %string_code(-1,"abc",C) should_give C==99.
 %string_code(-2,"abc",C) should_give C==98.

--- a/src/pl-string.c
+++ b/src/pl-string.c
@@ -214,7 +214,7 @@ PRED_IMPL("string_code", 3, string_code, PL_FA_NONDETERMINISTIC)
 
     gen:
       if ( tchar == -1 )
-      { if ( PL_unify_integer(A1, idx) &&
+      { if ( PL_unify_integer(A1, idx+1) &&
 	     PL_unify_integer(A3, text_get_char(&t, idx)) )
 	{ if ( idx+1 < t.length )
 	    ForeignRedoInt(idx+1);


### PR DESCRIPTION
There is a bug in the current implementation of `string_code/3`:
* `-,+,-` mode uses 0-based index, and
* `+,+,-` mode uses 1-based index as shown below:

```
Welcome to SWI-Prolog (threaded, 64 bits, version 7.7.25)
SWI-Prolog comes with ABSOLUTELY NO WARRANTY. This is free software.
Please run ?- license. for legal details.

For online help and background, visit http://www.swi-prolog.org
For built-in help, use ?- help(Topic). or ?- apropos(Word).

1 ?- string_code(I,"ABC",C).
I = 0,                          <------------ notice the 0
C = 65 ;
I = 1,
C = 66 ;
I = 2,
C = 67.

2 ?- string_code(1,"ABC",C).    <------------ notice the 1
C = 65.

3 ?-
```

This PR:
 * fixes the problem using a 1-based index for both, in accordance with the documentation. 
 * adds a test