### PR TITLE
Support rational exponents in ar_pow

### DIFF
--- a/src/Tests/core/test_rational.pl
+++ b/src/Tests/core/test_rational.pl
@@ -116,7 +116,6 @@ test(conversion) :-
 % rational exponent power tests (3)
 test(float_to_rat) :-
 	assertion(8.0 is 4.0**3r2),
-	%assertion((NaN is -4.0**3r2,NaN=1.5NaN)),  % neg. base, even Q
 	assertion(1.5NaN is -4.0**3r2),  % neg. base, even Q
 	assertion(2.0 is 8.0**1r3),
 	assertion(-2.0 is -8.0**1r3),

--- a/src/Tests/core/test_rational.pl
+++ b/src/Tests/core/test_rational.pl
@@ -110,7 +110,7 @@ test(conversion) :-
     assertion(1 is truncate(3r2)),
     assertion(-1 is truncate(-3r2)),
     assertion(2 is integer(5r3)),
-    assertion((5)/(3) =:= float(5r3)),
+    assertion((R1 is float(5r3), R2 is (5)/(3), check_error(R1,R2))),  % compensate for rounding errors
     assertion(rationalize((1)/(2)) =:= 1r2).
 
 % rational exponent power tests (3)


### PR DESCRIPTION
1. Added `if` block to `ar_pow` for rational exponents.
2. Expanded rational unit tests to cover various cases (different numeric base types, signs, etc.)

Built and tested except that the test cases `test_rational.pl` have only been run in isolation, not in a pl_unit test environment. 