### PR TITLE
PORT: Android minizip to use consistent file api

### DIFF
--- a/cmake/AndroidTargets.cmake
+++ b/cmake/AndroidTargets.cmake
@@ -1,4 +1,4 @@
 # Set target options for Android
 
-# Minizip needs USE_FILE32API on Android
-target_compile_definitions(libswipl PRIVATE USE_FILE32API=1)
+# Example:
+#target_compile_definitions(libswipl PRIVATE MY_C_DEFINE=1)

--- a/src/minizip/ioapi.h
+++ b/src/minizip/ioapi.h
@@ -21,7 +21,7 @@
 #ifndef _ZLIBIOAPI64_H
 #define _ZLIBIOAPI64_H
 
-#if (!defined(_WIN32)) && (!defined(WIN32)) && (!defined(__APPLE__))
+#if (!defined(_WIN32)) && (!defined(WIN32)) && (!defined(__APPLE__)) && (!defined(__ANDROID__))
 
   // Linux needs this to support file operation on files larger then 4+GB
   // But might need better if/def to select just the platforms that needs them.
@@ -51,7 +51,7 @@
 #define fseeko64 fseek
 #else
 #if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) \
-	|| defined(__HAIKU__)
+	|| defined(__HAIKU__) || defined(__ANDROID__)
 #define fopen64 fopen
 #define ftello64 ftello
 #define fseeko64 fseeko


### PR DESCRIPTION
Hopeful Fix for  #507; System resources not found error. This error occurs only on some very specific android systems. So far only on android 7.1.1, armv7l, 32bit.





