### PR TITLE
When a I_ENTER instruction is encountered via D_BREAK and the hook re…

### DIFF
--- a/src/pl-vmi.c
+++ b/src/pl-vmi.c
@@ -227,7 +227,12 @@ VMI(D_BREAK, 0, 0, ())
       { popArgvArithStack(pop PASS_LD);
 	AR_END();
       }
-      PC = stepPC(PC-1);		/* skip the old calling instruction */
+      if (decode(c) == I_ENTER)
+      {                                 /* Skip to the end of the clause if we are replacing I_ENTER */
+        PC = &FR->clause->value.clause->codes[FR->clause->value.clause->code_size-1];
+      } else
+      { PC = stepPC(PC-1);		/* skip the old calling instruction */
+      }
       updateAlerted(LD);
       VMI_GOTO(I_USERCALL0);
   }


### PR DESCRIPTION
…places the goal with a new one (ie via the call/1 option) then skip the original body of the goal.

The thinking here is that if you're replacing the I_ENTER, then you're really trying to replace the entire body of the predicate, since it doesn't make sense to replace the I_ENTER instruction otherwise.

Jan points out that wrap_predicate/4 exists now and will probably do this in a much more elegant way, but for completion (and in terms of back porting) I've also submitted this PR