### PR TITLE
Operator-related fixes to SICStus emulation

### DIFF
--- a/library/dialect/sicstus.pl
+++ b/library/dialect/sicstus.pl
@@ -58,7 +58,11 @@
 	    prolog_flag/3,		% +Flag, -Old, +New
 	    prolog_flag/2,		% +Flag, -Value
 
-	    op(1150, fx, (block))
+	    op(1150, fx, (block)),
+	    op(1150, fx, (mode)),
+	    op(1100, xfy, (do)),
+	    op(900, fy, (spy)),
+	    op(900, fy, (nospy))
 	  ]).
 
 :- use_module(sicstus/block).
@@ -82,6 +86,14 @@ effect until the end of the file and in each file loaded from this file.
 @tbd	The dialect-compatibility packages are developed in a
 	`demand-driven' fashion.  Please contribute to this package.
 */
+
+% SICStus built-in operators that SWI doesn't declare by default.
+% Note: Although the do operator is declared here, do loops currently
+% aren't emulated by library(dialect/sicstus).
+:- op(1150, fx, user:(mode)).
+:- op(1100, xfy, user:(do)).
+:- op(900, fy, user:(spy)).
+:- op(900, fy, user:(nospy)).
 
 :- multifile
 	system:goal_expansion/2.

--- a/library/dialect/sicstus.pl
+++ b/library/dialect/sicstus.pl
@@ -119,8 +119,8 @@ push_sicstus_library :-
 
 %	declare all operators globally
 
-system:goal_expansion(op(Pri,Ass,Name),
-		      op(Pri,Ass,user:Name)) :-
+user:goal_expansion(op(Pri,Ass,Name),
+		    op(Pri,Ass,user:Name)) :-
 	\+ qualified(Name),
 	prolog_load_context(dialect, sicstus).
 
@@ -453,7 +453,7 @@ sicstus_flag(Name, Value) :-
 % could also consider adding # internally, but not turning it into an
 % operator.
 
-:- op(500, yfx, #).
+:- op(500, yfx, user:(#)).
 
 :- arithmetic_function(user:(#)/2).
 :- arithmetic_function(user:(\)/2).

--- a/library/dialect/sicstus.pl
+++ b/library/dialect/sicstus.pl
@@ -127,6 +127,14 @@ user:goal_expansion(op(Pri,Ass,Name),
 qualified(Var) :- var(Var), !, fail.
 qualified(_:_).
 
+% Import all operators from a module, even when using an explicit list
+% of imports. This simulates the SICStus behavior, where operators are
+% not module-sensitive and don't need to be listed in import lists.
+
+user:goal_expansion(use_module(Module,Imports),
+		    use_module(Module,[op(_,_,_)|Imports])) :-
+	% Prevent infinite recursion.
+	\+ memberchk(op(_,_,_),Imports).
 
 %%	setup_dialect
 %

--- a/library/dialect/sicstus/block.pl
+++ b/library/dialect/sicstus/block.pl
@@ -47,6 +47,8 @@ freeze/2 for simple cases).
 @tbd	This emulation is barely tested.
 */
 
+:- op(1150, fx, user:(block)).
+
 :- multifile
 	user:term_expansion/2,
 	block_declaration/2.		% Head, Module


### PR DESCRIPTION
Mostly fixes #731.

I've also added declarations for a few missing SICStus built-in operators. `mode` is probably the most useful one here. `spy` and `nospy` probably aren't used much in actual code, but it can't hurt to have them declared. The `do` declaration isn't all that useful, because the actual functionality of `do` loops isn't implemented, but this way they can at least be parsed.