### PR TITLE
FIXED: verify_safe_declaration/1 leaves a choicepoint

### DIFF
--- a/library/sandbox.pl
+++ b/library/sandbox.pl
@@ -433,6 +433,7 @@ verify_safe_declaration(Var) :-
     !,
     instantiation_error(Var).
 verify_safe_declaration(Module:Goal) :-
+    !,
     must_be(atom, Module),
     must_be(callable, Goal),
     (   ok_meta(Module:Goal)


### PR DESCRIPTION
`sandbox:verify_safe_declaration/1` leaves a choicepoint for `Module:Goal`, back-tracking to `Goal` and a permissions error after succeeding.