### PR TITLE
CLEANUP: memberchk/2 was still exported from lists.pl

### DIFF
--- a/library/lists.pl
+++ b/library/lists.pl
@@ -35,7 +35,6 @@
 
 :- module(lists,
         [ member/2,                     % ?X, ?List
-          memberchk/2,                  % ?X, ?List
           append/2,                     % +ListOfLists, -List
           append/3,                     % ?A, ?B, ?AB
           prefix/2,                     % ?Part, ?Whole


### PR DESCRIPTION
Looks like memberchk/2 was still being exported though not defined. Noticed this by https://eu.swi-prolog.org/pldoc/doc/_SWI_/library/lists.pl which complains about the undocumented memberchk/2.