### PR TITLE
ENHANCED: allow user:exception for missing shlibs, save dependencies

### DIFF
--- a/man/hack.doc
+++ b/man/hack.doc
@@ -471,6 +471,38 @@ predicates.  See also \prologflag{unknown} and \secref{autoload}.
 \arg{Context} is instantiated to the name of the missing global
 variable. The hook must call nb_setval/2 or b_setval/2 before returning
 with the action \const{retry}.
+
+    \termitem{missing_shared_object}{}
+\arg{Context} is instantiated to _{ arch: Arch, file: FileSpec },
+which points to the required architecture and `FileSpec` for the
+missing shared library. \arg{Action} can be unified with error, to
+throw an exception or with retry, in order to try to reload the
+missing library Normally the hook will obtain the missing library
+from the network, or a required dependency from the saved state (see
+qsave_foreign_libraries/4), and put them in a directory where the
+system dynamic linker can find it. The following example loads a
+required depdency from the saved state:
+
+\begin{code}
+:- use_foreign_library('input/shlib_with_dep.so').
+
+:- assertz((
+    user:exception(missing_shared_object,
+                   _{ arch: _, file: Spec },
+                   retry) :-
+        handle_missing_shlib(Spec)
+
+   )).
+
+handle_missing_shlib(Spec) :-
+        Spec = 'input/shlib_with_dep.so',
+        qsave_foreign_libraries(Arch, 'input/shlib_with_dep.so', [Dep], [deps]),
+        copy_file(Dep.entry,'libdep.so'). % linker finds it in current dir
+
+% here put some code that calls predicates in shlib_with_dep.so
+
+\end{code}
+
 \end{description}
 \end{description}
 

--- a/man/runtime.doc
+++ b/man/runtime.doc
@@ -163,16 +163,23 @@ to load a shared object from a zip file but requires write access to
 the file system. Future versions may provide shortcuts for specific
 platforms that bypass the file system.}
 
-If \arg{Action} is of the form \term{arch}{ListOfArches} then the
-shared objects for the specified architectures are stored in
-the saved state. On the command line, the list of architectures
-can be passed as \const{--foreign=<CommaSepArchesList>}. In
-order to obtain the shared object file for the specified
-architectures, qsave_program/2 calls a user defined hook:
-\term{qsave:arch_shlib}{+Arch, +FileSpec, -SoPath}. This hook
-needs to unify \const{SoPath} with the absolute path to the
-shared object for the specified architecture. \const{FileSpec} is
-of the form \const{foreign(Name)}.
+If  \arg{Action} is  of  the form  \term{arch}{ListOfArches} then  the
+shared objects for the specified architectures are stored in the saved
+state. On the command line, the list of architectures can be passed as
+\const{--foreign=<CommaSepArchesList>}. In order  to obtain the shared
+object file  for the specified architectures,  qsave_program/2 calls a
+user defined hook:  \term{qsave:arch_shlib}{+Arch, +FileSpec, -SoPath,
+-DepsPaths}.
+
+This hook needs to unify \const{SoPath}  with the absolute path to the
+main shared  object for the specified  architecture. Additional shared
+libraries on which the main shared library depends may be specified as
+a list of paths in \const{DepsPaths},  otherwise it should be bound to
+[]. These  dependencies are then  stored in the resulting  archive. In
+order to make the dependencies accessible to `open_shared_object` they
+need to  be copied  to an appropiate  directory manually.  Please note
+that the  dependencies are *not*  loaded automatically from  the saved
+state, see user:exception/3 for a way to do this.
 
 At runtime, SWI-Prolog will try to load the shared library which
 is compatible with the current architecture, obtained by calling

--- a/src/Tests/save/input/libdep.c
+++ b/src/Tests/save/input/libdep.c
@@ -1,0 +1,4 @@
+const char*
+shlib_fun_in_dep()
+{   return "three_three_three";
+}

--- a/src/Tests/save/input/missing_shlib.pl
+++ b/src/Tests/save/input/missing_shlib.pl
@@ -1,0 +1,19 @@
+:- set_prolog_flag(autoload, false).
+:- use_module(library(shlib)).
+:- use_module(library(qsave)).
+:- use_foreign_library('input/shlib_no_deps.so').
+
+:- assertz((
+    user:exception(missing_shared_object,
+                   _{ arch: _, file: Spec },
+                   retry) :-
+        Spec = 'input/shlib_no_deps.so',
+        rename_file('input/shlib_no_deps.so.bak',Spec)
+   )).
+
+% Test loading md54pl.so through user:exception
+shlib_test :-
+    shlib_fun(V),
+    format('~q.',[V]).
+
+% vim: sw=4 ft=prolog :

--- a/src/Tests/save/input/multi_arch_compat.pl
+++ b/src/Tests/save/input/multi_arch_compat.pl
@@ -1,0 +1,24 @@
+:- set_prolog_flag(autoload, false).
+:- use_module(library(shlib)).
+:- use_module(library(qsave)).
+:- asserta( user:file_search_path(foreign, './input') ).
+:- use_foreign_library(foreign(shlib_no_deps)).
+
+% Test loading shlib_no_deps.so ith another architecture
+% which is compatible with the current one.
+shlib_test :-
+    shlib_fun(V),
+    format('~q.',[V]).
+
+
+:- multifile qsave:arch_shlib/3.
+qsave:arch_shlib('x86_64-myarch', Spec, File, []) :-
+    Spec == foreign(shlib_no_deps),
+    absolute_file_name(Spec, File,
+                       [ access(execute),
+                         file_type(executable)
+                       ]).
+
+qsave:compat_arch(_, 'x86_64-myarch').
+
+% vim: sw=4 ft=prolog :

--- a/src/Tests/save/input/multi_arch_simple.pl
+++ b/src/Tests/save/input/multi_arch_simple.pl
@@ -1,0 +1,9 @@
+:- use_foreign_library('./input/shlib_no_deps').
+
+% Test loading shlib_no_deps from the
+% saved state
+shlib_test :-
+    shlib_fun(V), % V == three_three_three
+    format('~q.',[V]).
+
+% vim: sw=4 ft=prolog :

--- a/src/Tests/save/input/shlib_no_deps.c
+++ b/src/Tests/save/input/shlib_no_deps.c
@@ -1,0 +1,19 @@
+#include <SWI-Prolog.h>
+
+static atom_t ATOM_three_three_three;
+
+
+static foreign_t
+shlib_fun(term_t t)
+{   return PL_unify_atom(t,  ATOM_three_three_three);
+}
+
+
+#define MKATOM(n) ATOM_ ## n = PL_new_atom(#n);
+
+install_t
+install(void)
+{ MKATOM(three_three_three);
+
+  PL_register_foreign("shlib_fun", 1, shlib_fun, 0);
+}

--- a/src/Tests/save/input/shlib_with_dep.c
+++ b/src/Tests/save/input/shlib_with_dep.c
@@ -1,0 +1,15 @@
+#include <SWI-Prolog.h>
+
+const char* shlib_fun_in_dep();
+
+static foreign_t
+shlib_fun(term_t t)
+{   const char* str = shlib_fun_in_dep();
+    return PL_unify_atom_chars(t, str);
+}
+
+
+install_t
+install(void)
+{ PL_register_foreign("shlib_fun", 1, shlib_fun, 0);
+}

--- a/src/Tests/save/input/shlib_with_dep.pl
+++ b/src/Tests/save/input/shlib_with_dep.pl
@@ -1,0 +1,42 @@
+:- set_prolog_flag(autoload, false).
+:- use_module(library(shlib)).
+:- use_module(library(qsave)).
+:- use_foreign_library('input/shlib_with_dep.so').
+
+:- assertz((
+    user:exception(missing_shared_object,
+                   _{ arch: _, file: Spec },
+                   retry) :-
+        handle_missing_shlib(Spec)
+
+   )).
+
+handle_missing_shlib(Spec) :-
+        Spec = 'input/shlib_with_dep.so',
+        qsave_foreign_libraries(Arch, 'input/shlib_with_dep.so', [Dep], [deps]),
+        copy_file(Dep.entry,'libdep.so'). % linker finds it in current dir
+
+% Test loading md54pl.so through user:exception
+shlib_test :-
+    shlib_fun(V),
+    format('~q.',[V]).
+
+
+% Helpers
+copy_file(From, To) :-
+    setup_call_cleanup(
+        open(From, read, In, [type(binary)]),
+        setup_call_cleanup(
+            open(To, write, Out, [type(binary)]),
+            copy_stream_data(In,Out),
+            close(Out)
+        ),
+        close(In)).
+
+
+% qsave hook
+qsave:arch_shlib(_, File, File, ['input/libdep.so']) :-
+    File == 'input/shlib_with_dep.so'.
+
+
+% vim: sw=4 ft=prolog :

--- a/src/Tests/save/test_saved_states.pl
+++ b/src/Tests/save/test_saved_states.pl
@@ -77,7 +77,8 @@ test_saved_states :-
 	       'Skipped saved state files because the system does\n\c
 	        not offer us enough open files~n', []).
 test_saved_states :-
-	run_tests([ saved_state
+	run_tests([ saved_state,
+	            multi_arch
 		  ]).
 
 :- dynamic
@@ -157,18 +158,23 @@ set_windows_path :-
 set_windows_path.
 
 create_state(File, Output, Args) :-
+	create_state(File, Output, Args, ErrOutput),
+	assertion(no_error(ErrOutput)).
+
+create_state(File, Output, Args, ErrOutput) :-
 	me(Me),
 	append(Args, ['-o', Output, '-c', File, '-f', none], AllArgs),
 	test_dir(TestDir),
 	debug(save, 'Creating state in ~q using ~q ~q', [TestDir, Me, AllArgs]),
 	process_create(Me, AllArgs,
 		       [ cwd(TestDir),
-			 stderr(pipe(Err))
+			 stderr(pipe(Err)),
+			 process(Pid)
 		       ]),
 	read_stream_to_codes(Err, ErrOutput),
 	close(Err),
-	debug(save, 'Saved state', []),
-	assertion(no_error(ErrOutput)).
+	process_wait(Pid,_Status), % to allow error status
+	debug(save, 'Saved state', []).
 
 run_state(Exe, Args, Result) :-
 	debug(save, 'Running state ~q ~q', [Exe, Args]),
@@ -190,6 +196,20 @@ remove_state(_State) :-
 	debugging(save(keep)), !.
 remove_state(State) :-
 	catch(delete_file(State), _, true).
+
+build_shlib(Name) :-
+	 format(atom(Cmd), "swipl-ld -shared -fPIC -o input/~w.so input/~w.c",[Name, Name]),
+	 shell(Cmd).
+
+build_shlib(Name, Dep, DepDir) :-
+	 format(atom(Cmd), "swipl-ld -shared -fPIC -L~w -l~w -o input/~w.so input/~w.c ",[DepDir, Dep, Name, Name]),
+	 format(user_error, '~w~n', Cmd),
+	 shell(Cmd).
+
+build_test_shlibs :-
+	 build_shlib("shlib_no_deps"),
+	 build_shlib("libdep"),
+	 build_shlib("shlib_with_dep", "dep", "input").
 
 %%	read_terms(+In:stream, -Data:list)
 %
@@ -240,8 +260,69 @@ test(true, Result == [true]) :-
 	      run_state(Exe, [], Result)
 	    ),
 	    remove_state(Exe)).
-
 :- end_tests(saved_state).
+
+
+:- begin_tests(multi_arch).
+test(load_shlib_no_deps, Result == [three_three_three]) :-
+	state_output(4, Exe),
+	call_cleanup(
+	    ( create_state('input/multi_arch_simple.pl', Exe, ['-g', shlib_test]),
+	      run_state(Exe, [], Result)
+	    ),
+	    remove_state(Exe)).
+test(load_wrong_arch, ErrOut == "ERROR: architecture_shlib(x86_64-strange1) `'./input/shlib_no_deps'' does not exist\n") :-
+	state_output(5, Exe),
+	call_cleanup(
+	    ( create_state('input/multi_arch_simple.pl', Exe,
+	                 ['--foreign=x86_64-strange1', '-g', shlib_test],
+	                 ErrOut0),
+	      string_codes(ErrOut, ErrOut0)
+	    ),
+	    remove_state(Exe)).
+test(compatible_arch, Result == [three_three_three]) :-
+	state_output(6, Exe),
+	call_cleanup(
+	    ( create_state('input/multi_arch_compat.pl', Exe,
+	                   [ '--foreign=x86_64-myarch',
+	                     '--no-autoload',
+	                     '-g', shlib_test
+	                   ]),
+	      run_state(Exe, [], Result)
+	    ),
+	    remove_state(Exe)).
+test(retry_missing_shlib, Result == [three_three_three]) :-
+	state_output(7, Exe),
+	setup_call_cleanup(
+	    rename_file('input/shlib_no_deps.so',
+	                'input/shlib_no_deps.so.bak'),
+	    ( create_state('input/missing_shlib.pl', Exe,
+	                   [ '--no-autoload',
+	                     '-g', shlib_test
+	                   ]),
+	      run_state(Exe, [], Result)
+	    ),
+	    ( catch(rename_file('input/shlib_no_deps.so.bak',
+	                        'input/shlib_no_deps.so'),
+	                   _,true),
+	      remove_state(Exe)
+	    )).
+test(shlib_with_dep, Result == [three_three_three]) :-
+	state_output(8, Exe),
+	setup_call_cleanup(
+	    copy_file('input/libdep.so','libdep.so'), % for linker to find it
+	    ( create_state('input/shlib_with_dep.pl', Exe,
+	                   [ '--no-autoload',
+	                     '--foreign=save',
+	                     '-g', shlib_test
+	                   ]),
+	      delete_file('libdep.so'), % to load it from state
+	      run_state(Exe, [], Result)
+	    ),
+	    ( catch(delete_file('libdep.so'), _, true),
+	      remove_state(Exe)
+	    )).
+:- end_tests(multi_arch).
 
 :- else.				% No library(process) found
 


### PR DESCRIPTION
This patch allows the user to load a shared library from the
network or from the saved state by means of writing the
user:exception hook.

It also provides qsave_foreign_libraries/4 to retrieve
foreign libraries (for a compatible architecture) from
the saved state. This makes it easier to implement the
user:exception hook, while abstracting from the internal
naming of the shared libraries in the saved state.

Accordingly qsave_program/2 is also enhanced to store
dependencies for the main shared library.

Test cases are also provided.

Implements what was discussed in #425 and #427 