### PR TITLE
FIX: Memory leak in hash assessment keys allocated during assess_scan_clauses

### DIFF
--- a/src/pl-index.c
+++ b/src/pl-index.c
@@ -2098,7 +2098,13 @@ init_assessment_set(assessment_set *as)
 
 static void
 free_assessment_set(assessment_set *as)
-{ if ( as->assessments != as->buf )
+{ int i;
+  hash_assessment *a;
+  for (i=0, a=as->assessments; i<as->count; i++, a++)
+    if ( a->keys )
+      free(a->keys);
+
+  if ( as->assessments != as->buf )
     free(as->assessments);
 }
 
@@ -2559,9 +2565,6 @@ bestHash(Word av, size_t ac, ClauseList clist, float min_speedup,
       }
 
       ainfo->assessed = TRUE;
-
-      if ( a->keys )
-	free(a->keys);
     }
 
     free_assessment_set(&aset);


### PR DESCRIPTION
This commit fixes the following leaks reported by LeakSanitizer:

```
=================================================================
==8624==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 4194304 byte(s) in 1 object(s) allocated from:
    #0 0x492e89 in realloc (/home/ed/Documents/swipl-devel/build/src/swipl+0x492e89)
    #1 0x7fa46f341881 in assessAddKey /home/ed/Documents/swipl-devel/build/../src/pl-index.c:2270:24
    #2 0x1ffff  (<unknown module>)

Direct leak of 524288 byte(s) in 1 object(s) allocated from:
    #0 0x492e89 in realloc (/home/ed/Documents/swipl-devel/build/src/swipl+0x492e89)
    #1 0x7fa46f341881 in assessAddKey /home/ed/Documents/swipl-devel/build/../src/pl-index.c:2270:24
    #2 0x3fff  (<unknown module>)

Direct leak of 262144 byte(s) in 1 object(s) allocated from:
    #0 0x492e89 in realloc (/home/ed/Documents/swipl-devel/build/src/swipl+0x492e89)
    #1 0x7fa46f341881 in assessAddKey /home/ed/Documents/swipl-devel/build/../src/pl-index.c:2270:24
    #2 0x1fff  (<unknown module>)

Direct leak of 131072 byte(s) in 1 object(s) allocated from:
    #0 0x492e89 in realloc (/home/ed/Documents/swipl-devel/build/src/swipl+0x492e89)
    #1 0x7fa46f341881 in assessAddKey /home/ed/Documents/swipl-devel/build/../src/pl-index.c:2270:24
    #2 0xfff  (<unknown module>)

Direct leak of 114688 byte(s) in 3 object(s) allocated from:
    #0 0x492e89 in realloc (/home/ed/Documents/swipl-devel/build/src/swipl+0x492e89)
    #1 0x7fa46f341881 in assessAddKey /home/ed/Documents/swipl-devel/build/../src/pl-index.c:2270:24

```