### PR TITLE
Add xref_called/5 which includes caller's line number

### DIFF
--- a/library/prolog_xref.pl
+++ b/library/prolog_xref.pl
@@ -39,6 +39,7 @@
             xref_source/2,              % +Source, +Options
             xref_called/3,              % ?Source, ?Callable, ?By
             xref_called/4,              % ?Source, ?Callable, ?By, ?Cond
+            xref_called/5,              % ?Source, ?Callable, ?By, ?Cond, ?Line
             xref_defined/3,             % ?Source. ?Callable, -How
             xref_definition_line/2,     % +How, -Line
             xref_exported/2,            % ?Source, ?Callable
@@ -94,7 +95,7 @@
 
 
 :- dynamic
-    called/4,                       % Head, Src, From, Cond
+    called/5,                       % Head, Src, From, Cond, Line
     (dynamic)/3,                    % Head, Src, Line
     (thread_local)/3,               % Head, Src, Line
     (multifile)/3,                  % Head, Src, Line
@@ -526,6 +527,7 @@ xref_done(Source, Time) :-
 
 %!  xref_called(?Source, ?Called, ?By) is nondet.
 %!  xref_called(?Source, ?Called, ?By, ?Cond) is nondet.
+%!  xref_called(?Source, ?Called, ?By, ?Cond, ?Line) is nondet.
 %
 %   Enumerate the predicate-call relations. Predicate called by
 %   directives have a By '<directive>'.
@@ -535,8 +537,11 @@ xref_called(Source, Called, By) :-
 
 xref_called(Source, Called, By, Cond) :-
     canonical_source(Source, Src),
-    called(Called, Src, By, Cond).
+    called(Called, Src, By, Cond, _).
 
+xref_called(Source, Called, By, Cond, Line) :-
+    canonical_source(Source, Src),
+    called(Called, Src, By, Cond, Line).
 
 %!  xref_defined(?Source, +Goal, ?How) is nondet.
 %
@@ -1014,19 +1019,19 @@ process_directive(arithmetic_function(FSpec), Src) :-
     arith_callable(FSpec, Goal),
     !,
     current_source_line(Line),
-    assert_called(Src, '<directive>'(Line), Goal).
+    assert_called(Src, '<directive>'(Line), Goal, Line).
 process_directive(format_predicate(_, Goal), Src) :-
     !,
     current_source_line(Line),
-    assert_called(Src, '<directive>'(Line), Goal).
+    assert_called(Src, '<directive>'(Line), Goal, Line).
 process_directive(if(Cond), Src) :-
     !,
     current_source_line(Line),
-    assert_called(Src, '<directive>'(Line), Cond).
+    assert_called(Src, '<directive>'(Line), Cond, Line).
 process_directive(elif(Cond), Src) :-
     !,
     current_source_line(Line),
-    assert_called(Src, '<directive>'(Line), Cond).
+    assert_called(Src, '<directive>'(Line), Cond, Line).
 process_directive(else, _) :- !.
 process_directive(endif, _) :- !.
 process_directive(Goal, Src) :-
@@ -1381,7 +1386,8 @@ process_goal(Goal, Origin, Src, P) :-
     ),
     !,
     must_be(list, Called),
-    assert_called(Src, Origin, Goal),
+    current_source_line(Here),
+    assert_called(Src, Origin, Goal, Here),
     process_called_list(Called, Origin, Src, P).
 process_goal(Goal, Origin, Src, _) :-
     process_xpce_goal(Goal, Origin, Src),
@@ -1397,16 +1403,19 @@ process_goal(use_foreign_library(File, _Init), _Origin, Src, _) :-
 process_goal(Goal, Origin, Src, P) :-
     xref_meta_src(Goal, Metas, Src),
     !,
-    assert_called(Src, Origin, Goal),
+    current_source_line(Here),
+    assert_called(Src, Origin, Goal, Here),
     process_called_list(Metas, Origin, Src, P).
 process_goal(Goal, Origin, Src, _) :-
     asserting_goal(Goal, Rule),
     !,
-    assert_called(Src, Origin, Goal),
+    current_source_line(Here),
+    assert_called(Src, Origin, Goal, Here),
     process_assert(Rule, Origin, Src).
 process_goal(Goal, Origin, Src, P) :-
     partial_evaluate(Goal, P),
-    assert_called(Src, Origin, Goal).
+    current_source_line(Here),
+    assert_called(Src, Origin, Goal, Here).
 
 disjunction(Var)   --> {var(Var), !}, [Var].
 disjunction((A;B)) --> !, disjunction(A), disjunction(B).
@@ -1606,7 +1615,8 @@ pce_goal(get_object(_,_,_), get_object(arg, msg, -)).
 process_xpce_goal(G, Origin, Src) :-
     pce_goal(G, Process),
     !,
-    assert_called(Src, Origin, G),
+    current_source_line(Here),
+    assert_called(Src, Origin, G, Here),
     (   arg(I, Process, How),
         arg(I, G, Term),
         process_xpce_arg(How, Term, Origin, Src),
@@ -2215,53 +2225,53 @@ assert_constraint(Src, Head) :-
                 *       PHASE 1 ASSERTIONS      *
                 ********************************/
 
-%!  assert_called(+Src, +From, +Head) is det.
+%!  assert_called(+Src, +From, +Head, +Line) is det.
 %
 %   Assert the fact that Head is called by From in Src. We do not
 %   assert called system predicates.
 
-assert_called(_, _, Var) :-
+assert_called(_, _, Var, _) :-
     var(Var),
     !.
-assert_called(Src, From, Goal) :-
+assert_called(Src, From, Goal, Line) :-
     var(From),
     !,
-    assert_called(Src, '<unknown>', Goal).
-assert_called(_, _, Goal) :-
+    assert_called(Src, '<unknown>', Goal, Line).
+assert_called(_, _, Goal, _) :-
     expand_hide_called(Goal),
     !.
-assert_called(Src, Origin, M:G) :-
+assert_called(Src, Origin, M:G, Line) :-
     !,
     (   atom(M),
         callable(G)
     ->  current_condition(Cond),
         (   xmodule(M, Src)         % explicit call to own module
-        ->  assert_called(Src, Origin, G)
-        ;   called(M:G, Src, Origin, Cond) % already registered
+        ->  assert_called(Src, Origin, G, Line)
+        ;   called(M:G, Src, Origin, Cond, Line) % already registered
         ->  true
         ;   hide_called(M:G, Src)           % not interesting (now)
         ->  true
         ;   generalise(Origin, OTerm),
             generalise(G, GTerm)
-        ->  assert(called(M:GTerm, Src, OTerm, Cond))
+        ->  assert(called(M:GTerm, Src, OTerm, Cond, Line))
         ;   true
         )
     ;   true                        % call to variable module
     ).
-assert_called(Src, _, Goal) :-
+assert_called(Src, _, Goal, _) :-
     (   xmodule(M, Src)
     ->  M \== system
     ;   M = user
     ),
     hide_called(M:Goal, Src),
     !.
-assert_called(Src, Origin, Goal) :-
+assert_called(Src, Origin, Goal, Line) :-
     current_condition(Cond),
-    (   called(Goal, Src, Origin, Cond)
+    (   called(Goal, Src, Origin, Cond, Line)
     ->  true
     ;   generalise(Origin, OTerm),
         generalise(Goal, Term)
-    ->  assert(called(Term, Src, OTerm, Cond))
+    ->  assert(called(Term, Src, OTerm, Cond, Line))
     ;   true
     ).
 
@@ -2330,7 +2340,7 @@ assert_import(Src, Import, Export, From, Reexport) :-
     ->  assert(imported(Term, Src, From)),
         assert_reexport(Reexport, Src, Term)
     ;   current_source_line(Line),
-        assert_called(Src, '<directive>'(Line), Term)
+        assert_called(Src, '<directive>'(Line), Term, Line)
     ).
 assert_import(Src, op(P,T,N), _, _, _) :-
     xref_push_op(Src, P,T,N).
@@ -2491,7 +2501,7 @@ assert_multifile(PI, Src) :-                    % :- multifile(Spec)
 assert_public(PI, Src) :-                       % :- public(Spec)
     pi_to_head(PI, Term),
     current_source_line(Line),
-    assert_called(Src, '<public>'(Line), Term),
+    assert_called(Src, '<public>'(Line), Term, Line),
     assert(public(Term, Src, Line)).
 
 assert_export(PI, Src) :-                       % :- export(Spec)


### PR DESCRIPTION
In order to facilitate finding the exact line number that a given predicate was called from via `xref_called`, include the `current_line` in the `called` functor.

This gives the line of the particular clause of the calling predicate, which then makes it possible for callers to walk the body term to find the call exactly. Obviously it would be preferable for `xref_called` to return that particular line number exactly, but that seems to require keeping subterm positions through the entire sequence of `process_*` predicates, which seems like it would be a substantial change.

This also will change the number of solutions reported by `xref_called/3` and `xref_called/4`, since the same caller can now be repeated multiple times.

example of the behaviour change; given the below code (in `test.pl`):

```prolog
 1 :- module(test, []).
 2 
 3 foo(X) :-
 4   bar(X).
 5 foo(X) :-
 6   true,
 7   bar(X).
 8 
 9 bar(X).

```

Previously:

```prolog
?- Src = '/home/james/tmp/test.pl',
    xref_source(Src), 
    findall(By, xref_called(Src, bar(_), By, _), Callers).
Src = '/home/james/tmp/test.pl',
Callers = [foo(_1834)].
```

New behaviour: 

```prolog
?- Src = '/home/james/tmp/test.pl',
    xref_source(Src), 
    findall(By-Loc, xref_called(Src, bar(_), By, _, Loc), Callers).
Src = '/home/james/tmp/test.pl',
Callers = [foo(_2498)-3, foo(_2482)-5].
```