### PR TITLE
FIXED:  Using `map/1` option in `qsave_program/2` no longer causes "Format error: too many arguments"

### DIFF
--- a/library/qsave.pl
+++ b/library/qsave.pl
@@ -757,7 +757,7 @@ save_records :-
     feedback('~nRECORDS~n', []),
     (   current_key(X),
         X \== '$topvar',                        % do not safe toplevel variables
-        feedback('~n~t~8|~w ', [X, V]),
+        feedback('~n~t~8|~w ', [X]),
         recorded(X, V, _),
         feedback('.', []),
         '$add_directive_wic'(recordz(X, V, _)),


### PR DESCRIPTION
Fixes "Format error: too many arguments" when `qsave_program/2` uses `map/1` option