### PR TITLE
Fix DBLP:dblpjournals/tplp/CovingtonBOWP12 BibTeX entry.

### DIFF
--- a/man/pl.bib
+++ b/man/pl.bib
@@ -1111,7 +1111,7 @@ pages          = {14--17}
       Languages Implementation and Logic Programming (PLILP'94)}, LNCS
       844, Madrid 1994.
 
-@inproceedings{DBLP:dblpjournals/tplp/CovingtonBOWP12,
+@article{DBLP:dblpjournals/tplp/CovingtonBOWP12,
    author              = {Michael A. Covington and
                           Roberto Bagnara and
                           Richard A. O'Keefe and
@@ -1119,6 +1119,8 @@ pages          = {14--17}
                           Simon Price},
    title               = {Coding guidelines for {Prolog}.},
    journal             = {{TPLP}},
+   volume              = {12},
+   number              = {6},
    year                = {2012},
    pages               = {889-927},
    ee                  = {http://journals.cambridge.org/action/displayAbstract?aid}


### PR DESCRIPTION
BibTeX complains that booktitle is missing from this entry.  The real problem is that it should have type \@article, not \@inproceedings, and the volume and number are missing.