### PR TITLE
FIXED: Debug statement in pl-tabling.c which depended on multi-thread…

### DIFF
--- a/src/pl-tabling.c
+++ b/src/pl-tabling.c
@@ -3294,7 +3294,11 @@ PRED_IMPL("$tbl_wkl_add_answer", 4, tbl_wkl_add_answer, 0)
     atom_t action;
     int rc;
 
+#ifdef O_PLMT
     DEBUG(0, assert(false(wl->table, TRIE_ISSHARED) || wl->table->tid));
+#else  // O_PLMT
+    DEBUG(0, assert(false(wl->table, TRIE_ISSHARED)));
+#endif  // O_PLMT
 
     kp = valTermRef(A2);
     if ( true(wl->table, TRIE_ISMAP) )


### PR DESCRIPTION
…ing being enabled without checking if multi-threading is enabled.

This makes the build with `-DCMAKE_BUILD_TYPE=Debug -DMULTI_THREADED=OFF` pass again and I presume this logic is solid, but please check if the added debug statement makes sense for single-threaded builds.