### PR TITLE
Improve documentation

### DIFF
--- a/CMAKE.md
+++ b/CMAKE.md
@@ -32,19 +32,7 @@ the current git version.
 
 ## Native build
 
-### Getting the source
-
-The   source   may   be    downloaded    as     a    tar    ball    from
-http://www.swi-prolog.org or downloaded using git. The git sequence is:
-
-    git clone https://github.com/SWI-Prolog/swipl-devel.git
-    cd swipl-devel
-    git submodule update --init
-
-If not all modules are needed, one can clone/update particular ones as follows:
-
-    git submodule update --init packages/jpl packages/clib packages/sgml
-
+See [README.md](README.md) for how to get the source code.
 
 ### Building from source
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,50 @@
 # SWI-Prolog: A comprehensive Prolog implementation
 
-## Forking, cloning and submitting patches
+## Getting the source code
 
 This repositories uses many [GIT
-submodules](https://git-scm.com/book/en/v1/Git-Tools-Submodules). This
-cause the common __fork and clone not to work__. Instead, _clone_ from
+submodules](https://git-scm.com/book/en/v1/Git-Tools-Submodules).
+This causes the common __fork and clone not to work__.
+Instead, _clone_ from
 https://github.com/SWI-Prolog/swipl-devel.git and next associate your
-clone with your _fork_ (replace `me` with your github user name).
+clone with your _fork_.
+Follow the steps below.
+
+First, clone this Git repository:
 
     git clone https://github.com/SWI-Prolog/swipl-devel.git
     cd swipl-devel
-    git submodule update --init
+
+Finally, fork this repository on GitHub, and associate your fork:
+
+    # Replace "myfork" with any name you want except "origin".
+    # Replace "me" with your github user name.
+
     git remote add myfork git@github.com:me/swipl-devel.git
 
-See [How to submit a patch](http://www.swi-prolog.org/howto/SubmitPatch.html)
-for details.
+Optional: Clone the package submodules you want to use/modify.
+(If you don't know which packages you need, skip this step.
+You can come back here later.)
+You can specify individual package paths in the command line:
 
-## Building
+    git submodule update --init -- packages/jpl packages/clib packages/sgml
 
-See
-[CMAKE.md](https://github.com/SWI-Prolog/swipl-devel/blob/master/CMAKE.md)
+## Building from source
+
+See [CMAKE.md](CMAKE.md)
 and [Build SWI-Prolog from source](http://www.swi-prolog.org/build/)
 
+## Contributing
+
+There are several ways to contribute to SWI-Prolog:
+
+- Write source code.
+[Submit a patch](http://www.swi-prolog.org/howto/SubmitPatch.html).
+- Write or improve documentation. (How?)
+- Report an issue. (How?)
+- Help answer questions in the [SWI-Prolog Discourse group](https://swi-prolog.discourse.group).
+- Propose improvements in the SWI-Prolog Discourse group.
+- Donate/sponsor/fund an improvement. (How?)
 
 ## Web home
 


### PR DESCRIPTION
Continuing this discussion:

https://swi-prolog.discourse.group/t/improving-contributor-guide-discoverability-was-consolidating-the-71-github-repositories-to-simplify-maintenance-and-contribution/492

Here I try to improve the readme by centralizing and deduplicating some information.

In the long run, we should delete all copies of this information from other places such as the wiki, in order to not confuse people by outdated information.

Don't merge this yet. I have several questions in the comments.

Tip: You can use *relative-path* links in GitHub markdown files.
Example: `[CMAKE.md](CMAKE.md)` in README.md
