### PR TITLE
FIXED: add -rdynamic to cflags to export symbols (fix #420)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(SWI-Prolog)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set(CMAKE_POLICY_DEFAULT_CMP0075 NEW)
+set(CMAKE_ENABLE_EXPORTS ON)
 
 option(MULTI_THREADED
        "Enable multiple Prolog threads"


### PR DESCRIPTION
* After cmake 3.4 -rdynamic is not added when building a
  target. This breaks the android termux build. This patch
  solves the problem.

More information in #420