### PR TITLE
Using _BitScanReverse/_BitScanReverse64 as according to Microsoft documentation

### DIFF
--- a/src/pl-inline.h
+++ b/src/pl-inline.h
@@ -41,6 +41,11 @@
 #ifdef __WINDOWS__
 #include <windows.h>
 #undef small
+#include <intrin.h>
+#if SIZEOF_VOIDP == 8
+  #pragma intrinsic(_BitScanReverse64)
+#endif
+#pragma intrinsic(_BitScanReverse)
 #endif
 
 		 /*******************************
@@ -67,22 +72,24 @@ MSB(size_t i)
 { unsigned long index;
 #if SIZEOF_VOIDP == 8
   unsigned __int64 mask = i;
-  BitScanReverse64(&index, mask);
+  _BitScanReverse64(&index, mask);
 #else
   unsigned long mask = i;
-  BitScanReverse(&index, mask);
+  _BitScanReverse(&index, mask);
 #endif
 
   return index;
 }
 
+#if SIZEOF_VOIDP == 8
 #define HAVE_MSB64 1
 static inline int
 MSB64(int64_t i)
 { unsigned long index;
-  BitScanReverse64(&index, i);
+  _BitScanReverse64(&index, i);
   return index;
 }
+#endif
 
 #define MEMORY_BARRIER() MemoryBarrier()
 

--- a/src/pl-inline.h
+++ b/src/pl-inline.h
@@ -39,13 +39,15 @@
 #define LD LOCAL_LD
 
 #ifdef __WINDOWS__
-#include <windows.h>
-#undef small
-#include <intrin.h>
-#if SIZEOF_VOIDP == 8
-  #pragma intrinsic(_BitScanReverse64)
-#endif
-#pragma intrinsic(_BitScanReverse)
+  #include <windows.h>
+  #undef small
+  #include <intrin.h>
+  #ifdef _MSC_VER
+    #if SIZEOF_VOIDP == 8
+      #pragma intrinsic(_BitScanReverse64)
+    #endif
+    #pragma intrinsic(_BitScanReverse)
+  #endif
 #endif
 
 		 /*******************************


### PR DESCRIPTION
Without this patch I was getting errors about `BitScanReverse(64)` being undefined on a `Windows Server 2012 R2` machine.
```
warning C4013: 'BitScanReverse64' undefined; assuming extern returning int
error LNK2001: unresolved external symbol _BitScanReverse64
```
Funnily enough it was working perfectly on `Windows Server 2016` and `Windows 10`, all using the `Visual Studio 15 2017` CMake generator (sorry, don't know the specific MSVC versions).
According to the Microsoft documentation the intrinsics:
- Start with an underscore
- Require inclusion of `<intrin.h>`
- Require a `#pragma`

This patch makes the usage match the documentation and solves the problem on all platforms.
Documentation: https://docs.microsoft.com/en-us/cpp/intrinsics/bitscanreverse-bitscanreverse64?view=vs-2017

Furthermore `_BitScanReverse64` is only defined on 64-bit targets, so I added a check for that around the definition of `MSB64`.
```
warning C4163: '_BitScanReverse64': not available as an intrinsic function
warning C4013: '_BitScanReverse64' undefined; assuming extern returning int
error LNK2001: unresolved external symbol __BitScanReverse64
```