### PR TITLE
Workaround so that must_be docs work with html_text/[1,2]

### DIFF
--- a/library/error.pl
+++ b/library/error.pl
@@ -206,7 +206,7 @@ resource_error(Culprit) :-
 %   types.
 %
 %   | acyclic | Acyclic term (tree); see acyclic_term/1 |
-%   | any | |
+%   | any | any term |
 %   | between(FloatL,FloatU) | Number [FloatL..FloatU] |
 %   | between(IntL,IntU) | Integer [IntL..IntU] |
 %   | boolean | One of =true= or =false= |


### PR DESCRIPTION
`html_text/[1,2]` doesn't support html like this:
```
<tr><td>row 1 column 1</td><td>row 1 column 2</td></tr>
<tr><td>row 2 column 1</td></tr>
```

This is the kind of html generated by pldoc for the first two rows of the `must_be/2` table.
This workaround keeps the table with two columns for each row, and so it works with `html_text`.