### PR TITLE
PORT: Android minizip USE_FILE32API

### DIFF
--- a/cmake/AndroidTargets.cmake
+++ b/cmake/AndroidTargets.cmake
@@ -1,6 +1,4 @@
 # Set target options for Android
 
-# Minizip needs USE_FILE32API set in 32-bit architectures
-if(CMAKE_SIZEOF_VOID_P EQUAL 4)
-  target_compile_definitions(libswipl PRIVATE USE_FILE32API=1)
-endif()
+# Minizip needs USE_FILE32API on Android
+target_compile_definitions(libswipl PRIVATE USE_FILE32API=1)


### PR DESCRIPTION
Fix 'fopen64' not found in termux.