### PR TITLE
Fix incorrect argument name

### DIFF
--- a/CMAKE.md
+++ b/CMAKE.md
@@ -222,7 +222,7 @@ Adjust as necessary.
 	  -DBUILD_SWIPL_LD=OFF \
 	  -DSWIPL_PACKAGES=OFF \
 	  -DINSTALL_DOCUMENTATION=OFF \
-	  -DNATIVE_FRIEND=build \
+	  -DSWIPL_NATIVE_FRIEND=build \
 	  -G Ninja ..
 
 ### Building a 32-bit version on 64-bit Debian based Linux


### PR DESCRIPTION
Flag -DNATIVE_FRIEND is not used by the cmake build, there is only -DSWIPL_NATIVE_FRIEND.