### PR TITLE
Handle failure inside 'fast' opcodes which D_BREAK replaces with 'slo…

### DIFF
--- a/src/Tests/debug/test_d_break.pl
+++ b/src/Tests/debug/test_d_break.pl
@@ -105,6 +105,8 @@ t_break(i_departatm(_,_,_)) :- @(test:c1(foo),foo).
 t_break(i_callatm(_,_,_)) :- @(test:c1(foo),foo), c1.
 t_break(i_departatmv(_,_,_)) :- Ctx = foo, @(test:c1(Ctx),Ctx).
 t_break(i_callatmv(_,_,_))   :- Ctx = foo, @(test:c1(Ctx),Ctx), c1.
+t_break(c_fastcut) :- A = a, (A == a -> true ; true).
+t_break(c_fastcond) :- A = a, (A == b -> true ; true).
 :- retract(old_optimise(Old)),
    set_prolog_flag(optimise, Old).
 


### PR DESCRIPTION
…w' opcodes that do not trigger FASTCOND_FAILED. To do this, if we hit D_BREAK and there is a fast condition pending, convert it into a real choicepoint

Consider this simple program:
```
foo(X):-
        ( X == 'FOO' ->
            true
        ; true
        ),
        writeln(foo_completed).
```
This compiles to:
```
   0 i_enter
   1 c_fastcond(1,8)
   4 b_eq_vc(0,'FOO')
   7 c_fastcut(1)
   9 i_true
  10 c_jmp(1)
  12 i_true
  13 b_atom(foo_completed)
  15 i_depart(writeln/1)
  17 i_exit
```

If we break on instruction 4, and replace the b_eq_vc with a goal which fails, then the failure will hit BODY_FAILED rather than FASTCOND_FAILED. Since BODY_FAILED does not know about LD->fast_condition, it will try (slow) backtracking, find no choice points, and foo/1 will fail.

This PR contains a proposal to have D_BREAK turn these fast conditions into ordinary choice points if they exist when a D_BREAK is executed. IT also modifies C_FASTCUT to handle the case where this has happened and LD->fast_condition has been cleared