### PR TITLE
Fix typos and format summary.doc

### DIFF
--- a/man/summary.doc
+++ b/man/summary.doc
@@ -123,20 +123,18 @@ suggest predicates from a keyword.
 \predicatesummary{call_cleanup}{3}{Guard a goal with a cleaup-handler}
 \predicatesummary{call_cleanup}{2}{Guard a goal with a cleaup-handler}
 \predicatesummary{call_dcg}{3}{As phrase/3 without type checking}
-\predicatesummary{call_delays}{2}{Get the condition associated with an
-answer} \predicatesummary{call_residue_vars}{2}{Find residual attributed
-variables} \predicatesummary{call_residual_program}{2}{Get residual
-program associated with an answer}
-\predicatesummary{call_shared_object_function}{2}{UNIX: Call C-function
-in shared (.so) file} \predicatesummary{call_with_depth_limit}{3}{Prove
-goal with bounded depth}
-\predicatesummary{call_with_inference_limit}{3}{Prove goal in limited
-inferences} \predicatesummary{callable}{1}{Test for atom or compound
-term} \predicatesummary{cancel_halt}{1}{Cancel halt/0 from an at_halt/1
-hook} \predicatesummary{catch}{3}{Call goal, watching for exceptions}
-\predicatesummary{char_code}{2}{Convert between character and character
-code} \predicatesummary{char_conversion}{2}{Provide mapping of input
-characters} \predicatesummary{char_type}{2}{Classify characters}
+\predicatesummary{call_delays}{2}{Get the condition associated with an answer}
+\predicatesummary{call_residue_vars}{2}{Find residual attributed variables}
+\predicatesummary{call_residual_program}{2}{Get residual program associated with an answer}
+\predicatesummary{call_shared_object_function}{2}{UNIX: Call C-function in shared (.so) file}
+\predicatesummary{call_with_depth_limit}{3}{Prove goal with bounded depth}
+\predicatesummary{call_with_inference_limit}{3}{Prove goal in limited inferences}
+\predicatesummary{callable}{1}{Test for atom or compound term}
+\predicatesummary{cancel_halt}{1}{Cancel halt/0 from an at_halt/1 hook}
+\predicatesummary{catch}{3}{Call goal, watching for exceptions}
+\predicatesummary{char_code}{2}{Convert between character and character code}
+\predicatesummary{char_conversion}{2}{Provide mapping of input characters}
+\predicatesummary{char_type}{2}{Classify characters}
 \predicatesummary{character_count}{2}{Get character index on a stream}
 \predicatesummary{chdir}{1}{Compatibility: change working directory}
 \predicatesummary{chr_constraint}{1}{CHR Constraint declaration}
@@ -152,89 +150,82 @@ characters} \predicatesummary{char_type}{2}{Classify characters}
 \predicatesummary{close}{1}{Close stream}
 \predicatesummary{close}{2}{Close stream (forced)}
 \predicatesummary{close_dde_conversation}{1}{Win32: Close DDE channel}
-\predicatesummary{close_shared_object}{1}{UNIX: Close shared library
-(.so file)} \predicatesummary{collation_key}{2}{Sort key for locale
-dependent ordering} \predicatesummary{comment_hook}{3}{\hook{prolog}
-handle comments in sources} \predicatesummary{compare}{3}{Compare, using
-a predicate to determine the order}
-\predicatesummary{compile_aux_clauses}{1}{Compile predicates for
-goal_expansion/2} \predicatesummary{compile_predicates}{1}{Compile
-dynamic code to static} \predicatesummary{compiling}{0}{Is this a
-compilation run?} \predicatesummary{compound}{1}{Test for compound term}
-\predicatesummary{compound_name_arity}{3}{Name and arity of a compound
-term} \predicatesummary{compound_name_arguments}{3}{Name and arguments
-of a compound term} \predicatesummary{code_type}{2}{Classify a
-character-code} \predicatesummary{consult}{1}{Read (compile) a Prolog
-source file} \predicatesummary{context_module}{1}{Get context module of
-current goal} \predicatesummary{convert_time}{8}{Break time stamp into
-fields} \predicatesummary{convert_time}{2}{Convert time stamp to string}
-\predicatesummary{copy_stream_data}{2}{Copy all data from stream to
-stream} \predicatesummary{copy_stream_data}{3}{Copy n bytes from stream
-to stream} \predicatesummary{copy_predicate_clauses}{2}{Copy clauses
-between predicates} \predicatesummary{copy_term}{2}{Make a copy of a
-term} \predicatesummary{copy_term}{3}{Copy a term and obtain
-attribute-goals} \predicatesummary{copy_term_nat}{2}{Make a copy of a
-term without attributes} \predicatesummary{create_prolog_flag}{3}{Create
-a new Prolog flag}
-\predicatesummary{current_arithmetic_function}{1}{Examine evaluable
-functions} \predicatesummary{current_atom}{1}{Examine existing atoms}
+\predicatesummary{close_shared_object}{1}{UNIX: Close shared library (.so file)}
+\predicatesummary{collation_key}{2}{Sort key for locale dependent ordering}
+\predicatesummary{comment_hook}{3}{\hook{prolog} handle comments in sources}
+\predicatesummary{compare}{3}{Compare, using a predicate to determine the order}
+\predicatesummary{compile_aux_clauses}{1}{Compile predicates for goal_expansion/2}
+\predicatesummary{compile_predicates}{1}{Compile dynamic code to static}
+\predicatesummary{compiling}{0}{Is this a compilation run?}
+\predicatesummary{compound}{1}{Test for compound term}
+\predicatesummary{compound_name_arity}{3}{Name and arity of a compound term}
+\predicatesummary{compound_name_arguments}{3}{Name and arguments of a compound term}
+\predicatesummary{code_type}{2}{Classify a character-code}
+\predicatesummary{consult}{1}{Read (compile) a Prolog source file}
+\predicatesummary{context_module}{1}{Get context module of current goal}
+\predicatesummary{convert_time}{8}{Break time stamp into fields}
+\predicatesummary{convert_time}{2}{Convert time stamp to string}
+\predicatesummary{copy_stream_data}{2}{Copy all data from stream to stream}
+\predicatesummary{copy_stream_data}{3}{Copy n bytes from stream to stream}
+\predicatesummary{copy_predicate_clauses}{2}{Copy clauses between predicates}
+\predicatesummary{copy_term}{2}{Make a copy of a term}
+\predicatesummary{copy_term}{3}{Copy a term and obtain attribute-goals}
+\predicatesummary{copy_term_nat}{2}{Make a copy of a term without attributes}
+\predicatesummary{create_prolog_flag}{3}{Create a new Prolog flag}
+\predicatesummary{current_arithmetic_function}{1}{Examine evaluable functions}
+\predicatesummary{current_atom}{1}{Examine existing atoms}
 \predicatesummary{current_blob}{2}{Examine typed blobs}
-\predicatesummary{current_char_conversion}{2}{Query input character
-mapping} \predicatesummary{current_engine}{1}{Enumerate known engines}
+\predicatesummary{current_char_conversion}{2}{Query input character mapping}
+\predicatesummary{current_engine}{1}{Enumerate known engines}
 \predicatesummary{current_flag}{1}{Examine existing flags}
-\predicatesummary{current_foreign_library}{2}{\pllib{shlib} Examine
-loaded shared libraries (.so files)}
-\predicatesummary{current_format_predicate}{2}{Enumerate user-defined
-format codes} \predicatesummary{current_functor}{2}{Examine existing
-name/arity pairs} \predicatesummary{current_input}{1}{Get current input
-stream} \predicatesummary{current_key}{1}{Examine existing database
-keys} \predicatesummary{current_locale}{1}{Get the current locale}
+\predicatesummary{current_foreign_library}{2}{\pllib{shlib} Examine loaded shared libraries (.so files)}
+\predicatesummary{current_format_predicate}{2}{Enumerate user-defined format codes}
+\predicatesummary{current_functor}{2}{Examine existing name/arity pairs}
+\predicatesummary{current_input}{1}{Get current input stream}
+\predicatesummary{current_key}{1}{Examine existing database keys}
+\predicatesummary{current_locale}{1}{Get the current locale}
 \predicatesummary{current_module}{1}{Examine existing modules}
 \predicatesummary{current_op}{3}{Examine current operator declarations}
 \predicatesummary{current_output}{1}{Get the current output stream}
-\predicatesummary{current_predicate}{1}{Examine existing predicates
-(ISO)} \predicatesummary{current_predicate}{2}{Examine existing
-predicates} \predicatesummary{current_signal}{3}{Current software signal
-mapping} \predicatesummary{current_stream}{3}{Examine open streams}
+\predicatesummary{current_predicate}{1}{Examine existing predicates (ISO)}
+\predicatesummary{current_predicate}{2}{Examine existing predicates}
+\predicatesummary{current_signal}{3}{Current software signal mapping}
+\predicatesummary{current_stream}{3}{Examine open streams}
 \predicatesummary{current_table}{2}{Find answer table for a variant}
 \predicatesummary{current_transaction}{1}{Detect encapsulating transactions}
 \predicatesummary{current_trie}{1}{Enumerate known tries}
 \predicatesummary{cyclic_term}{1}{Test term for cycles}
 \predicatesummary{day_of_the_week}{2}{Determine ordinal-day from date}
-\predicatesummary{date_time_stamp}{2}{Convert date structure to
-time-stamp} \predicatesummary{date_time_value}{3}{Extract info from a
-date structure} \predicatesummary{dcg_translate_rule}{2}{Source
-translation of DCG rules}
-\predicatesummary{dcg_translate_rule}{4}{Source translation of DCG
-rules} \predicatesummary{dde_current_connection}{2}{Win32: Examine open
-DDE connections} \predicatesummary{dde_current_service}{2}{Win32:
-Examine DDE services provided} \predicatesummary{dde_execute}{2}{Win32:
-Execute command on DDE server}
+\predicatesummary{date_time_stamp}{2}{Convert date structure to time-stamp}
+\predicatesummary{date_time_value}{3}{Extract info from a date structure}
+\predicatesummary{dcg_translate_rule}{2}{Source translation of DCG rules}
+\predicatesummary{dcg_translate_rule}{4}{Source translation of DCG rules}
+\predicatesummary{dde_current_connection}{2}{Win32: Examine open DDE connections}
+\predicatesummary{dde_current_service}{2}{Win32: Examine DDE services provided}
+\predicatesummary{dde_execute}{2}{Win32: Execute command on DDE server}
 \predicatesummary{dde_register_service}{2}{Win32: Become a DDE server}
 \predicatesummary{dde_request}{3}{Win32: Make a DDE request}
 \predicatesummary{dde_poke}{3}{Win32: POKE operation on DDE server}
-\predicatesummary{dde_unregister_service}{1}{Win32: Terminate a DDE
-service} \predicatesummary{debug}{0}{Test for debugging mode}
+\predicatesummary{dde_unregister_service}{1}{Win32: Terminate a DDE service}
+\predicatesummary{debug}{0}{Test for debugging mode}
 \predicatesummary{debug}{1}{Select topic for debugging}
 \predicatesummary{debug}{3}{Print debugging message on topic}
-\predicatesummary{debug_control_hook}{1}{\hook{prolog} Extend spy/1,
-etc.} \predicatesummary{debugging}{0}{Show debugger status}
+\predicatesummary{debug_control_hook}{1}{\hook{prolog} Extend spy/1, etc.}
+\predicatesummary{debugging}{0}{Show debugger status}
 \predicatesummary{debugging}{1}{Test where we are debugging topic}
 \predicatesummary{default_module}{2}{Query module inheritance}
 \predicatesummary{del_attr}{2}{Delete attribute from variable}
 \predicatesummary{del_attrs}{1}{Delete all attributes from variable}
 \predicatesummary{del_dict}{4}{Delete Key-Value pair from a dict}
-\predicatesummary{delays_residual_program}{2}{Get the residual program
-for an answer} \predicatesummary{delete_directory}{1}{Remove a folder
-from the file system} \predicatesummary{delete_file}{1}{Remove a file
-from the file system} \predicatesummary{delete_import_module}{2}{Remove
-module from import list} \predicatesummary{deterministic}{1}{Test
-deterministicy of current clause} \predicatesummary{dif}{2}{Constrain
-two terms to be different} \predicatesummary{directory_files}{2}{Get
-entries of a directory/folder}
-\oppredsummary{discontiguous}{1}{fx}{1150}{Indicate distributed
-definition of a predicate} \predicatesummary{divmod}{4}{Compute quotient
-and remainder of two integers}
+\predicatesummary{delays_residual_program}{2}{Get the residual program for an answer}
+\predicatesummary{delete_directory}{1}{Remove a folder from the file system}
+\predicatesummary{delete_file}{1}{Remove a file from the file system}
+\predicatesummary{delete_import_module}{2}{Remove module from import list}
+\predicatesummary{deterministic}{1}{Test deterministicy of current clause}
+\predicatesummary{dif}{2}{Constrain two terms to be different}
+\predicatesummary{directory_files}{2}{Get entries of a directory/folder}
+\oppredsummary{discontiguous}{1}{fx}{1150}{Indicate distributed definition of a predicate}
+\predicatesummary{divmod}{4}{Compute quotient and remainder of two integers}
 \predicatesummary{downcase_atom}{2}{Convert atom to lower-case}
 \predicatesummary{duplicate_term}{2}{Create a copy of a term}
 \predicatesummary{dwim_match}{2}{Atoms match in ``Do What I Mean'' sense}
@@ -247,56 +238,55 @@ and remainder of two integers}
 \predicatesummary{elif}{1}{Part of conditional compilation (directive)}
 \predicatesummary{else}{0}{Part of conditional compilation (directive)}
 \predicatesummary{empty_assoc}{1}{Create/test empty association tree}
-\predicatesummary{empty_nb_set}{1}{Test/create an empty
-non-backtrackable set} \predicatesummary{encoding}{1}{Define encoding
-inside a source file} \predicatesummary{endif}{0}{End of conditional
-compilation (directive)} \predicatesummary{engine_create}{3}{Create an
-interactor} \predicatesummary{engine_create}{4}{Create an interactor}
+\predicatesummary{empty_nb_set}{1}{Test/create an empty non-backtrackable set}
+\predicatesummary{encoding}{1}{Define encoding inside a source file}
+\predicatesummary{endif}{0}{End of conditional compilation (directive)}
+\predicatesummary{engine_create}{3}{Create an interactor}
+\predicatesummary{engine_create}{4}{Create an interactor}
 \predicatesummary{engine_destroy}{1}{Destroy an interactor}
 \predicatesummary{engine_fetch}{1}{Get term from caller}
 \predicatesummary{engine_next}{2}{Ask interactor for next term}
 \predicatesummary{engine_next_reified}{2}{Ask interactor for next term}
 \predicatesummary{engine_post}{2}{Send term to an interactor}
-\predicatesummary{engine_post}{3}{Send term to an interactor and wait
-for reply} \predicatesummary{engine_self}{1}{Get handle to running
-interactor} \predicatesummary{engine_yield}{1}{Make term available to
-caller} \predicatesummary{ensure_loaded}{1}{Consult a file if that has
-not yet been done} \predicatesummary{erase}{1}{Erase a database record
-or clause} \predicatesummary{exception}{3}{\hook{user} Handle runtime
-exceptions} \predicatesummary{exists_directory}{1}{Check existence of
-directory} \predicatesummary{exists_file}{1}{Check existence of file}
+\predicatesummary{engine_post}{3}{Send term to an interactor and wait for reply}
+\predicatesummary{engine_self}{1}{Get handle to running interactor}
+\predicatesummary{engine_yield}{1}{Make term available to caller}
+\predicatesummary{ensure_loaded}{1}{Consult a file if that has not yet been done}
+\predicatesummary{erase}{1}{Erase a database record or clause}
+\predicatesummary{exception}{3}{\hook{user} Handle runtime exceptions}
+\predicatesummary{exists_directory}{1}{Check existence of directory}
+\predicatesummary{exists_file}{1}{Check existence of file}
 \predicatesummary{exists_source}{1}{Check existence of a Prolog source}
 \predicatesummary{exists_source}{2}{Check existence of a Prolog source}
 \predicatesummary{expand_answer}{2}{Expand answer of query}
 \predicatesummary{expand_file_name}{2}{Wildcard expansion of file names}
-\predicatesummary{expand_file_search_path}{2}{Wildcard expansion of file
-paths} \predicatesummary{expand_goal}{2}{Compiler: expand goal in
-clause-body} \predicatesummary{expand_goal}{4}{Compiler: expand goal in
-clause-body} \predicatesummary{expand_query}{4}{Expanded entered query}
-\predicatesummary{expand_term}{2}{Compiler: expand read term into
-clause(s)} \predicatesummary{expand_term}{4}{Compiler: expand read term
-into clause(s)} \predicatesummary{expects_dialect}{1}{For which Prolog
-dialect is this code written?}
+\predicatesummary{expand_file_search_path}{2}{Wildcard expansion of file paths}
+\predicatesummary{expand_goal}{2}{Compiler: expand goal in clause-body}
+\predicatesummary{expand_goal}{4}{Compiler: expand goal in clause-body}
+\predicatesummary{expand_query}{4}{Expanded entered query}
+\predicatesummary{expand_term}{2}{Compiler: expand read term into clause(s)}
+\predicatesummary{expand_term}{4}{Compiler: expand read term into clause(s)}
+\predicatesummary{expects_dialect}{1}{For which Prolog dialect is this code written?}
 \predicatesummary{explain}{1}{\pllib{explain} Explain argument}
-\predicatesummary{explain}{2}{\pllib{explain} 2nd argument is
-explanation of first} \predicatesummary{export}{1}{Export a predicate
-from a module} \predicatesummary{fail}{0}{Always false}
+\predicatesummary{explain}{2}{\pllib{explain} 2nd argument is explanation of first}
+\predicatesummary{export}{1}{Export a predicate from a module}
+\predicatesummary{fail}{0}{Always false}
 \predicatesummary{false}{0}{Always false}
 \predicatesummary{fast_term_serialized}{2}{Fast term (de-)serialization}
 \predicatesummary{fast_read}{2}{Read binary term serialization}
 \predicatesummary{fast_write}{2}{Write binary term serialization}
-\predicatesummary{current_prolog_flag}{2}{Get system configuration
-parameters} \predicatesummary{file_base_name}{2}{Get file part of path}
+\predicatesummary{current_prolog_flag}{2}{Get system configuration parameters}
+\predicatesummary{file_base_name}{2}{Get file part of path}
 \predicatesummary{file_directory_name}{2}{Get directory part of path}
-\predicatesummary{file_name_extension}{3}{Add, remove or test file
-extensions} \predicatesummary{file_search_path}{2}{Define path-aliases
-for locating files} \predicatesummary{find_chr_constraint}{1}{Returns a
-constraint from the store} \predicatesummary{findall}{3}{Find all
-solutions to a goal} \predicatesummary{findall}{4}{Difference list
-version of findall/3} \predicatesummary{findnsols}{4}{Find first \arg{N}
-solutions} \predicatesummary{findnsols}{5}{Difference list version of
-findnsols/4} \predicatesummary{fill_buffer}{1}{Fill the input buffer of
-a stream} \predicatesummary{flag}{3}{Simple global variable system}
+\predicatesummary{file_name_extension}{3}{Add, remove or test file extensions}
+\predicatesummary{file_search_path}{2}{Define path-aliases for locating files}
+\predicatesummary{find_chr_constraint}{1}{Returns a constraint from the store}
+\predicatesummary{findall}{3}{Find all solutions to a goal}
+\predicatesummary{findall}{4}{Difference list version of findall/3}
+\predicatesummary{findnsols}{4}{Find first \arg{N} solutions}
+\predicatesummary{findnsols}{5}{Difference list version of findnsols/4}
+\predicatesummary{fill_buffer}{1}{Fill the input buffer of a stream}
+\predicatesummary{flag}{3}{Simple global variable system}
 \predicatesummary{float}{1}{Type check for a floating point number}
 \predicatesummary{float_class}{2}{Classify (special) floats}
 \predicatesummary{float_parts}{4}{Get mantissa and exponent of a float}
@@ -388,59 +378,55 @@ a stream} \predicatesummary{flag}{3}{Simple global variable system}
 \predicatesummary{last}{2}{Last element of a list}
 \predicatesummary{leash}{1}{Change ports visited by the tracer}
 \predicatesummary{length}{2}{Length of a list}
-\predicatesummary{library_directory}{1}{\hook{user} Directories holding
-Prolog libraries} \predicatesummary{license}{0}{Evaluate licenses of
-loaded modules} \predicatesummary{license}{1}{Define license for current
-file} \predicatesummary{license}{2}{Define license for named module}
+\predicatesummary{library_directory}{1}{\hook{user} Directories holding Prolog libraries}
+\predicatesummary{license}{0}{Evaluate licenses of loaded modules}
+\predicatesummary{license}{1}{Define license for current file}
+\predicatesummary{license}{2}{Define license for named module}
 \predicatesummary{line_count}{2}{Line number on stream}
-\predicatesummary{line_position}{2}{Character position in line on
-stream} \predicatesummary{list_debug_topics}{0}{List registered topics
-for debugging} \predicatesummary{list_to_assoc}{2}{Create association
-tree from list} \predicatesummary{list_to_set}{2}{Remove duplicates from
-a list} \predicatesummary{list_strings}{0}{Help porting to version 7}
+\predicatesummary{line_position}{2}{Character position in line on stream}
+\predicatesummary{list_debug_topics}{0}{List registered topics for debugging}
+\predicatesummary{list_to_assoc}{2}{Create association tree from list}
+\predicatesummary{list_to_set}{2}{Remove duplicates from a list}
+\predicatesummary{list_strings}{0}{Help porting to version 7}
 \predicatesummary{load_files}{1}{Load source files}
 \predicatesummary{load_files}{2}{Load source files with options}
-\predicatesummary{load_foreign_library}{1}{\pllib{shlib} Load shared
-library (.so file)}
-\predicatesummary{load_foreign_library}{2}{\pllib{shlib} Load shared
-library (.so file)} \predicatesummary{locale_create}{3}{Create a new
-locale object} \predicatesummary{locale_destroy}{1}{Destroy a locale
-object} \predicatesummary{locale_property}{2}{Query properties of locale
-objects} \predicatesummary{locale_sort}{2}{Language dependent sort of
-atoms} \predicatesummary{make}{0}{Reconsult all changed source files}
+\predicatesummary{load_foreign_library}{1}{\pllib{shlib} Load shared library (.so file)}
+\predicatesummary{load_foreign_library}{2}{\pllib{shlib} Load shared library (.so file)}
+\predicatesummary{locale_create}{3}{Create a new locale object}
+\predicatesummary{locale_destroy}{1}{Destroy a locale object}
+\predicatesummary{locale_property}{2}{Query properties of locale objects}
+\predicatesummary{locale_sort}{2}{Language dependent sort of atoms}
+\predicatesummary{make}{0}{Reconsult all changed source files}
 \predicatesummary{make_directory}{1}{Create a folder on the file system}
 \predicatesummary{make_library_index}{1}{Create autoload file INDEX.pl}
 \predicatesummary{malloc_property}{1}{Property of the allocator}
-\predicatesummary{make_library_index}{2}{Create selective autoload file INDEX.pl} \predicatesummary{map_assoc}{2}{Map association tree}
+\predicatesummary{make_library_index}{2}{Create selective autoload file INDEX.pl}
+\predicatesummary{map_assoc}{2}{Map association tree}
 \predicatesummary{map_assoc}{3}{Map association tree}
 \predicatesummary{dict_create}{3}{Create a dict from data}
 \predicatesummary{dict_pairs}{3}{Convert between dict and list of pairs}
 \predicatesummary{max_assoc}{3}{Highest key in association tree}
 \predicatesummary{memberchk}{2}{Deterministic member/2}
 \predicatesummary{message_hook}{3}{Intercept print_message/2}
-\predicatesummary{message_line_element}{2}{\hook{prolog} Intercept
-print_message_lines/3}
-\predicatesummary{message_property}{2}{\hook{user} Define display of a
-message} \predicatesummary{message_queue_create}{1}{Create queue for
-thread communication} \predicatesummary{message_queue_create}{2}{Create
-queue for thread communication}
-\predicatesummary{message_queue_destroy}{1}{Destroy queue for thread
-communication} \predicatesummary{message_queue_property}{2}{Query
-message queue properties} \predicatesummary{message_queue_set}{2}{Set a
-message queue property}
-\predicatesummary{message_to_string}{2}{Translate message-term to
-string} \predicatesummary{meta_predicate}{1}{Declare access to other
-predicates} \predicatesummary{min_assoc}{3}{Lowest key in association
-tree} \predicatesummary{module}{1}{Query/set current type-in module}
+\predicatesummary{message_line_element}{2}{\hook{prolog} Intercept print_message_lines/3}
+\predicatesummary{message_property}{2}{\hook{user} Define display of a message}
+\predicatesummary{message_queue_create}{1}{Create queue for thread communication}
+\predicatesummary{message_queue_create}{2}{Create queue for thread communication}
+\predicatesummary{message_queue_destroy}{1}{Destroy queue for thread communication}
+\predicatesummary{message_queue_property}{2}{Query message queue properties}
+\predicatesummary{message_queue_set}{2}{Set a message queue property}
+\predicatesummary{message_to_string}{2}{Translate message-term to string}
+\predicatesummary{meta_predicate}{1}{Declare access to other predicates}
+\predicatesummary{min_assoc}{3}{Lowest key in association tree}
+\predicatesummary{module}{1}{Query/set current type-in module}
 \predicatesummary{module}{2}{Declare a module}
 \predicatesummary{module}{3}{Declare a module with language options}
 \predicatesummary{module_property}{2}{Find properties of a module}
-\oppredsummary{module_transparent}{1}{fx}{1150}{Indicate module based
-meta-predicate} \predicatesummary{msort}{2}{Sort, do not remove
-duplicates} \oppredsummary{multifile}{1}{fx}{1150}{Indicate distributed
-definition of predicate} \predicatesummary{mutex_create}{1}{Create a
-thread-synchronisation device} \predicatesummary{mutex_create}{2}{Create
-a thread-synchronisation device}
+\oppredsummary{module_transparent}{1}{fx}{1150}{Indicate module based meta-predicate}
+\predicatesummary{msort}{2}{Sort, do not remove duplicates}
+\oppredsummary{multifile}{1}{fx}{1150}{Indicate distributed definition of predicate}
+\predicatesummary{mutex_create}{1}{Create a thread-synchronisation device}
+\predicatesummary{mutex_create}{2}{Create a thread-synchronisation device}
 \predicatesummary{mutex_destroy}{1}{Destroy a mutex}
 \predicatesummary{mutex_lock}{1}{Become owner of a mutex}
 \predicatesummary{mutex_property}{2}{Query mutex properties}
@@ -510,25 +496,24 @@ a thread-synchronisation device}
 \predicatesummary{peek_string}{3}{Read a string without removing}
 \predicatesummary{phrase}{2}{Activate grammar-rule set}
 \predicatesummary{phrase}{3}{Activate grammar-rule set (returning rest)}
-\predicatesummary{phrase_from_quasi_quotation}{2}{Parse quasi quotation
-with DCG} \predicatesummary{please}{3}{Query/change environment
-parameters} \predicatesummary{plus}{3}{Logical integer addition}
+\predicatesummary{phrase_from_quasi_quotation}{2}{Parse quasi quotation with DCG}
+\predicatesummary{please}{3}{Query/change environment parameters}
+\predicatesummary{plus}{3}{Logical integer addition}
 \predicatesummary{portray}{1}{\hook{user} Modify behaviour of print/1}
 \predicatesummary{predicate_property}{2}{Query predicate attributes}
-\predicatesummary{predsort}{3}{Sort, using a predicate to determine the
-order} \predicatesummary{print}{1}{Print a term}
+\predicatesummary{predsort}{3}{Sort, using a predicate to determine the order}
+\predicatesummary{print}{1}{Print a term}
 \predicatesummary{print}{2}{Print a term on a stream}
 \predicatesummary{print_message}{2}{Print message from (exception) term}
 \predicatesummary{print_message_lines}{3}{Print message to stream}
 \predicatesummary{profile}{1}{Obtain execution statistics}
 \predicatesummary{profile}{2}{Obtain execution statistics}
-\predicatesummary{profile_count}{3}{Obtain profile results on a
-predicate} \predicatesummary{profiler}{2}{Obtain/change status of the
-profiler} \predicatesummary{prolog}{0}{Run interactive top level}
+\predicatesummary{profile_count}{3}{Obtain profile results on a predicate}
+\predicatesummary{profiler}{2}{Obtain/change status of the profiler}
+\predicatesummary{prolog}{0}{Run interactive top level}
 \predicatesummary{prolog_alert_signal}{2}{Query/set unblock signal}
-\predicatesummary{prolog_choice_attribute}{3}{Examine the choice point
-stack} \predicatesummary{prolog_current_choice}{1}{Reference to most
-recent choice point}
+\predicatesummary{prolog_choice_attribute}{3}{Examine the choice point stack}
+\predicatesummary{prolog_current_choice}{1}{Reference to most recent choice point}
 \predicatesummary{prolog_current_frame}{1}{Reference to goal's environment stack}
 \predicatesummary{prolog_cut_to}{1}{Realise global cuts}
 \predicatesummary{prolog_edit:locate}{2}{Locate targets for edit/1}
@@ -562,8 +547,8 @@ recent choice point}
 \predicatesummary{put}{2}{Write a character on a stream}
 \predicatesummary{put_assoc}{4}{Add Key-Value to association tree}
 \predicatesummary{put_attr}{3}{Put attribute on a variable}
-\predicatesummary{put_attrs}{2}{Set/replace all attributes on a
-variable} \predicatesummary{put_byte}{1}{Write a byte}
+\predicatesummary{put_attrs}{2}{Set/replace all attributes on a variable}
+\predicatesummary{put_byte}{1}{Write a byte}
 \predicatesummary{put_byte}{2}{Write a byte on a stream}
 \predicatesummary{put_char}{1}{Write a character}
 \predicatesummary{put_char}{2}{Write a character on a stream}
@@ -586,65 +571,64 @@ variable} \predicatesummary{put_byte}{1}{Write a byte}
 \predicatesummary{read_clause}{3}{Read clause from stream}
 \predicatesummary{read_history}{6}{Read using history substitution}
 \predicatesummary{read_link}{3}{Read a symbolic link}
-\predicatesummary{read_pending_codes}{3}{Fetch buffered input from a
-stream} \predicatesummary{read_pending_chars}{3}{Fetch buffered input
-from a stream} \predicatesummary{read_string}{3}{Read a number of
-characters into a string} \predicatesummary{read_string}{5}{Read string
-upto a delimiter} \predicatesummary{read_term}{2}{Read term with
-options} \predicatesummary{read_term}{3}{Read term with options from
-stream} \predicatesummary{read_term_from_atom}{3}{Read term with options
-from atom} \predicatesummary{recorda}{2}{Record term in the database
-(first)} \predicatesummary{recorda}{3}{Record term in the database
-(first)} \predicatesummary{recorded}{2}{Obtain term from the database}
+\predicatesummary{read_pending_codes}{3}{Fetch buffered input from a stream}
+\predicatesummary{read_pending_chars}{3}{Fetch buffered input from a stream}
+\predicatesummary{read_string}{3}{Read a number of characters into a string}
+\predicatesummary{read_string}{5}{Read string upto a delimiter}
+\predicatesummary{read_term}{2}{Read term with options}
+\predicatesummary{read_term}{3}{Read term with options from stream}
+\predicatesummary{read_term_from_atom}{3}{Read term with options from atom}
+\predicatesummary{recorda}{2}{Record term in the database (first)}
+\predicatesummary{recorda}{3}{Record term in the database (first)}
+\predicatesummary{recorded}{2}{Obtain term from the database}
 \predicatesummary{recorded}{3}{Obtain term from the database}
 \predicatesummary{recordz}{2}{Record term in the database (last)}
 \predicatesummary{recordz}{3}{Record term in the database (last)}
-\predicatesummary{redefine_system_predicate}{1}{Abolish system
-definition} \predicatesummary{reexport}{1}{Load files and re-export the
-imported predicates} \predicatesummary{reexport}{2}{Load predicates from
-a file and re-export it}
-\predicatesummary{reload_foreign_libraries}{0}{Reload DLLs/shared
-objects} \predicatesummary{reload_library_index}{0}{Force reloading the
-autoload index} \predicatesummary{rename_file}{2}{Change name of file}
+\predicatesummary{redefine_system_predicate}{1}{Abolish system definition}
+\predicatesummary{reexport}{1}{Load files and re-export the imported predicates}
+\predicatesummary{reexport}{2}{Load predicates from a file and re-export it}
+\predicatesummary{reload_foreign_libraries}{0}{Reload DLLs/shared objects}
+\predicatesummary{reload_library_index}{0}{Force reloading the autoload index}
+\predicatesummary{rename_file}{2}{Change name of file}
 \predicatesummary{repeat}{0}{Succeed, leaving infinite backtrack points}
 \predicatesummary{require}{1}{This file requires these predicates}
 \predicatesummary{reset}{3}{Wrapper for delimited continuations}
 \predicatesummary{reset_gensym}{1}{Reset a gensym key}
 \predicatesummary{reset_gensym}{0}{Reset all gensym keys}
-\predicatesummary{reset_profiler}{0}{Clear statistics obtained by the
-profiler} \predicatesummary{resource}{2}{Declare a program resource}
+\predicatesummary{reset_profiler}{0}{Clear statistics obtained by the profiler}
+\predicatesummary{resource}{2}{Declare a program resource}
 \predicatesummary{resource}{3}{Declare a program resource}
 \predicatesummary{retract}{1}{Remove clause from the database}
-\predicatesummary{retractall}{1}{Remove unifying clauses from the
-database} \predicatesummary{same_file}{2}{Succeeds if arguments refer to
-same file} \predicatesummary{same_term}{2}{Test terms to be at the same
-address} \predicatesummary{see}{1}{Change the current input stream}
+\predicatesummary{retractall}{1}{Remove unifying clauses from the database}
+\predicatesummary{same_file}{2}{Succeeds if arguments refer to same file}
+\predicatesummary{same_term}{2}{Test terms to be at the same address}
+\predicatesummary{see}{1}{Change the current input stream}
 \predicatesummary{seeing}{1}{Query the current input stream}
 \predicatesummary{seek}{4}{Modify the current position in a stream}
 \predicatesummary{seen}{0}{Close the current input stream}
-\predicatesummary{select_dict}{2}{Select matching attributes from a
-dict} \predicatesummary{select_dict}{3}{Select matching attributes from
-a dict} \predicatesummary{set_end_of_stream}{1}{Set physical end of an
-open file} \predicatesummary{set_flag}{2}{Set value of a flag}
+\predicatesummary{select_dict}{2}{Select matching attributes from a dict}
+\predicatesummary{select_dict}{3}{Select matching attributes from a dict}
+\predicatesummary{set_end_of_stream}{1}{Set physical end of an open file}
+\predicatesummary{set_flag}{2}{Set value of a flag}
 \predicatesummary{set_input}{1}{Set current input stream from a stream}
 \predicatesummary{set_locale}{1}{Set the default local}
 \predicatesummary{set_malloc}{1}{Set memory allocator property}
 \predicatesummary{set_module}{1}{Set properties of a module}
-\predicatesummary{set_output}{1}{Set current output stream from a
-stream} \predicatesummary{set_prolog_IO}{3}{Prepare streams for
-interactive session} \predicatesummary{set_prolog_flag}{2}{Define a
-system feature} \predicatesummary{set_prolog_gc_thread}{1}{Control the
-gc thread} \predicatesummary{set_prolog_stack}{2}{Modify stack
-characteristics} \predicatesummary{set_random}{1}{Control random number
-generation} \predicatesummary{set_stream}{2}{Set stream attribute}
+\predicatesummary{set_output}{1}{Set current output stream from a stream}
+\predicatesummary{set_prolog_IO}{3}{Prepare streams for interactive session}
+\predicatesummary{set_prolog_flag}{2}{Define a system feature}
+\predicatesummary{set_prolog_gc_thread}{1}{Control the gc thread}
+\predicatesummary{set_prolog_stack}{2}{Modify stack characteristics}
+\predicatesummary{set_random}{1}{Control random number generation}
+\predicatesummary{set_stream}{2}{Set stream attribute}
 \predicatesummary{set_stream_position}{2}{Seek stream to position}
 \predicatesummary{setup_call_cleanup}{3}{Undo side-effects safely}
-\predicatesummary{setup_call_catcher_cleanup}{4}{Undo side-effects
-safely} \predicatesummary{setarg}{3}{Destructive assignment on term}
+\predicatesummary{setup_call_catcher_cleanup}{4}{Undo side-effects safely}
+\predicatesummary{setarg}{3}{Destructive assignment on term}
 \predicatesummary{setenv}{2}{Set shell environment variable}
-\predicatesummary{setlocale}{3}{Set/query C-library regional
-information} \predicatesummary{setof}{3}{Find all unique solutions to a
-goal} \predicatesummary{shell}{1}{Execute OS command}
+\predicatesummary{setlocale}{3}{Set/query C-library regional information}
+\predicatesummary{setof}{3}{Find all unique solutions to a goal}
+\predicatesummary{shell}{1}{Execute OS command}
 \predicatesummary{shell}{2}{Execute OS command}
 \predicatesummary{shift}{1}{Shift control to the closest reset/3}
 \predicatesummary{show_profile}{1}{Show results of the profiler}
@@ -673,18 +657,17 @@ goal} \predicatesummary{shell}{1}{Execute OS command}
 \predicatesummary{string}{1}{Type check for string}
 \predicatesummary{string_concat}{3}{atom_concat/3 for strings}
 \predicatesummary{string_length}{2}{Determine length of a string}
-\predicatesummary{string_chars}{2}{Conversion between string and list of
-characters} \predicatesummary{string_codes}{2}{Conversion between string
-and list of character codes} \predicatesummary{string_code}{3}{Get or
-find a character code in a string}
+\predicatesummary{string_chars}{2}{Conversion between string and list of characters}
+\predicatesummary{string_codes}{2}{Conversion between string and list of character codes}
+\predicatesummary{string_code}{3}{Get or find a character code in a string}
 \predicatesummary{string_lower}{2}{Case conversion to lower case}
 \predicatesummary{string_upper}{2}{Case conversion to upper case}
-\predicatesummary{string_predicate}{1}{\hook{check} Predicate contains
-strings} \predicatesummary{strip_module}{3}{Extract context module and
-term} \predicatesummary{style_check}{1}{Change level of warnings}
+\predicatesummary{string_predicate}{1}{\hook{check} Predicate contains strings}
+\predicatesummary{strip_module}{3}{Extract context module and term}
+\predicatesummary{style_check}{1}{Change level of warnings}
 \predicatesummary{sub_atom}{5}{Take a substring from an atom}
-\predicatesummary{sub_atom_icasechk}{3}{Case insensitive substring
-match} \predicatesummary{sub_string}{5}{Take a substring from a string}
+\predicatesummary{sub_atom_icasechk}{3}{Case insensitive substring match}
+\predicatesummary{sub_string}{5}{Take a substring from a string}
 \predicatesummary{subsumes_term}{2}{One-sided unification test}
 \predicatesummary{succ}{2}{Logical integer successor relation}
 \predicatesummary{swritef}{2}{Formatted write on a string}

--- a/man/threads.doc
+++ b/man/threads.doc
@@ -110,8 +110,8 @@ Enable/disable debugging the new thread. If \const{false} (default
 started. The thread debugging predicates such as tspy/1 and tdebug/0 do
 not signal threads with the debug property set to
 \const{false}.\footnote{Currently, the flag is only used as a hint for
-the the various debugging primitives, i.e., the system does not
-really enforce that the target thread stays in \jargon{nodebug} mode.}
+the various debugging primitives, i.e., the system does not really
+enforce that the target thread stays in \jargon{nodebug} mode.}
 
     \termitem{detached}{Bool}
 If \const{false} (default), the thread can be waited for using
@@ -139,7 +139,7 @@ inherited:
         \item The \jargon{typein} module (see module/1)
         \item The standard streams (\const{user_input}, etc.)
         \item The default encoding (see \prologflag{encoding})
-        \item The default locale (see setlocale/1)
+        \item The default locale (see set_locale/1)
         \item All prolog flags
 	\item The stack limit (see Prolog flag \prologflag{stack_limit}).
     \end{itemize}
@@ -231,7 +231,7 @@ mutexes and proper cleanup in setup_call_cleanup/3, etc. Please use the
 exception mechanism (throw/1) to abort execution using non-standard
 control.\bug{The Windows port does not properly cleanup for
 \jargon{detached} threads while the cleanup for other threads is
-executed by the thread running thread_join/2 using the exitted thread as
+executed by the thread running thread_join/2 using the exited thread as
 \jargon{engine}. This is due to a bug in the
 \href{https://sourceforge.net/p/mingw-w64/bugs/469/}{MinGW pthread
 implementation}.}
@@ -354,7 +354,7 @@ exception (see throw/1 and catch/3).
 
 	\termitem{engine}{Boolean}
 If the thread is an engine (see \chapref{engines}), \arg{Boolean} is
-\const{true}.  Othwerwise the property is not present.
+\const{true}.  Otherwise the property is not present.
 
 	\termitem{thread}{ThreadId}
 If the thread is an engine that is currently attached to a thread,
@@ -461,7 +461,7 @@ in seconds.  This is a relative-time version of the \const{deadline}
 option.  If both options are provided, the earlier time is effective.
 
 If \arg{Time} is 0 or 0.0, thread_send_message/3 examines the queue and
-sends the message if space is availabel, but
+sends the message if space is available, but
 does not suspend if no space is available, failing immediately instead.
 
 If \arg{Time} $< 0$, thread_send_message/3 fails immediately without
@@ -530,7 +530,7 @@ Create a message queue from \arg{Options}.  Defined options are:
 Create a message queue that is identified by the atom \arg{Alias}.
 Message queues created this way must be explicitly destroyed by the
 user. If the alias option is omitted, an \emph{Anonymous} queue is
-created that is indentified by a \jargon{blob} (see \secref{blob}) and
+created that is identified by a \jargon{blob} (see \secref{blob}) and
 subject to garbage collection.\footnote{Garbage collecting anonymous
 message queues is not part of the ISO proposal and most likely not
 a widely implemented feature.}
@@ -617,7 +617,7 @@ Set a property on the queue.  Supported properties are:
     \begin{description}
         \termitem{max_size}{+Size}
 Change the number of terms that may appear in the message queue before
-the next thread_send_message/2,3 blocks on it.  If the value is higher
+the next thread_send_message/[2,3] blocks on it.  If the value is higher
 then the current maximum and the queue has writers waiting, wakeup the
 writers.  The value can be lower than the current number of terms in
 the queue.  In that case writers will block until the queue is drained
@@ -681,8 +681,8 @@ be updated using the standard Prolog database update predicates
 Waiting is implemented using a POSIX \jargon{condition variable} and
 matching \jargon{mutex}. On a matching database change the condition
 variable is signalled using a \jargon{broadcast}, waking up all threads
-waiting in thread/2. Multiple database updates can be grouped and cause
-a single wakeup using thread_update/2. This predicate also allows
+waiting in thread_wait/2. Multiple database updates can be grouped and
+cause a single wakeup using thread_update/2. This predicate also allows
 signalling the module condition variable without updating the database
 and controlling whether all or a single thread is activated.
 
@@ -717,14 +717,14 @@ optionally when the call terminates due to a timeout.
 	\nodescription
 
 	\termitem{timeout}{+Time}
-	Timeout and deadling handling.  See thread_get_message/3 for
+	Timeout and deadline handling.  See thread_get_message/3 for
 	details.  This predicate fails when it terminates due to one
 	of these options.
 
         \termitem{retry_every}{+Time}
 	Retry goal every \arg{Time} seconds regardless of whether an
 	event happened.  The default is 1 second.  This ensures that
-	signals (see thread_signal/1) and time limits are respected
+	signals (see thread_signal/2) and time limits are respected
 	with an optional delay.\footnote{Some operating systems process
 	such signals immediately, while others only check for such
 	events synchronously.}
@@ -769,7 +769,7 @@ between updating and waiting threads.  \arg{Options}:
     \begin{description}
 	\termitem{module}{+Module}
 	Determines the module to operate on.  Default is the context
-	module assosciated with the \arg{Options} argument.
+	module associated with the \arg{Options} argument.
 	\termitem{notify}{+Atom}
 	Determines whether all waiting threads are activated
 	(\const{broadcast}, default) or a single thread
@@ -897,7 +897,7 @@ with_mutex/2. It also illustrates the problem of mutexes. The predicate
 with_mutex/2 behaves as once/1 with respect to the guarded goal. This
 means that our predicate \nopredref{address}{2} is no longer a nice
 logical non-deterministic relation.  This could be solved by explicit
-locking and unlocking a mutex using setup_call_cleanup/2, but at the
+locking and unlocking a mutex using setup_call_cleanup/3, but at the
 risk of deadlocking the program if the choice point is left open by
 accident.
 
@@ -913,7 +913,7 @@ address(Id, Address) :-
 		   address_db(Id, Address)).
 \end{code}
 
-Message queues (see message_queue_create/3) often provide simpler
+Message queues (see message_queue_create/2) often provide simpler
 and more robust ways for threads to communicate.  Still, mutexes
 can be a sensible solution and are therefore provided.
 
@@ -936,7 +936,7 @@ is preferred over the equivalent \term{mutex_create}{name}.
 Destroy a mutex. If the mutex is not locked, it is destroyed and further
 access yields an \except{existence_error} exception. As of version
 7.1.19, this behaviour is reliable.  If the mutex is locked, the mutex
-is sheduled for \emph{delayed destruction}: it will be destroyed when
+is scheduled for \emph{delayed destruction}: it will be destroyed when
 it becomes unlocked.
 
     \predicate{with_mutex}{2}{+MutexId, :Goal}
@@ -1326,7 +1326,7 @@ bindings inside \arg{Goal} are visible to the caller, but it should be
 noted that the values are being \emph{copied}. If \arg{Goal} throws an
 exception, this exception is re-thrown by in_pce_thread/1. If the
 calling thread is the `pce thread', in_pce_thread_sync/1 executes a
-direct meta-call. See also pce_thread/1.
+direct meta-call. See also in_pce_thread/1.
 
 Note that in_pce_thread_sync/1 is expensive because it requires copying
 and thread communication.  For example, \exam{in_pce_thread_sync{true}}


### PR DESCRIPTION
In `man/threads.doc`, there were 2 predicate name typos which I'm not confident of my fixes:

* Line 142, `setlocale/1` -> `set_locale/1` (might be `setlocale/3`?)

* Line 684, `thread/2` -> `thread_wait/2`