### PR TITLE
added prod_list/2

### DIFF
--- a/library/lists.pl
+++ b/library/lists.pl
@@ -62,6 +62,7 @@
 
                                         % Lists of numbers
           sum_list/2,                   % +List, -Sum
+          prod_list/2,                  % +List, -Prod
           max_list/2,                   % +List, -Max
           min_list/2,                   % +List, -Min
           numlist/3,                    % +Low, +High, -List
@@ -551,6 +552,21 @@ sum_list([], Sum, Sum).
 sum_list([X|Xs], Sum0, Sum) :-
     Sum1 is Sum0 + X,
     sum_list(Xs, Sum1, Sum).
+
+%!  prod_list(+List, -Sum) is det.
+%
+%   Prod is the result of multiplying all numbers in List.
+
+prod_list(Xs, Prod) :-
+    prod_list(Xs, 1, Prod).
+
+prod_list([], Prod, Prod).
+prod_list([X|Xs], Prod0, Prod) :-
+    (   X =\= 0 ->
+    	Prod1 is Prod0 * X;
+    	prod_list([],0,Prod)
+    ),
+    prod_list(Xs, Prod1, Prod).
 
 %!  max_list(+List:list(number), -Max:number) is semidet.
 %

--- a/library/lists.pl
+++ b/library/lists.pl
@@ -556,6 +556,8 @@ sum_list([X|Xs], Sum0, Sum) :-
 %!  prod_list(+List, -Prod) is det.
 %
 %   Prod is the result of multiplying all numbers in List.
+%   If List = [], Prod is 1 since it is the neutral 
+%   element of multiplication
 
 prod_list(Xs, Prod) :-
     prod_list(Xs, 1, Prod).

--- a/library/lists.pl
+++ b/library/lists.pl
@@ -553,7 +553,7 @@ sum_list([X|Xs], Sum0, Sum) :-
     Sum1 is Sum0 + X,
     sum_list(Xs, Sum1, Sum).
 
-%!  prod_list(+List, -Sum) is det.
+%!  prod_list(+List, -Prod) is det.
 %
 %   Prod is the result of multiplying all numbers in List.
 
@@ -561,11 +561,9 @@ prod_list(Xs, Prod) :-
     prod_list(Xs, 1, Prod).
 
 prod_list([], Prod, Prod).
+prod_list([0|_],0,0):- !.
 prod_list([X|Xs], Prod0, Prod) :-
-    (   X =\= 0 ->
-    	Prod1 is Prod0 * X;
-    	prod_list([],0,Prod)
-    ),
+    Prod1 is Prod0 * X,
     prod_list(Xs, Prod1, Prod).
 
 %!  max_list(+List:list(number), -Max:number) is semidet.


### PR DESCRIPTION
Since i often do artithmetic operations in Prolog, i've added the predicate prod_list/2 that computes the product of the elements of a list. Its implementation is intuitive. If the list is empty, i've opted to set the result to 1 since 1 is the neutral element of multiplication.