### PR TITLE
High order tests

### DIFF
--- a/src/Tests/library/test_dcg_high_order.pl
+++ b/src/Tests/library/test_dcg_high_order.pl
@@ -17,6 +17,8 @@ start --> "(".
 
 end --> ")".
 
+:- use_module(library(dcg/basics), [string//1]).
+
 test('sequence//2 ground list',
      forall(member(t(Codes, Result, Rest),
                    [t(``, [], []),
@@ -67,7 +69,7 @@ test('sequence//3 det element',
     L == Result,
     R == Rest.
 
-test('sequence//3 det element trailing sep', fixme('Sep should not be consumed')) :-
+test('sequence//3 det element trailing sep', fail) :-
     phrase(sequence(a, sep, L), `a,`, R),
     L == [a],
     R == `,`.
@@ -80,8 +82,10 @@ test('sequence//3 det element trailing sep consumed silently', fail) :-
 test('sequence//3 separator only', fail) :-
     phrase(sequence(a, sep, _L), `,`).
 
-test('sequence//3 nondet element', fixme('Not sure what should happen')) :-
-    phrase(sequence(b, sep, _L), `b,b`, _R).
+test('sequence//3 nondet element', nondet) :-
+    phrase(sequence(string, sep, L), `b,b`, R),
+    L == [`b`, `b`],
+    R == [].
 
 test('sequence//5 det element',
      [forall(member(t(Codes, Result, Rest),
@@ -103,12 +107,8 @@ test('sequence//5 sep only', fail) :-
     phrase(sequence(start, a, sep, end, _L), `(,)`, _R).
 
 test('sequence//5 nondet element') :-
-    phrase(sequence(start, b, sep, end, L), `(b,b)`, R),
-    L == [b1,b1],
+    phrase(sequence(start, string, sep, end, L), `(b,b)`, R),
+    L == [`b`, `b`],
     R == [].
-
-test('sequence//5 nondet element, not first solution', fail) :-
-    phrase(sequence(start, b, sep, end, L), `(b,b)`),
-    L \== [b1,b1].
 
 :- end_tests(sequence).

--- a/src/Tests/library/test_dcg_high_order.pl
+++ b/src/Tests/library/test_dcg_high_order.pl
@@ -17,7 +17,7 @@ start --> "(".
 
 end --> ")".
 
-test('sequence/2 ground list',
+test('sequence//2 ground list',
      forall(member(t(Codes, Result, Rest),
                    [t(``, [], []),
                     t(`x`, [], `x`),
@@ -29,11 +29,11 @@ test('sequence/2 ground list',
     ) :-
     phrase(sequence(a, Result), Codes, Rest).
 
-test('sequence/2 order of solutions',
+test('sequence//2 order of solutions',
      all(List-Rest == [[a,a]-``, [a]-`a`, []-`aa`])) :-
     phrase(sequence(a, List), `aa`, Rest).
 
-test('sequence/2 det element',
+test('sequence//2 det element',
      [forall(member(t(Codes, Result, Rest),
                     [t(`a`, [a], []),
                      t(`x`, [], `x`),
@@ -47,12 +47,12 @@ test('sequence/2 det element',
     L == Result,
     R == Rest.
 
-test('sequence/2 nondet element', all(B == [b1,b2])) :-
+test('sequence//2 nondet element', all(B == [b1,b2])) :-
     phrase(sequence(b, [B,B]), `bb`, ``).
-test('sequence/2 nondet element and rest', all(B == [b1,b2])) :-
+test('sequence//2 nondet element and rest', all(B == [b1,b2])) :-
     phrase(sequence(b, [B,B]), `bbx`, `x`).
 
-test('sequence/3 det element',
+test('sequence//3 det element',
      [forall(member(t(Codes, Result, Rest),
                     [t(``, [], []),
                      t(`a`, [a], []),
@@ -67,23 +67,23 @@ test('sequence/3 det element',
     L == Result,
     R == Rest.
 
-test('sequence/3 det element trailing sep', fixme('Sep should not be consumed')) :-
+test('sequence//3 det element trailing sep', fixme('Sep should not be consumed')) :-
     phrase(sequence(a, sep, L), `a,`, R),
     L == [a],
     R == `,`.
 
-test('sequence/3 det element trailing sep', fail) :-
+test('sequence//3 det element trailing sep consumed silently', fail) :-
     phrase(sequence(a, sep, L), `a,`, R),
     L == [a],
     R == [].
 
-test('sequence/3 separator only', fail) :-
+test('sequence//3 separator only', fail) :-
     phrase(sequence(a, sep, _L), `,`).
 
-test('sequence/3 nondet element', fixme('Not sure what should happen')) :-
+test('sequence//3 nondet element', fixme('Not sure what should happen')) :-
     phrase(sequence(b, sep, _L), `b,b`, _R).
 
-test('sequence/5 det element',
+test('sequence//5 det element',
      [forall(member(t(Codes, Result, Rest),
              [t(`()`, [], []),
               t(`(a)`, [a], []),
@@ -96,18 +96,18 @@ test('sequence/5 det element',
     L == Result,
     R == Rest.
 
-test('sequence/5 det element trailing sep', fail) :-
+test('sequence//5 det element trailing sep', fail) :-
     phrase(sequence(start, a, sep, end, _L), `(a,)`, _R).
 
-test('sequence/5 sep only', fail) :-
+test('sequence//5 sep only', fail) :-
     phrase(sequence(start, a, sep, end, _L), `(,)`, _R).
 
-test('sequence/5 nondet element') :-
+test('sequence//5 nondet element') :-
     phrase(sequence(start, b, sep, end, L), `(b,b)`, R),
     L == [b1,b1],
     R == [].
 
-test('sequence/5 nondet element, not first solution', fail) :-
+test('sequence//5 nondet element, not first solution', fail) :-
     phrase(sequence(start, b, sep, end, L), `(b,b)`),
     L \== [b1,b1].
 

--- a/src/Tests/library/test_dcg_high_order.pl
+++ b/src/Tests/library/test_dcg_high_order.pl
@@ -1,0 +1,114 @@
+:- module(test_dcg_high_order, [test_dcg_high_order/0]).
+:- use_module(library(dcg/high_order)).
+
+test_dcg_high_order :-
+    run_tests([sequence]).
+
+:- begin_tests(sequence).
+
+a(a) --> "a".
+
+b(b1) --> "b".
+b(b2) --> "b".
+
+sep --> ",".
+
+start --> "(".
+
+end --> ")".
+
+test('sequence/2 ground list',
+     forall(member(t(Codes, Result, Rest),
+                   [t(``, [], []),
+                    t(`x`, [], `x`),
+                    t(`a`, [a], []),
+                    t(`aaa`, [a,a,a], []),
+                    t(`ax`, [a], `x`),
+                    t(`aaax`, [a,a,a], `x`)
+                   ]))
+    ) :-
+    phrase(sequence(a, Result), Codes, Rest).
+
+test('sequence/2 order of solutions',
+     all(List-Rest == [[a,a]-``, [a]-`a`, []-`aa`])) :-
+    phrase(sequence(a, List), `aa`, Rest).
+
+test('sequence/2 det element',
+     [forall(member(t(Codes, Result, Rest),
+                    [t(`a`, [a], []),
+                     t(`x`, [], `x`),
+                     t(`ax`, [a], `x`),
+                     t(`aaa`, [a,a,a], ``),
+                     t(`aaax`, [a,a,a], `x`)
+                    ])),
+      nondet
+     ]) :-
+    phrase(sequence(a, L), Codes, R),
+    L == Result,
+    R == Rest.
+
+test('sequence/2 nondet element', all(B == [b1,b2])) :-
+    phrase(sequence(b, [B,B]), `bb`, ``).
+test('sequence/2 nondet element and rest', all(B == [b1,b2])) :-
+    phrase(sequence(b, [B,B]), `bbx`, `x`).
+
+test('sequence/3 det element',
+     [forall(member(t(Codes, Result, Rest),
+                    [t(``, [], []),
+                     t(`a`, [a], []),
+                     t(`x`, [], `x`),
+                     t(`ax`, [a], `x`),
+                     t(`a,a,a`, [a,a,a], ``),
+                     t(`a,a,ax`, [a,a,a], `x`)
+                    ])),
+      nondet
+     ]) :-
+    phrase(sequence(a, sep, L), Codes, R),
+    L == Result,
+    R == Rest.
+
+test('sequence/3 det element trailing sep', fixme('Sep should not be consumed')) :-
+    phrase(sequence(a, sep, L), `a,`, R),
+    L == [a],
+    R == `,`.
+
+test('sequence/3 det element trailing sep', fail) :-
+    phrase(sequence(a, sep, L), `a,`, R),
+    L == [a],
+    R == [].
+
+test('sequence/3 separator only', fail) :-
+    phrase(sequence(a, sep, _L), `,`).
+
+test('sequence/3 nondet element', fixme('Not sure what should happen')) :-
+    phrase(sequence(b, sep, _L), `b,b`, _R).
+
+test('sequence/5 det element',
+     [forall(member(t(Codes, Result, Rest),
+             [t(`()`, [], []),
+              t(`(a)`, [a], []),
+              t(`(a,a)`, [a,a], []),
+              t(`()x`, [], `x`),
+              t(`(a,a)x`, [a,a], `x`)
+             ]))
+     ]) :-
+    phrase(sequence(start, a, sep, end, L), Codes, R),
+    L == Result,
+    R == Rest.
+
+test('sequence/5 det element trailing sep', fail) :-
+    phrase(sequence(start, a, sep, end, _L), `(a,)`, _R).
+
+test('sequence/5 sep only', fail) :-
+    phrase(sequence(start, a, sep, end, _L), `(,)`, _R).
+
+test('sequence/5 nondet element') :-
+    phrase(sequence(start, b, sep, end, L), `(b,b)`, R),
+    L == [b1,b1],
+    R == [].
+
+test('sequence/5 nondet element, not first solution', fail) :-
+    phrase(sequence(start, b, sep, end, L), `(b,b)`),
+    L \== [b1,b1].
+
+:- end_tests(sequence).


### PR DESCRIPTION
These are some _preliminary_ tests for library(dcg/high_order). I tried to test the most obvious behaviors.

There are a few things that were problematic for me.

First, I might be completely misunderstanding the idea of "nondet elements".

The test "sequence//2 order of solutions" is exactly as documented, but I am not completely clear about how this is useful.

The test "sequence//3 det element trailing sep" is the troublesome one.

The test "sequence//3 nondet element", well, I don't know what should happen. The current behavior is that it is nondet only for the last element, after the last separator. This is kinda documented but maybe a bit surprising?

Finally, should it be explicitly documented that sequence//5 cuts any choice points left by the element?