### PR TITLE
snap: use kde-neon extension

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: swi-prolog
 base: core18
 adopt-info: swi-prolog
-icon: packages/swipl-win/swipl.png
+#icon: packages/swipl-win/swipl.png
 license: 'BSD-2-Clause'
 summary: ISO/Edinburgh-style Prolog implementation
 description: |
@@ -22,25 +22,27 @@ description: |
 
 apps:
   swipl:
-    command: kf5-launch $SNAP/usr/bin/swipl
+    command: swipl
+    extensions:
+      - kde-neon
+    plugs:
+      - home
+      - network
+      - removable-media
+      - opengl
+      - audio-playback
+      - audio-record
   swipl-win:
-    command: kf5-launch $SNAP/usr/bin/swipl-win
-
-plugs:
-  home:
-  network:
-  x11:
-  desktop:
-  desktop-legacy:
-  removable-media:
-  opengl:
-  audio-playback:
-  audio-record:
-  kde-frameworks-5-plug:
-    content: kde-frameworks-5-core18-all
-    interface: content
-    default-provider: kde-frameworks-5-core18
-    target: kf5
+    command: swipl-win
+    extensions:
+      - kde-neon
+    plugs:
+      - home
+      - network
+      - removable-media
+      - opengl
+      - audio-playback
+      - audio-record
 
 grade: stable
 confinement: strict
@@ -57,7 +59,12 @@ parts:
       # Custom build process to enable PGO build
       mkdir -p $SNAPCRAFT_PART_SRC/build
       cd $SNAPCRAFT_PART_SRC/build
-      cmake -DCMAKE_BUILD_TYPE=Release -DSWIPL_PACKAGES_JAVA=OFF -DCMAKE_INSTALL_PREFIX=/usr -DSWIPL_INSTALL_IN_LIB=ON -G Ninja ..
+      cmake -DCMAKE_BUILD_TYPE=Release \
+      -DSWIPL_PACKAGES_JAVA=OFF \
+      -DCMAKE_INSTALL_PREFIX=/usr \
+      -DSWIPL_INSTALL_IN_LIB=ON \
+      -DCMAKE_FIND_ROOT_PATH=/snap/kde-frameworks-5-core18-sdk/current \
+      -G Ninja ..
       ../scripts/pgo-compile.sh
       ninja
       DESTDIR=$SNAPCRAFT_PART_INSTALL ninja install
@@ -107,6 +114,4 @@ parts:
       - unixodbc-dev
       - zlib1g-dev
       - libyaml-dev
-  kde-frameworks-5-env:
-    plugin: dump
-    source: https://github.com/apachelogger/kf5-snap-env.git
+      - libglvnd-dev


### PR DESCRIPTION
I managed to find some time to look a the snap integration recently.
This PR adds the (not yet autoconnected) kde-neon content snap.
This is used for the qt interface to swipl.

The snap is confined, thus it will not integrate with other programs or libraries installed via other means.
It will support packages installed in swipl itself.
If this is not acceptable the other solution is to build a classic unconfined snap.