### PR TITLE
FIXED: If source(false) is provided as an option, the location of the…

### DIFF
--- a/library/prolog_codewalk.pl
+++ b/library/prolog_codewalk.pl
@@ -1138,6 +1138,9 @@ prolog:message_location(clause(ClauseRef)) -->
     [ '~w: '-[Name] ].
 prolog:message_location(file_term_position(Path, TermPos)) -->
     message_location_file_term_position(Path, TermPos).
+prolog:message_location(file(Path, Line, _, _)) -->
+    !,
+    [ '~w:~d: '-[File, Line] ].
 prolog:message(codewalk(reiterate(New, Iteration, CPU))) -->
     [ 'Found new meta-predicates in iteration ~w (~3f sec)'-
       [Iteration, CPU], nl ],


### PR DESCRIPTION
… clause is provided by a file/4 term, but there is no clause of prolog:message_location for file/4, meaning that the prolog:message/2 call for trace_call_to fails, and the message is printed as an unknown message