### PR TITLE
ieee fix 2 

### DIFF
--- a/library/prolog_codewalk.pl
+++ b/library/prolog_codewalk.pl
@@ -260,9 +260,15 @@ walk_clauses(Clauses, OTerm) :-
 %   True if we must scan Module according to OTerm.
 
 scan_module(M, OTerm) :-
+    walk_option_module(OTerm, M1),
+    nonvar(M1),
+    !,
+    \+ M \= M1.
+scan_module(M, OTerm) :-
     walk_option_module_class(OTerm, Classes),
     module_property(M, class(Class)),
-    memberchk(Class, Classes).
+    memberchk(Class, Classes),
+    !.
 
 %!  walk_from_initialization(+OTerm)
 %

--- a/src/Tests/core/test_rational.pl
+++ b/src/Tests/core/test_rational.pl
@@ -45,7 +45,8 @@
 */
 
 test_rational :-
-    run_tests([ rational
+    run_tests([ rational,
+                rationalize
 	      ]).
 
 set_prefer_rationals(Old, New) :-
@@ -190,8 +191,25 @@ test(syntax_fail) :-
 
 :- end_tests(rational).
 
+:- begin_tests(rationalize).
+
+test(roundtrip_rational) :-
+    forall(between(1,1000,_),
+           ( rfloat(F),
+             F =:= rational(F))).
+test(roundtrip_rationalize) :-
+    forall(between(1,1000,_),
+           ( rfloat(F),
+             F =:= rationalize(F))).
+
+:- end_tests(rationalize).
+
 bad_syntax(String) :-
     catch(term_string(R,String), error(syntax_error(_T), _C), true),
     var(R).		% test that exception happened
 
 check_error(N1,N2) :- abs(N1-N2) < 1e-12.
+
+rfloat(X) :-
+    random_between(-308,308,E),
+    X is random_float * 10**E.

--- a/src/pl-gmp.c
+++ b/src/pl-gmp.c
@@ -1569,7 +1569,7 @@ mpq_set_double(mpq_t q, double f)	/* float -> nice rational */
 
   while ((mpz_fdiv(pna, pda)) != fabs)
   { /* infinite x indicates failure to converge */
-    if ( !finite(x) )
+    if ( !isfinite(x) )
       goto _bitwise_conversion_;
 
     double xi = floor(x);


### PR DESCRIPTION
1. `pl-arith.c` - added custom lgamma for consistent answers across platforms when arg <=0.

2. `test_ieee754.pl` Fixes and expanded tests:
  - rounding tests use imprecise expressions to test effect of mode
  - `roundtoward` tests added
  - exception tests added
  - power tests fixed. Require parentheses for negative IEEE special values due to operators `-` and `**` precedence.