### PR TITLE
DOC: Mainly extended "Notation of Predicate Descs"

### DIFF
--- a/man/builtin.doc
+++ b/man/builtin.doc
@@ -6479,9 +6479,11 @@ ERROR: Domain error: `compound_non_zero_arity' expected, found `a()'
 \end{code}
 
     \predicate{compound_name_arity}{3}{?Compound, ?Name, ?Arity}
-Rationalized version of functor/3 that only works for compound terms
-and can examine and create compound terms with zero arguments (e.g,
-\exam{name()}).  See also compound_name_arguments/3.
+Rationalized version of functor/3 that only works for compound terms.
+A \const{type_error} is thrown if, at call time, \arg{Compound} is
+instantiated to something that is not a compound term. The predicate
+can examine and create compound terms with zero arguments 
+(e.g, \exam{name()}). See also compound_name_arguments/3.
 
     \predicate{compound_name_arguments}{3}{?Compound, ?Name, ?Arguments}
 Rationalized version of \predref{=..}{2} that can compose and decompose

--- a/man/builtin.doc
+++ b/man/builtin.doc
@@ -1678,10 +1678,12 @@ error condition and do not instantiate their argument. See also library
 
 \begin{description}
     \predicate[ISO]{var}{1}{@Term}
-True if \arg{Term} currently is a free variable.
+True if \arg{Term} currently is an uninstantiated (fresh,unbound) 
+variable.
 
     \predicate[ISO]{nonvar}{1}{@Term}
-True if \arg{Term} currently is not a free variable.
+True if \arg{Term} currently is not an uninstantiated (fresh,unbound) 
+variable. The complement of var/1.
 
     \predicate[ISO]{integer}{1}{@Term}
 True if \arg{Term} is bound to an integer.
@@ -1740,7 +1742,7 @@ True if \arg{Term} is bound to a compound term.  See also functor/3
 
     \predicate[ISO]{callable}{1}{@Term}
 True if \arg{Term} is bound to an atom or a compound term. This was
-intended as a type-test for arguments to call/1 and call/2.. Note that
+intended as a type-test for arguments to call/1, call/2 etc. Note that
 callable only tests the \jargon{surface term}. Terms such as (22,true)
 are considered callable, but cause call/1 to raise a type error.
 Module-qualification of meta-argument (see meta_predicate/1) using
@@ -1763,12 +1765,32 @@ ERROR:    [6] p(user:22)
 \end{code}
 
     \predicate[ISO]{ground}{1}{@Term}
-True if \arg{Term} holds no free variables. See also nonground/2
-and term_variables/2.
+True if \arg{Term} is a term with no ``hole'' at any of its leaves.
+In case subterms of \arg{Term} are named with variables, none of these variables
+are uninstantiated (fresh, unbound) and for all of them, ground/1 would succeed.
+
+See also nonground/2 (used for coroutining) and term_variables/2.
+
+Notice that \jargon{the anonymous variable} stays un-ground as every new occurrence
+is really a new variable:
+
+\begin{code}
+?- _=foo,ground(_).
+false.
+\end{code}
+
+whereas a \jargon{don't care variable} can become ground:
+
+\begin{code}
+?- _X=foo,ground(_X).
+_X = foo.
+\end{code}
+
 
     \predicate{cyclic_term}{1}{@Term}
-True if \arg{Term} contains cycles, i.e.\ is an infinite term.
-See also acyclic_term/1 and \secref{cyclic}.%
+True if \arg{Term} contains cycles, i.e.\ is an infinite term 
+aka. a \jargon{rational tree}. See also acyclic_term/1 and
+\secref{cyclic}.%
 	\footnote{The predicates cyclic_term/1 and acyclic_term/1 are
 		  compatible with SICStus Prolog.  Some Prolog systems
 		  supporting cyclic terms use \nopredref{is_cyclic}{1}.}
@@ -2669,7 +2691,7 @@ relevant \jargon{error context} information.
 It may be a compound term of arity 1,2 or 3 - or simply an atom if
 there is no relevant error context information.
 
-\item [\arg{Context}] gives additional context information beyond
+\item [\arg{Context}] additional context information beyond
 the one in \arg{Formal}. If may be unset, i.e. a fresh variable, or
 set to something that hopefully will help the programmer in debugging.
 The structure of \arg{Context} is left unspecified by the ISO
@@ -2677,8 +2699,9 @@ Standard, so SWI-Prolog creates it own convention (see below).
 \end{itemlist}
 
 Thus, constructing an error term and throwing it might take
-this form (although you would not use the explicit naming given here
-for illustration purposes, but write the term to throw directly):
+this form (although you would not use the illustrative explicit
+naming given here; instead composing the exception term directly in
+a one-liner):
 
 \begin{code}
 Exception = error(Formal, Context),
@@ -2689,6 +2712,23 @@ Culprit   = ... some value ...,
 throw(Exception)
 \end{code}
 
+Note that the ISO standard formal term tries to express \emph{what should be the case}
+or \emph{what is the expected correct state}, and not \emph{what is the problem}.
+
+For example:
+
+\begin{itemlist}
+\item If a variable is found to be uninstantiated but should be instantiated, you get a
+formal term equal to \const{instantiation_error}: The problem is not that there is an
+unwanted instantiation, but that the correct state is the one with an instantiated variable.
+\item In case a variable is found to be instantiated but should be uninstantiated (because
+it will be used for output), you get a formal term equal to \const{uninstantiation_error(Culprit)}:
+The problem is not that there is lack of instantiation, but that the correct state is the one
+which \const{Culprit} (or one of its subterms) is more uninstantiated than is the case.
+\item If you try to disassemble an empty list with compound_name_arguments/3, you get a formal
+\const{type_error(compound,[])}. The problem is not that \const{[]} is (erroneously) a 
+compound term, but that a compound term is expected and \const{[]} doesn't belong to that class.
+\end{itemlist}
 
 \subsubsection{Throwing exceptions from applications and libraries}
 \label{sec:throwsfromuserpreds}
@@ -6448,7 +6488,7 @@ Rationalized version of \predref{=..}{2} that can compose and decompose
 compound terms with zero arguments. See also compound_name_arity/3.
 
     \predicate{numbervars}{3}{+Term, +Start, -End}
-Unify the free variables in \arg{Term} with a term \term{\$VAR}{N},
+Unify the unbound variables in \arg{Term} with a term \term{\$VAR}{N},
 where \arg{N} is the number of the variable. Counting starts at
 \arg{Start}. \arg{End} is unified with the number that should be given
 to the next variable.\bug{Only \jargon{tagged integers} are supported
@@ -8493,10 +8533,12 @@ the same as sort/2.  See also keysort/2.
     \predicate[ISO]{findall}{3}{+Template, :Goal, -Bag}
 Create a list of the instantiations \arg{Template} gets successively on
 backtracking over \arg{Goal} and unify the result with \arg{Bag}.
-Succeeds with an empty list if \arg{Goal} has no solutions. findall/3 is
-equivalent to bagof/3 with all free variables bound with the existential
-operator (\op{^}), except that bagof/3 fails when \arg{Goal} has no
-solutions.
+Succeeds with an empty list if \arg{Goal} has no solutions.\\
+
+findall/3 is equivalent to bagof/3 with all \jargon{free} variables 
+appearing in \arg{Goal} scoped to the \arg{Goal} with an existential
+(caret) operator (\op{^}), except that bagof/3 fails when \arg{Goal} 
+has no solutions.
 
     \predicate{findall}{4}{+Template, :Goal, -Bag, +Tail}
 As findall/3, but returns the result as the difference list
@@ -8543,7 +8585,7 @@ L = [1, 2, 3, 4].
 
     \predicate[ISO]{bagof}{3}{+Template, :Goal, -Bag}
 Unify \arg{Bag} with the alternatives of \arg{Template}. If \arg{Goal}
-has free variables besides the one sharing with \arg{Template}, bagof/3
+has \jargon{free} variables besides the one sharing with \arg{Template}, bagof/3
 will backtrack over the alternatives of these free variables, unifying
 \arg{Bag} with the corresponding alternatives of \arg{Template}. The
 construct \exam{+\arg{Var}{^}\arg{Goal}} tells bagof/3 not to bind
@@ -10192,7 +10234,7 @@ expansion mechanism described in \secref{topvars}.
     \predicate{expand_query}{4}{+Query, -Expanded, +Bindings, -ExpandedBindings}
 Hook in module \const{user}, normally not defined.  \arg{Query} and
 \arg{Bindings} represents the query read from the user and the names
-of the free variables as obtained using read_term/3.  If this predicate
+of the fresh variables as obtained using read_term/3.  If this predicate
 succeeds, it should bind \arg{Expanded} and \arg{ExpandedBindings} to
 the query and bindings to be executed by the top level.  This predicate
 is used by the top level (prolog/0).  See also expand_answer/2 and

--- a/man/builtin.doc
+++ b/man/builtin.doc
@@ -3,66 +3,179 @@
 \section{Notation of Predicate Descriptions}	\label{sec:preddesc}
 
 We have tried to keep the predicate descriptions clear and concise.
-First, the predicate name is printed in bold face, followed by the
-arguments in italics.  Arguments are preceded by a mode indicator.
-There is no complete agreement on mode indicators in the Prolog
+First, the predicate name is printed in \textbf{bold face}, followed by the
+arguments%
+\footnote{A note on vocabulary: The word \jargon{parameter} is
+commonly understood to describe an element of a function's declaration
+i.e. a \textit{formal parameter}, whereas the word \jargon{argument}
+is commonly understood to describe the value, structure or element passed
+at a parameter's positon at call time i.e. an \textit{actual parameter}.
+However, this manual uses \jargon{argument} in both cases. This is 
+standard usage in the Prolog community. Indeed, the ISO standard has an
+entry for \jargon{argument} as ``a \jargon{term} which is associated with 
+a \jargon{predication} or \jargon{compound term}'' but none for 
+\jargon{parameter}.} %
+in \textit{italics}. Arguments are preceded by a \jargon{mode indicator}.\\
+
+\subsection{The argument mode indicator}        \label{sec:argmode}
+\index{argument mode indicator}%
+
+An \jargon{argument mode indicator} gives information about the intended 
+direction in which information carried by a predicate argument is supposed
+to flow.
+
+Mode indicators (and types) are not a formal part of the Prolog language 
+but help in explaining intended semantics to the programmer and, if they
+appear as part of structured comments in source code, allow performing
+compile-time and run-time verifications and may make automatic test code
+generation possible.
+
+There is no complete agreement on argument mode indicators in the Prolog
 community.  We use the following definitions:%
-	\footnote{These definitions are taken from PlDoc.  The current
-		  manual has only one mode declaration per predicate and
-		  therefore predicates with mode (+,-) and (-,+) are
-		  described as (?,?).  The \chr{@}-mode is often replaced
-		  by \chr{+}.}
+	\footnote{These definitions are taken from the \jargon{PlDoc} markup
+                  language description. \jargon{PldDoc} markup is used
+                  for source code markup (as well as for the commenting tool).
+                  The current manual has only one
+                  mode declaration per predicate and therefore predicates
+                  with mode \const{(+,-)} and \const{(-,+)} are described
+                  as \const{(?,?)}.  The \const{@}-mode is often replaced
+		  by \const{+}.}
 
 \begin{center}
 \begin{tabular}{lp{0.7\linewidth}}
 \hline
-++&	Argument must be ground, i.e., the argument may not contain a
-	variable anywhere. \\
-+ &	Argument must be fully instantiated to a term that satisfies the
-	type.  This is not necessarily \jargon{ground}, e.g., the term
-	\exam{[_]} is a \jargon{list}, although its only member is
-	unbound. \\
-- &	Argument is an \emph{output} argument.  Unless specified
-	otherwise, output arguments need not to be unbound. For
-	example, the goal \exam{findall(X, Goal, [T])} is good style and
-	equivalent to \exam{findall(X, Goal, Xs), Xs = [T]}\footnote{The
-	ISO standard dictates that \exam{findall(X, Goal, 1)} raises a
-	\const{type_error} exception, breaking this semantic relation.
-	SWI-Prolog does not follow the standard here.}  Note that the
-	\jargon{determinism} specification, e.g., ``det'' only applies
-	if this argument is unbound. \\
---&	Argument must be unbound.  Typically used by predicates that
-	create `something' and return a handle to the created object,
-	such as open/3 which creates a \jargon{stream}. \\
-? &	Argument must be bound to a \emph{partial term} of the indicated
-	type.  Note that a variable is a partial term for any type.
-	Think of the argument as either \jargon{input} or \jargon{output} or
-	\emph{both} input and output.  For example, in
-	\exam{stream_property(S, reposition(Bool))}, the \const{reposition}
-	part of the term is input and the uninstantiated \arg{Bool} is output. \\
-: &	Argument is a meta-argument.  Implies \chr{+}. See \chapref{modules}
-	for more information on module handling. \\
-@ &	Argument is not further instantiated. Typically used for type tests.\\
+++&	At call time, the argument must be \jargon{ground}, i.e., the
+        argument must not contain any variables that are still unbound. \\
++ &	At call time, the argument must be instantiated to a term satisfying
+        some (informal) type specification. The argument need not necessarily
+	be ground.
+        For example, the term \exam{[_]} is a list, although its only
+	member is the anonymous variable, which is always unbound (and thus 
+        nonground). \\
+- &	Argument is an \emph{output} argument. It may or may not be bound at 
+        call-time. If the argument is bound at call time, the goal behaves
+	as if the argument were unbound, and then unified with that term after 
+	the goal succeeds. This is what is called being \jargon{steadfast}: 
+        instantiation of output arguments at call-time does not change the
+        semantics of the predicate, although optimizations may be performed.
+        For example, the goal \exam{findall(X, Goal, [T])} is good style and 
+        equivalent to \exam{findall(X, Goal, Xs), Xs = [T]}%
+        \footnote{The ISO standard dictates that \exam{findall(X, Goal, 1)}
+        raise a \const{type_error} exception, breaking steadfastness. SWI-Prolog
+        does not follow the standard here.} %
+	Note that any \jargon{determinism} specification, e.g., \const{det}, only 
+	applies	if the argument is unbound. For the case where the argument is
+        bound or involved in constraints, \const{det} effectively becomes 
+        \const{semidet}, and \const{multi} effectively becomes
+        \const{nondet}. \\
+--&	At call time, the argument must be unbound. This is typically used by
+        predicates that	create `something' and return a handle to the created
+        object,	such as open/3, which creates a \jargon{stream}. \\
+? &	At call time, the argument must be bound to a \emph{partial term} 
+        (a term which may or may not be ground) satisfying some (informal) type
+        specification. Note that an unbound variable \emph{is} a partial
+        term. Think of the argument as either providing input or accepting
+        output or being used for both input and output.
+        For example, in	\exam{stream_property(S, reposition(Bool))}, the
+        \const{reposition} part of the term provides input and the 
+        unbound-at-call-time \arg{Bool} variable accepts output. \\
+: &	Argument is a \jargon{meta-argument}, for example a term that can be
+        called as goal. The predicate is thus a \jargon{meta-predicate}. This 
+        flag implies \const{+}. \\
+@ &	Argument will not be further instantiated than it is at call-time.
+        Typically used for type tests. \\
 ! &	Argument contains a mutable structure that may be modified using
 	setarg/3 or nb_setarg/3. \\
 \hline
 \end{tabular}
 \end{center}
 
+\textbf{See also}
+
+\begin{itemize}
+   \item \secref{metacall} for examples of meta-predicates, and \secref{metapred} 
+         for mode flags to label meta-predicate arguments in module export
+         declarations. \\
+   \item ``Type, mode and determinism declaration headers'' in the \jargon{PlDoc}
+         part of the manual. \\
+\end{itemize}
+
+
+\subsection{The predicate indicator}            \label{sec:predicate_indic}
 \index{predicate indicator}%
+
 Referring to a predicate in running text is done using a
 \jargon{predicate indicator}. The canonical and most generic form of a
-predicate indicator is a term <module>:<name>/<arity>. If the module is
-irrelevant (built-in predicate) or can be inferred from the context it
-is often omitted. Compliant to the ISO standard draft on DCG (see
-\secref{DCG}), SWI-Prolog also allows for [<module>]:<name>//<arity> to
-refer to a grammar rule. For all non-negative arity, <name>//<arity> is
-the same as <name>/<arity>+2, regardless of whether or not the
-referenced predicate is defined or can be used as a grammar rule.
-The //-notation can be used in all places that traditionally allow
+predicate indicator is a term \exam{[<module>:]<name>/<arity>}. The module is
+generally omitted if it is irrelevant (case of a built-in predicate) or if it 
+can be inferred from context.
+
+\subsection{The non-terminal indicator}         \label{sec:nonterminal_indic}
+\index{non-terminal indicator}%
+
+Compliant to the ISO standard draft (but well-established practice) on Definite
+Clause Grammars (see \secref{DCG}), SWI-Prolog also allows for the
+\jargon{non-terminal indicator} to refer to a \jargon{DCG grammar rule}. 
+The non-terminal indicator is written as \exam{[<module>]:<name>//<arity>}.
+
+For any arity larger or equal to 0, \exam{<name>//<arity>} is understood
+to be equivalent to \exam{<name>/<arity>+2}, regardless of whether or not the
+referenced predicate is defined or can be used as a grammar rule.%
+\footnote{This, however, makes a specific assumption about the implementation
+of DCG rules, namely that DCG rules are preprocessed into standard Prolog
+rules taking two additional arguments, the input list and the output list,
+in accumulator style. This \emph{need} not be true in all implementations.} %
+The \const{//}-notation can be used in all places that traditionally allow
 for a predicate indicator, e.g., the module declaration, spy/1,
 and dynamic/1.
 
+\subsection{Predicate behaviour and determinism} \label{sec:determinism}
+\index{predicate behaviour and determinism}%
+
+To describe the general behaviour of a predicate, the following vocabulary
+is employed. In source code, structured comments contain the corresponding
+keywords:
+
+\begin{center}
+\begin{tabular}{lp{0.7\linewidth}}
+\hline
+\const{det} &  	  A \jargon{deterministic} predicate always succeeds exactly
+                  once. Performing a \jargon{redo} means moving leftwards to the 
+                  predicate preceding or else hitting the clause head. 
+                  If the predicate is \jargon{well-behaved},
+                  it tells the Prolog Processor that there indeed are no 
+                  alternative solutions after the first one (``it leaves no 
+                  choicepoints''). Programmatically, this is implemented by a
+                  cut found at the very end of the predicate's clause.
+                  On the Prolog Toplevel, a
+                  deterministic, well-behaved predicate will always only 
+                  say \const{true}. and not accept a \const{;} for more solutions.
+                  Generally, predicates of this kind perform side-effects, I/O
+                  and control. Example: true/0.\\
+\const{semidet} & A \jargon{semi-deterministic} predicate succeeds at most
+                  once. In case of success, behaviour and well-behaved behaviour
+                  are as described for the case of a deterministic predicate.
+                  On the Prolog Toplevel, a well-behaved semi-deterministic 
+                  predicate will either say \const{true} or \const{false}
+                  and not accept a \const{;} for more solutions. Example:
+                  memberchk/2.\\
+\const{nondet}  & A \jargon{non-deterministic} predicate may fail or 
+                  succeed and provide an arbitrary number of additional solutions
+                  on \jargon{redo}. 
+                  This is the most general situation. The predicate may
+                  additionally provide \jargon{determinism on the last solution}, i.e.
+                  leave no choicepoints after the last success. Whether that
+                  is possible depends. Consider a call to the nondeterministic
+                  predicate member/2. 
+                  For the goal \exam{member(foo,[foo,2,3,foo])}, the predicate will
+                  provide determinism on the last solution. For the goal
+                  \exam{member(foo,[foo,2,3,4])} it will not: there is no
+                  way that the predicate can know there is no further \const{foo}
+                  in the list after the first \const{foo} without performing exhaustive
+                  search, which is only performed on \jargon{redo}.
+\hline
+\end{tabular}
+\end{center}
 
 \section{Character representation}		\label{sec:chars}
 
@@ -2623,7 +2736,7 @@ from \pllib{error}. Termwise, these predicates look exactly like the
 \end{itemlist}
 
 
-\subsection{Printing messages}			\label{sec:printmsg}
+\section{Printing messages}			\label{sec:printmsg}
 
 The predicate print_message/2 is used to print a message term in a
 human-readable format. The other predicates from this section allow the user
@@ -2699,7 +2812,7 @@ The predicate print_message/2 first translates the \arg{Term} into a
 list of `message lines' (see print_message_lines/3 for details). Next,
 it calls the hook message_hook/3 to allow the user to intercept the
 message. If message_hook/3 fails it prints the message unless \arg{Kind}
-is silent.
+is \const{silent}.
 
 The print_message/2 predicate and its rules are in the file
 \file{<plhome>/boot/messages.pl}, which may be inspected for more
@@ -2833,7 +2946,7 @@ using the hook prolog:message//1.  If not defined, it is simply printed.
 \end{description}
 
 
-\subsubsection{Printing from libraries}		\label{sec:libprintmsg}
+\subsection{Printing from libraries}		\label{sec:libprintmsg}
 
 Libraries should \emph{not} use format/3 or other output predicates
 directly. Libraries that print informational output directly to the
@@ -5894,7 +6007,7 @@ current output.
 
     \predicate[semidet]{write_length}{3}{+Term, -Length, +Options}
 True when \arg{Length} is the number of characters emitted for
-\arg{write_term}{Term, Options}.  In addition to valid options for
+\term{write_term}{Term, Options}.  In addition to valid options for
 write_term/2, it processes the option:
 
     \begin{description}


### PR DESCRIPTION
1. Reviewed & extended Section 4.1 "Notation of Predicate Descriptions". In particular:
-  Rewrote the text for mode flags
- Give the description of "predicate indicator" and "non-terminal indicator" their own headings
- Add a section for "determinism" (always a mystery to freshmen and this is probably my 6th revision until I could structure this correctly).
2. Moved section "Printing messages" and "Printing from libraries" _up one level_. Currently they are under section "Exceptions", which is obviously wrong.
3. Two minor typo fixes.
4. Added text to exceptions emphasizing that exceptions say "what would be correct", not "what is wrong" 
5. The adjective "free" is used to describe variables in a few places where "fresh"/"uninstantiated" looks more appropriate. Fixed.
6. Changed the explanation for ground/1 a bit and added a note on anonymous and don't care variables (one of the problems of Prolog-for-beginners is that the expression "the term contains a variable" is exceedingly misleading - indeed, terms contain "holes" and variables name parts of terms, which may or may not be "holes" ... but terms don't contain variables at all, except when represented in written code, which is quite different; I tried to make this cleared in ground/1; it's a bit quixotic)