### PR TITLE
DOC: Correct examples for rational numbers

### DIFF
--- a/customize/init.pl
+++ b/customize/init.pl
@@ -153,7 +153,7 @@ hooks, file_search_path/2, set_prolog_flag/2 and portray/1.
 
 % As of version 8.1.22 SWI-Prolog  provides   native  support for proper
 % atomic rational nubers. This is controlled by the two flags below. The
-% default  is  conservative,  supporting  rationals  as  `1R3`  and  use
+% default  is  conservative,  supporting  rationals  as  `1r3`  and  use
 % floating point numbers for integer   divisions  and exponentation with
 % negative exponent (e.g., `2^(-2)`).
 %

--- a/man/overview.doc
+++ b/man/overview.doc
@@ -1774,7 +1774,7 @@ values are \const{natural} (e.g., \exam{1/3}) or \const{compatibility}
 This flag is module sensitive.
 
 The default for this flag is currently \const{compatibility}, which
-reads and writes rational numbers as e.g., \exam{1R3}.\footnote{There is
+reads and writes rational numbers as e.g., \exam{1r3}.\footnote{There is
 still some discussion on the separating character. See
 \secref{syntax-rational-numbers}.} We will consider \const{natural} as a
 default in the future. Users are strongly encouraged to set this flag to


### PR DESCRIPTION
After reading carefully through the discussions of rational numbers [here](https://swi-prolog.discourse.group/t/proper-rational-numbers-prototype-for-testing-discussion/3161/75), [here](https://swi-prolog.discourse.group/t/ann-swi-prolog-8-1-22/1867?u=fnogatz) and [here](https://github.com/SWI-Prolog/swipl-devel/issues/539), I came to the conclusion that the consensus about the syntax for rational numbers in SWI-Prolog is `1r3` instead of the formerly discussed `1R3`. At least, the latter always throws a syntax error ;)

I therefore suggest to correct the documentation accordingly :grinning: I checked via `grep -R '[1-9]R[1-9]'`, these seem to be the only occurrences of the legacy syntax with the uppercase `R`.