### PR TITLE
Cross-architecture shlib support for saved states

### DIFF
--- a/boot/init.pl
+++ b/boot/init.pl
@@ -3522,7 +3522,6 @@ compile_aux_clauses(Clauses) :-
 '$expand_goal'(In, In).
 '$expand_term'(In, Layout, In, Layout).
 
-
                  /*******************************
                  *         TYPE SUPPORT         *
                  *******************************/

--- a/man/runtime.doc
+++ b/man/runtime.doc
@@ -144,19 +144,54 @@ from the runtime environment or location where it was built. See also
 	\termitem{emulator}{+File}
 File to use for the emulator.  Default is the running Prolog image.
 
-	\termitem{foreign}{+Action}
-If \const{save}, include shared objects (DLLs) into the saved state. See
-current_foreign_library/2. If the program \program{strip} is available,
-this is first used to reduce the size of the shared object. If a state
-is started, use_foreign_library/1 first tries to locate the foreign
-resource in the resource database. When found it copies the content of
-the resource to a temporary file and loads it. If possible (Unix), the
-temporary object is deleted immediately after opening.\footnote{This
-option is experimental and currently disabled by default. It will become
-the default if it proves robust.}\footnote{Creating a temporary file is
-the most portable way to load a shared object from a zip file but
-requires write access to the file system.  Future versions may provide
-shortcuts for specific platforms that bypass the file system.}
+\termitem{foreign}{+Action}
+
+If \const{save}, include shared objects (DLLs) for the current
+architecture into the saved state. See current_foreign_library/2,
+and current_prolog_flag(arch, Arch). If the program \program{strip}
+is available, this is first used to reduce the size of the shared
+object. If a state is started, use_foreign_library/1 first tries
+to locate the foreign resource in the resource database. When
+found it copies the content of the resource to a temporary file
+and loads it. If possible (Unix), the temporary object is deleted
+immediately after opening.\footnote{This option is experimental and
+currently disabled by default. It will become the default if it proves
+robust.}\footnote{Creating a temporary file is the most portable way
+to load a shared object from a zip file but requires write access to
+the file system. Future versions may provide shortcuts for specific
+platforms that bypass the file system.}
+
+If Action is of the form \const{arch(ListOfArches)} then the
+shared objects for the specified architectures are stored in
+the saved state. On the command line, the list of architectures
+can be passed as \const{--foreign=<CommaSepArchesList>}. In
+order to obtain the shared object file for the specified
+architectures, qsave_program/2 calls a user defined hook:
+\const{qsave:arch_find_shlib(+Arch, +FileSpec, -SoPath)}. This hook
+needs to unify \const{SoPath} with the absolute path to the
+shared object for the specified architecture. \const{FileSpec} is
+of the form \const{foreign(Name)}.
+
+At runtime, SWI-Prolog will try to load the shared library which
+is compatible with the current architecture, obtained by calling
+\const{current_prolog_flag(arch, Arch)}. An architecture is
+compatible if one of the two following conditions is true (tried
+in order):
+
+\begin{enumerate}
+    \item{There is a shared object in the saved state file which
+          matches the current architecture name (from
+          current_prolog_flag/2) exactly.}
+    \item{The user definable \const{qsave:compat_arch(Arch1, Arch2)}
+          hook succeeds.}
+\end{enumerate}
+
+This last one is useful when one wants to produce one shared object file
+that works for multiple architectures, usually compiling for the lowest
+common denominator of a certain CPU type. For example, it is common to compile
+for armv7 if even if the code will be running on newer arm CPUs. It
+is also useful to provide highly-optimized shared objects for
+particular architectures.
 
 	\termitem{undefined}{+Value}
 Defines what happens if an undefined predicate is found during the


### PR DESCRIPTION
Okay, this is a working version supporting multi-architectures for shared libraries in the saved state.
What is missing now is to add some tests to the test suite, but wanted to submit the PR now that you made the intermediate code independent of word size. It is looking good!!

Let me know what you think. This is what is implemented (from the documentation included in the PR):

**foreign(+Action)**
If save, include shared objects (DLLs) for the current architecture into the saved state. See `current_foreign_library/2`, and `current_prolog_flag(arch, Arch)`. If the program strip is available, this is first used to reduce the size of the shared object. If a state is started, `use_foreign_library/1` first tries to locate the foreign resource in the resource database. When found it copies the content of the resource to a temporary file and loads it. If possible (Unix), the temporary object is deleted immediately after opening.

If Action is of the form `arch(ListOfArches)` then the shared objects for the specified architectures are stored in the saved state. On the command line, the list of architectures can be passed as `--foreign=\<CommaSepArchesList\>`. In order to obtain the shared object file for the specified architectures, `qsave_program/2` calls a user defined hook: `qsave:arch_find_shlib(+Arch, +FileSpec, -SoPath)`. This hook needs to unify `SoPath` with the absolute path to the shared object for the specified architecture. `FileSpec` is of the form foreign(Name).

At runtime, SWI-Prolog will try to load the shared library which is compatible with the current architecture, obtained by calling `current_prolog_flag(arch, Arch)`. An architecture is compatible if one of the two following conditions is true (tried in order):

1. There is a shared object in the saved state file which matches the current architecture name (from `current_prolog_flag/2`) exactly.
2. The user definable `qsave:compat_arch(CurrentArch, SoArch)` hook succeeds.

This last one is useful when one wants to produce one shared object file that works for multiple architectures, usually compiling for the lowest common denominator of a certain CPU type. For example, it is common to compile for armv7 if even if the code will be running on newer arm CPUs. It is also useful to provide highly-optimized shared objects for particular architectures.

Discussion in #414 
