### PR TITLE
PORT: fixes 91f03daf6, FreeBSD headers

### DIFF
--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -210,13 +210,13 @@ check_function_exists(clock_gettime HAVE_CLOCK_GETTIME)
 # threads and scheduling
 if(CMAKE_USE_PTHREADS_INIT)
 check_c_source_compiles(
-    "#include <pthread.h>
+    "#include <sys/param..h>
      #include <sys/cpuset.h>
      int main() {}"
     SYS_CPUSET_H_FOUND)
 if(SYS_CPUSET_H_FOUND)
   check_c_source_compiles(
-      "#include <pthread.h>
+      "#include <sys/param.h>
        #include <sys/cpuset.h>
        int main(int argc, char** argv)
        {
@@ -230,7 +230,7 @@ if(SYS_CPUSET_H_FOUND)
        }"
       HAVE_SYS_CPUSET_H)
   check_c_source_compiles(
-      "#include <pthread.h>
+      "#include <sys/param.h>
        #include <sys/cpuset.h>
        typedef cpuset_t cpu_set_t;
        int main() { cpu_set_t *set; CPU_ZERO(set);}"

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -210,7 +210,7 @@ check_function_exists(clock_gettime HAVE_CLOCK_GETTIME)
 # threads and scheduling
 if(CMAKE_USE_PTHREADS_INIT)
 check_c_source_compiles(
-    "#include <sys/param..h>
+    "#include <sys/param.h>
      #include <sys/cpuset.h>
      int main() {}"
     SYS_CPUSET_H_FOUND)

--- a/src/pl-thread.c
+++ b/src/pl-thread.c
@@ -120,6 +120,7 @@ _syscall0(pid_t,gettid)
 #endif
 
 #ifdef HAVE_SYS_CPUSET_H
+#include <sys/param.h>         /* pulls sys/cdefs.h and sys/types.h for sys/cpuset.h */
 #include <sys/cpuset.h>        /* CPU_ZERO(), CPU_SET, cpuset_t */
 #endif
 #ifdef HAVE_PTHREAD_NP_H


### PR DESCRIPTION
I made a mistake:
contrary to my claim in 91f03daf6, pthread.h doesn't pull in the files
necessary to consume sys/cpuset.h, but sys/param.h does.
I'm sorry! I still don't know how could the test build on FreeBSD be successfull...