### PR TITLE
Add neovim support for edit_command/2

### DIFF
--- a/library/edit.pl
+++ b/library/edit.pl
@@ -387,6 +387,7 @@ edit_command(edit,        '%e %f').
 
 edit_command(emacsclient, Command) :- edit_command(emacs, Command).
 edit_command(vim,         Command) :- edit_command(vi,    Command).
+edit_command(nvim,        Command) :- edit_command(vi,    Command).
 
 substitute(FromAtom, ToAtom, Old, New) :-
     atom_codes(FromAtom, From),


### PR DESCRIPTION
[Neovim](https://github.com/neovim/neovim) is a popular modern alternative (refactoring of the original Vim codebase) to Vim, which aims to provide more modern experience of development.