### PR TITLE
Correct spelling in 2.16.1.3

### DIFF
--- a/man/overview.doc
+++ b/man/overview.doc
@@ -2413,7 +2413,7 @@ format('This is a long line that looks better if it was\
 \end{code}
 
 Note that SWI-Prolog also allows unescaped newlines to appear in quoted
-material.  This is not allowed be the ISO standard, but used to be
+material.  This is not allowed by the ISO standard, but used to be
 common practice before.
     \escapeitem{e}
 Escape character (\textsc{ASCII} 27). Not ISO, but widely supported.


### PR DESCRIPTION
Section [*Character Escape Syntax*](http://www.swi-prolog.org/pldoc/man?section=charescapes)