### PR TITLE
Update snap.md with config files and interfaces

### DIFF
--- a/snap/local/snap.md
+++ b/snap/local/snap.md
@@ -5,20 +5,30 @@ Snap that runs the latest version of swipl and swipl-win.
 The snap is strictly contained, so it has limited access to the host
 system via the following plugs:
 
-| Plug              | Description               |
-| ----------------- | ------------------------- |
-| home              | $HOME (no hidden folders) |
-| network           | network access            |
-| x11               | I/O and graphics output   |
-| desktop           | common desktop elements   |
-| desktop-legacy    | legacy desktop elements   |
-| removable-media   | removable media           |
-| opengl            | opengl/gpu hardware       |
-| audio-playback    | audio playback devices    |
-| audio-record      | audio record devices      |
+| Plug              | Description               | Autoconnected |
+| ----------------- | ------------------------- | ------------- |
+| home              | $HOME (no hidden folders) | Yes           |
+| network           | network access            | Yes           |
+| x11               | I/O and graphics output   | Yes           |
+| desktop           | common desktop elements   | Yes           |
+| desktop-legacy    | legacy desktop elements   | Yes           |
+| removable-media   | removable media           | No            |
+| opengl            | opengl/gpu hardware       | Yes           |
+| audio-playback    | audio playback devices    | Yes           |
+| audio-record      | audio record devices      | No            |
+
+To connect the removable-media (read/write files on removable storage devices) run the following command:
+```sh
+snap connect swi-prolog:removable-media
+```
+
+To connect the audio-record (allows audio recording via supported services) run the following command:
+```sh
+snap connect swi-prolog:audio-record
+```
 
 If other connections are needed they can be added from this
-[list](https://snapcraft.io/docs/supported-interfaces).
+[list](https://snapcraft.io/docs/supported-interfaces) in future releases.
 
 ## Installation
 
@@ -31,6 +41,16 @@ If the snap did not add the automated aliases you can add them as follows:
 snap alias swi-prolog.swipl swipl
 snap alias swi-prolog.swipl-win swipl-win
 ```
+
+## Usage
+
+The config folders are located in a directory specific to the snap:
+```
+~/.config -> ~/snap/swi-prolog/current/.config
+~/.local -> ~/snap/swi-prolog/current/.local
+```
+
+The rest of the non hidden folders in $HOME are visible as normal
 
 ## Font issues
 


### PR DESCRIPTION
Show where the config files are relocated in a snap.
Add the instructions to enable unconnected interfaces