### PR TITLE
ar_pow C11 compliance and relaxed rounding test

### DIFF
--- a/library/writef.pl
+++ b/library/writef.pl
@@ -233,11 +233,11 @@ swritef(String, Format) :-
     name(Atom, String),
     '$padout'(Atom, Size, Just).
 '$padout'(Term, Size, Just) :-
-    format(string(Atom), Term, Atom),
-    atom_length(Atom, Length),
+    format(string(String), '~w', [Term]),
+    atom_length(String, Length),
     '$padout'(Just, Size, Length, Left, Right),
     tab(Left),
-    write(Atom),
+    write(String),
     tab(Right).
 
 '$string'(0) :- !, fail.


### PR DESCRIPTION
1. Fixes for C11 compliance on integer special cases (incl. `0**nan`).
2. IEEE test cases: relaxed rounding check for round to_zero. No longer expects equivalence with Rn/Rp.