### PR TITLE
Add initial SICStus 4 emulation (split from existing SICStus 3 emulation)

### DIFF
--- a/library/dialect/sicstus.pl
+++ b/library/dialect/sicstus.pl
@@ -60,7 +60,6 @@
 
 	    op(1150, fx, (block)),
 	    op(1150, fx, (mode)),
-	    op(1100, xfy, (do)),
 	    op(900, fy, (spy)),
 	    op(900, fy, (nospy))
 	  ]).
@@ -73,25 +72,25 @@
 :- use_module(library(arithmetic)).
 
 
-/** <module> SICStus compatibility library
+/** <module> SICStus 3 compatibility library
 
 This library is intended to be activated   using  the directive below in
-files that are designed for use with  SICStus Prolog. The changes are in
+files that are designed for use with SICStus Prolog 3. The changes are in
 effect until the end of the file and in each file loaded from this file.
 
     ==
     :- expects_dialect(sicstus).
     ==
 
+This library only provides compatibility with version 3 of SICStus Prolog.
+For SICStus Prolog 4 compatibility, use library(dialect/sicstus4) instead.
+
 @tbd	The dialect-compatibility packages are developed in a
 	`demand-driven' fashion.  Please contribute to this package.
 */
 
 % SICStus built-in operators that SWI doesn't declare by default.
-% Note: Although the do operator is declared here, do loops currently
-% aren't emulated by library(dialect/sicstus).
 :- op(1150, fx, user:(mode)).
-:- op(1100, xfy, user:(do)).
 :- op(900, fy, user:(spy)).
 :- op(900, fy, user:(nospy)).
 
@@ -134,7 +133,7 @@ push_sicstus_library :-
 user:goal_expansion(op(Pri,Ass,Name),
 		    op(Pri,Ass,user:Name)) :-
 	\+ qualified(Name),
-	prolog_load_context(dialect, sicstus).
+	(prolog_load_context(dialect, sicstus) ; prolog_load_context(dialect, sicstus4)).
 
 qualified(Var) :- var(Var), !, fail.
 qualified(_:_).
@@ -164,7 +163,7 @@ setup_dialect.
 
 system:goal_expansion(if(If,Then,Else),
 		      (If *-> Then ; Else)) :-
-	prolog_load_context(dialect, sicstus),
+	(prolog_load_context(dialect, sicstus) ; prolog_load_context(dialect, sicstus4)),
 	\+ (sub_term(X, [If,Then,Else]), X == !).
 
 %%	if(:If, :Then, :Else)
@@ -260,7 +259,7 @@ system:term_expansion(
 	   [ (:- module(Name, Exports))
 	   | Declarations
 	   ]) :-
-	prolog_load_context(dialect, sicstus),
+	(prolog_load_context(dialect, sicstus) ; prolog_load_context(dialect, sicstus4)),
 	phrase(sicstus_module_decls(Options), Declarations).
 
 sicstus_module_decls([]) --> [].
@@ -476,11 +475,8 @@ sicstus_flag(Name, Value) :-
 :- op(500, yfx, user:(#)).
 
 :- arithmetic_function(user:(#)/2).
-:- arithmetic_function(user:(\)/2).
 
-user:(#(X,Y,R)) :-				% SICStus 3
-	R is xor(X,Y).
-user:(\(X,Y,R)) :-				% SICStus 4
+user:(#(X,Y,R)) :-
 	R is xor(X,Y).
 
 

--- a/library/dialect/sicstus/arrays.pl
+++ b/library/dialect/sicstus/arrays.pl
@@ -43,11 +43,12 @@
 	  ]).
 :- use_module(library(rbtrees)).
 
-/** <module> SICStus 3 compatible array-library
+/** <module> SICStus 3-compatible library(arrays).
 
-@deprecated library(arrays) is dropped from SICStus
+@deprecated library(arrays) has been removed in SICStus 4.
 @compat	    This library builds on library(rbtrees) and therefore the
 	    internal representation differs from the SICStus implementation.
+@see	    https://sicstus.sics.se/sicstus/docs/3.12.11/html/sicstus/Arrays.html
 */
 
 

--- a/library/dialect/sicstus/block.pl
+++ b/library/dialect/sicstus/block.pl
@@ -45,6 +45,7 @@ implementation through a coroutining primitive   (typically  when/2, but
 freeze/2 for simple cases).
 
 @tbd	This emulation is barely tested.
+@see	https://sicstus.sics.se/sicstus/docs/3.12.11/html/sicstus/Block-Declarations.html
 */
 
 :- op(1150, fx, user:(block)).

--- a/library/dialect/sicstus/lists.pl
+++ b/library/dialect/sicstus/lists.pl
@@ -66,6 +66,20 @@
 
 sicstus:rename_module(lists, sicstus_lists).
 
+/** <module> SICStus 3-compatible library(lists).
+
+@tbd	This library is incomplete.
+	As of SICStus 3.12.11, the following predicates are missing:
+
+	* no_doubles/1
+	* non_member/2
+	* remove_duplicates/2
+	* same_length/3
+	* suffix/2
+
+@see	https://sicstus.sics.se/sicstus/docs/3.12.11/html/sicstus/Lists.html
+*/
+
 %%	substitute(+OldElem, +List, +NewElem, -NewList) is det.
 %
 %	NewList is as List with all value that are identical (==) to OldElem

--- a/library/dialect/sicstus/lists.pl
+++ b/library/dialect/sicstus/lists.pl
@@ -34,8 +34,15 @@
 
 :- module(sicstus_lists,
 	  [ substitute/4,		% +Elem, +List, +NewElem, -List
-	    nth/3,
-	    sublist/2			% ?Sub, +List
+	    nth/3,			% ?N, ?List, ?Element
+	    nth/4,			% ?N, ?List, ?Element, ?Rest
+	    sublist/2,			% ?Sub, +List
+
+	    % The following predicates are built-in on SWI.
+	    % We re-export them here to avoid warnings
+	    % when SICStus code explicitly imports them from library(lists).
+	    is_list/1,			% +Term
+	    memberchk/2			% +Element, +List
 	  ]).
 :- reexport('../../lists').
 
@@ -69,6 +76,17 @@ substitute_([O|T0], Old, New, [V|T]) :-
 
 nth(Index, List, Element) :-
 	nth1(Index, List, Element).
+
+
+%%	nth(?Index, ?List, ?Element, ?Rest) is nondet.
+%
+%	True if Element is the N-th element in List and Rest is the
+%	remainder (as if by select/3) of List. Counting starts at 1.
+%
+%	@deprecated use nth1/4.
+
+nth(Index, List, Element, Rest) :-
+	nth1(Index, List, Element, Rest).
 
 
 %%	sublist(?Sub, +List)

--- a/library/dialect/sicstus/lists.pl
+++ b/library/dialect/sicstus/lists.pl
@@ -44,7 +44,23 @@
 	    is_list/1,			% +Term
 	    memberchk/2			% +Element, +List
 	  ]).
-:- reexport('../../lists').
+:- reexport('../../lists',
+	    [ append/3,
+	      delete/3,
+	      last/2,
+	      max_list/2,
+	      member/2,
+	      min_list/2,
+	      nextto/3,
+	      nth0/3,
+	      nth0/4,
+	      permutation/2,
+	      prefix/2,
+	      reverse/2,
+	      same_length/2,
+	      select/3,
+	      sum_list/2
+	    ]).
 
 :- multifile sicstus:rename_module/2.
 

--- a/library/dialect/sicstus/sockets.pl
+++ b/library/dialect/sicstus/sockets.pl
@@ -56,10 +56,10 @@
 
 sicstus:rename_module(sockets, sicstus_sockets).
 
-/** <module> SICStus compatible socket library
+/** <module> SICStus 3-compatible library(sockets).
 
 @tbd Our implementation does not support AF_UNIX sockets.
-@see http://www.sics.se/sicstus/docs/3.7.1/html/sicstus_28.html
+@see https://sicstus.sics.se/sicstus/docs/3.12.11/html/sicstus/Sockets.html
 */
 
 socket(Domain, Socket) :-

--- a/library/dialect/sicstus/system.pl
+++ b/library/dialect/sicstus/system.pl
@@ -72,11 +72,19 @@
 
 sicstus:rename_module(system, sicstus_system).
 
-/** <module> SICStus-3 library system
+/** <module> SICStus 3-compatible library(system).
 
+@tbd	This library is incomplete.
+	As of SICStus 3.12.11, the following predicates are missing:
 
+	* delete_file/2
+	* directory_files/2
+	* file_exists/2
+	* file_property/2
+	* host_id/1
+	* kill/2
 
-@tbd	This library is incomplete
+@see	https://sicstus.sics.se/sicstus/docs/3.12.11/html/sicstus/System-Utilities.html
 */
 
 %%	environ(?Name, ?Value) is nondet.

--- a/library/dialect/sicstus/system.pl
+++ b/library/dialect/sicstus/system.pl
@@ -81,10 +81,17 @@ sicstus:rename_module(system, sicstus_system).
 
 %%	environ(?Name, ?Value) is nondet.
 %
-%	True if Value an atom associated   with the environment variable
-%	Name.
+%	True if Value is an atom associated with the environment variable
+%	or system property Name.
 %
-%	@tbd	Mode -Name is not supported
+%	@tbd	Mode -Name is not supported.
+%
+%		Because SWI-Prolog doesn't have an obvious equivalent to
+%		SICStus system properties, this predicate currently
+%		behaves as if no system properties are defined,
+%		i. e. only environment variables are returned.
+%
+%	@compat sicstus
 
 environ(Name, Value) :-
 	getenv(Name, Value).

--- a/library/dialect/sicstus/terms.pl
+++ b/library/dialect/sicstus/terms.pl
@@ -41,6 +41,11 @@
 
 sicstus:rename_module(terms, sicstus_terms).
 
+/** <module> SICStus 3-compatible library(terms).
+
+@see	https://sicstus.sics.se/sicstus/docs/3.12.11/html/sicstus/Term-Utilities.html
+*/
+
 %%	term_variables_bag(+Term, -Variables) is det.
 %
 %	Variables is a list  of  variables   that  appear  in  Term. The

--- a/library/dialect/sicstus/terms.pl
+++ b/library/dialect/sicstus/terms.pl
@@ -44,9 +44,9 @@ sicstus:rename_module(terms, sicstus_terms).
 %%	term_variables_bag(+Term, -Variables) is det.
 %
 %	Variables is a list  of  variables   that  appear  in  Term. The
-%	variables are ordered according to depth-first lef-right walking
+%	variables are ordered according to depth-first left-right walking
 %	of the term. Variables contains no  duplicates. This is the same
-%	as SWI-Prolog's term_variables.
+%	as SWI-Prolog's term_variables/2.
 
 term_variables_bag(Term, Variables) :-
 	term_variables(Term, Variables).

--- a/library/dialect/sicstus/timeout.pl
+++ b/library/dialect/sicstus/timeout.pl
@@ -38,10 +38,12 @@
 	  ]).
 :- use_module(library(time)).
 
-/** <module> SICStus compatible time out handling
+/** <module> SICStus 3-compatible library(timeout).
 
 @author Ulrich Neumerkel
 @author Jan Wielemaker
+
+@see https://sicstus.sics.se/sicstus/docs/3.12.11/html/sicstus/Timeout.html
 */
 
 :- meta_predicate

--- a/library/dialect/sicstus4.pl
+++ b/library/dialect/sicstus4.pl
@@ -1,0 +1,133 @@
+/*  Part of SWI-Prolog
+
+    WWW:           http://www.swi-prolog.org
+    Copyright (c)  2020, SWI-Prolog Solutions b.v.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in
+       the documentation and/or other materials provided with the
+       distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+
+:- module(sicstus4,
+	  [ op(1100, xfy, (do))
+	  ]).
+:- reexport(sicstus,
+	    [ (block)/1,
+	      if/3,
+	      use_module/3,
+	      bb_put/2,
+	      bb_get/2,
+	      bb_delete/2,
+	      bb_update/3,
+	      create_mutable/2,
+	      get_mutable/2,
+	      update_mutable/2,
+	      read_line/1,
+	      read_line/2,
+	      trimcore/0,
+	      prolog_flag/3,
+	      prolog_flag/2,
+	      op(1150, fx, (block)),
+	      op(1150, fx, (mode)),
+	      op(900, fy, (spy)),
+	      op(900, fy, (nospy))
+	    ]).
+
+/** <module> SICStus 4 compatibility library
+
+This library is intended to be activated using the directive below in
+files that are designed for use with SICStus Prolog 4. The changes are in
+effect until the end of the file and in each file loaded from this file.
+
+    ==
+    :- expects_dialect(sicstus4).
+    ==
+
+This library only provides compatibility with version 4 of SICStus Prolog.
+For SICStus Prolog 3 compatibility, use library(dialect/sicstus) instead.
+
+@tbd	The dialect-compatibility packages are developed in a
+	`demand-driven' fashion. Please contribute to this package.
+*/
+
+% Note: Although the do operator is declared here, do loops currently
+% aren't emulated by library(dialect/sicstus4).
+:- op(1100, xfy, user:(do)).
+
+
+		 /*******************************
+		 *	    LIBRARY SETUP	*
+		 *******************************/
+
+%%	push_sicstus4_library
+%
+%	Pushes searching for dialect/sicstus4 in front of every library
+%	directory that contains such as sub-directory.
+
+push_sicstus4_library :-
+	(   absolute_file_name(library(dialect/sicstus4), Dir,
+			       [ file_type(directory),
+				 access(read),
+				 solutions(all),
+				 file_errors(fail)
+			       ]),
+	    asserta((user:file_search_path(library, Dir) :-
+		    prolog_load_context(dialect, sicstus4))),
+	    fail
+	;   true
+	).
+
+
+:- push_sicstus4_library.
+
+
+		 /*******************************
+		 *	  LIBRARY MODULES	*
+		 *******************************/
+
+%%	rename_module(?SICStus4Module, ?RenamedSICStus4Module) is nondet.
+%
+%	True if RenamedSICStus4Module is the  name  that  we use for the
+%	SICStus 4 native module SICStus4Module. We do this in places where
+%	the module-name conflicts. All explicitly qualified goals are
+%	mapped to the SICStus 4 equivalent of the module.
+
+:- multifile
+	rename_module/2.
+
+system:goal_expansion(M:Goal, SicstusM:Goal) :-
+	atom(M),
+	rename_module(M, SicstusM),
+	prolog_load_context(dialect, sicstus4).
+
+% Provide (\)/2 as arithmetic function.  Ideally, we should be able to
+% bind multiple names to built-in functions.  This is rather slow.  We
+% could also consider adding # internally, but not turning it into an
+% operator.
+
+:- arithmetic_function(user:(\)/2).
+
+user:(\(X,Y,R)) :-
+	R is xor(X,Y).

--- a/library/dialect/sicstus4/lists.pl
+++ b/library/dialect/sicstus4/lists.pl
@@ -1,0 +1,167 @@
+/*  Part of SWI-Prolog
+
+    WWW:           http://www.swi-prolog.org
+    Copyright (c)  2020, SWI-Prolog Solutions b.v.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in
+       the documentation and/or other materials provided with the
+       distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+
+:- module(sicstus4_lists,
+	  [ keys_and_values/3,		% ?Pairs, ?Keys, ?Values
+	    subseq0/2,			% +Sequence, ?SubSequence
+	    subseq1/2,			% +Sequence, ?SubSequence
+	    scanlist/4,			% :Pred, ?Xs, ?V1, ?V
+	    scanlist/5,			% :Pred, ?Xs, ?Ys, ?V1, ?V
+	    scanlist/6,			% :Pred, ?Xs, ?Ys, ?Zs, ?V1, ?V
+	    
+	    % is_list/1 is built-in on SWI.
+	    % We re-export it here to avoid warnings
+	    % when SICStus code explicitly imports it from library(lists).
+	    is_list/1			% +Term
+	  ]).
+:- reexport('../../lists',
+	    [ select/3,
+	      selectchk/3,
+	      append/2,
+	      delete/3,
+	      last/2,
+	      nextto/3,
+	      nth1/3,
+	      nth1/4,
+	      nth0/3,
+	      nth0/4,
+	      permutation/2,
+	      proper_length/2,
+	      reverse/2,
+	      same_length/2,
+	      select/4,
+	      selectchk/4,
+	      prefix/2,
+	      max_member/2,
+	      min_member/2
+	    ]).
+:- reexport('../../apply',
+	    [ maplist/2,
+	      maplist/3,
+	      maplist/4,
+	      convlist/3,
+	      exclude/3,
+	      include/3
+	    ]).
+:- use_module(library(pairs), [pairs_keys_values/3]).
+
+:- multifile sicstus4:rename_module/2.
+
+sicstus4:rename_module(lists, sicstus4_lists).
+
+/** <module> SICStus 4-compatible library(lists).
+
+@tbd	This library is incomplete.
+	As of SICStus 4.6.0, the following predicates are missing:
+
+	* append/5
+	* correspond/4
+	* delete/4
+	* one_longer/2
+	* perm/2
+	* perm2/4
+	* remove_dups/2
+	* rev/2
+	* same_length/3
+	* shorter_list/2
+	* sumlist/2
+	* transpose/2
+	* append_length/[3,4]
+	* prefix_length/3
+	* proper_prefix_length/3
+	* suffix_length/3
+	* proper_suffix_length/3
+	* rotate_list/[2,3]
+	* sublist/[3,4,5]
+	* cons/3
+	* last/3
+	* head/2
+	* tail/2
+	* proper_prefix/2
+	* suffix/2
+	* proper_suffix/2
+	* segment/2
+	* proper_segment/2
+	* cumlist/[4,5,6]
+	* map_product/4
+	* some/[2,3,4]
+	* somechk/[2,3,4]
+	* exclude/[4,5]
+	* include/[4,5]
+	* partition/5
+	* group/[3,4,5]
+	* ordered/[1,2]
+	* max_member/3
+	* min_member/3
+	* select_min/[3,4]
+	* select_max/[3,4]
+	* increasing_prefix/[3,4]
+	* decreasing_prefix/[3,4]
+	* clumps/2
+	* keyclumps/2
+	* clumped/2
+	* keyclumped/2
+
+@see	https://sicstus.sics.se/sicstus/docs/4.6.0/html/sicstus.html/lib_002dlists.html
+*/
+
+keys_and_values(Pairs, Keys, Values) :-
+	pairs_keys_values(Pairs, Keys, Values).
+
+
+%%	scanlist(:Pred, ?Xs, ?V1, ?V) is nondet.
+%%	scanlist(:Pred, ?Xs, ?Ys, ?V1, ?V) is nondet.
+%%	scanlist(:Pred, ?Xs, ?Ys, ?Zs, ?V1, ?V) is nondet.
+%
+%	Same as foldl/[4,5,6].
+%
+%	@compat SICStus 4
+
+:- meta_predicate scanlist(3, ?, ?, ?).
+scanlist(Pred, Xs, V1, V) :- foldl(Pred, Xs, V1, V).
+:- meta_predicate scanlist(4, ?, ?, ?, ?).
+scanlist(Pred, Xs, Ys, V1, V) :- foldl(Pred, Xs, Ys, V1, V).
+:- meta_predicate scanlist(5, ?, ?, ?, ?, ?).
+scanlist(Pred, Xs, Ys, Zs, V1, V) :- foldl(Pred, Xs, Ys, Zs, V1, V).
+
+
+subseq(Sequence, [], Sequence).
+subseq([Head|Tail], [Head|SubTail], Complement) :-
+	subseq(Tail, SubTail, Complement).
+subseq([Head|Tail], SubSequence, [Head|Complement]) :-
+	subseq(Tail, SubSequence, Complement).
+
+
+subseq0(Sequence, SubSequence) :- subseq(Sequence, SubSequence, _).
+subseq1(Sequence, SubSequence) :-
+	subseq(Sequence, SubSequence, Complement),
+	Complement \== [].

--- a/library/dialect/sicstus4/system.pl
+++ b/library/dialect/sicstus4/system.pl
@@ -1,0 +1,80 @@
+/*  Part of SWI-Prolog
+
+    WWW:           http://www.swi-prolog.org
+    Copyright (c)  2020, SWI-Prolog Solutions b.v.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in
+       the documentation and/or other materials provided with the
+       distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+
+:- module(sicstus4_system,
+	  [ environ/2,			% ?Name, ?Value
+	    environ/3			% ?Name, ?Value, +Source
+	  ]).
+:- reexport('../sicstus/system',
+	    [ now/1,
+	      datime/1,
+	      datime/2,
+	      sleep/1
+	    ]).
+
+:- multifile sicstus4:rename_module/2.
+
+sicstus4:rename_module(system, sicstus4_system).
+
+/** <module> SICStus 4-compatible library(system).
+
+@see	https://sicstus.sics.se/sicstus/docs/4.6.0/html/sicstus.html/lib_002dsystem.html
+*/
+
+%%	environ(?Name, ?Value) is nondet.
+%%	environ(?Name, ?Value, +Source) is nondet.
+%
+%	True if Value is an atom associated with the environment variable
+%	or system property Name.
+%
+%	Source may be =properties= (to get only system properties),
+%	=environment= (to get only environment variables),
+%	or =merged= (the default, to get both, with system properties
+%	taking precedence over environment variables of the same name).
+%
+%	@tbd	Mode -Name is not supported.
+%
+%		Because SWI-Prolog doesn't have an obvious equivalent to
+%		SICStus system properties, these predicates currently
+%		behave as if no system properties are defined,
+%		i. e. only environment variables are returned.
+%
+%	@compat SICStus 4
+
+environ(_Name, _Value, properties) :- fail.
+environ(Name, Value, environment) :- getenv(Name, Value).
+environ(Name, Value, mixed) :-
+	(   environ(Name, Value, properties)
+	->  true
+	;   environ(Name, Value, environment)
+	).
+environ(Name, Value) :- environ(Name, Value, mixed).

--- a/library/dialect/sicstus4/terms.pl
+++ b/library/dialect/sicstus4/terms.pl
@@ -1,0 +1,111 @@
+/*  Part of SWI-Prolog
+
+    WWW:           http://www.swi-prolog.org
+    Copyright (c)  2020, SWI-Prolog Solutions b.v.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in
+       the documentation and/or other materials provided with the
+       distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+
+:- module(sicstus4_terms,
+	  [ term_variables_set/2,	% @Term, -Variables
+	    subsumeschk/2,		% +Generic, @Specific
+	    term_order/3,		% @X, @Y, -R
+	    same_functor/2,		% ?T1, ?T2
+	    same_functor/3,		% ?T1, ?T2, ?N
+	    same_functor/4		% ?T1, ?T2, ?F, ?N
+	  ]).
+:- reexport('../sicstus/terms').
+
+:- multifile sicstus4:rename_module/2.
+
+sicstus4:rename_module(terms, sicstus4_terms).
+
+/** <module> SICStus 4-compatible library(terms).
+
+@tbd	This library is incomplete.
+	As of SICStus 4.6.0, the following predicates are missing:
+
+	* term_hash/3
+	* contains_term/2
+	* free_of_term/2
+	* occurrences_of_term/2
+	* contains_var/2
+	* free_of_var/2
+	* occurrences_of_var/2
+	* sub_term/2
+	* depth_bound/2
+	* length_bound/2
+	* size_bound/2
+	* term_depth/2
+	* term_size/2
+
+@see	https://sicstus.sics.se/sicstus/docs/4.6.0/html/sicstus.html/lib_002dterms.html
+*/
+
+%%	term_variables_set(@Term, -Variables) is det.
+%
+%	Same as term_variables_bag/2, but Variables is an ordered set.
+
+term_variables_set(Term, Variables) :-
+	term_variables(Term, VariablesBag),
+	sort(VariablesBag, Variables).
+
+%%	subsumeschk(+Generic, @Specific) is semidet.
+%
+%	SICStus 4 name of subsumes_chk/2.
+%
+%	@deprecated Replace by subsumes_term/2.
+
+subsumeschk(Generic, Specific) :- subsumes_chk(Generic, Specific).
+
+%%	term_order(@X, @Y, -R) is det.
+%
+%	Same as compare/3, except for the order of arguments.
+%
+%	@deprecated Use the standard compare/3 instead.
+
+term_order(X, Y, R) :- compare(R, X, Y).
+
+%%	same_functor(?T1, ?T2) is semidet.
+%%	same_functor(?T1, ?T2, ?N) is semidet.
+%%	same_functor(?T1, ?T2, ?F, ?N) is semidet.
+%
+%	True if T1 and T2 have the same functor F and arity N.
+%	Any unbound arguments will be computed from the bound arguments if possible.
+%	At least one of T1, T2, or both F and N must be bound,
+%	otherwise an error is thrown.
+
+same_functor(T1, T2) :- same_functor(T1, T2, _, _).
+same_functor(T1, T2, N) :- same_functor(T1, T2, _, N).
+same_functor(T1, T2, F, N) :-
+	nonvar(T1),
+	!,
+	functor(T1, F, N),
+	functor(T2, F, N).
+same_functor(T1, T2, F, N) :-
+	functor(T2, F, N),
+	functor(T1, F, N).

--- a/library/dialect/sicstus4/timeout.pl
+++ b/library/dialect/sicstus4/timeout.pl
@@ -1,0 +1,43 @@
+/*  Part of SWI-Prolog
+
+    WWW:           http://www.swi-prolog.org
+    Copyright (c)  2020, SWI-Prolog Solutions b.v.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in
+       the documentation and/or other materials provided with the
+       distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+
+:- module(sicstus4_timeout, []).
+:- reexport('../sicstus/timeout').
+
+:- multifile sicstus4:rename_module/2.
+
+sicstus4:rename_module(timeout, sicstus4_timeout).
+
+/** <module> SICStus 4-compatible library(timeout).
+
+@see	https://sicstus.sics.se/sicstus/docs/4.6.0/html/sicstus/lib_002dtimeout.html
+*/

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,7 +98,7 @@ set(SWIPL_DATA_DIRS
     boot
     ${SWIPL_DATA_INDEXED_DIRS}
     library/dialect library/dialect/swi library/dialect/eclipse
-    library/dialect/hprolog library/dialect/sicstus library/dialect/iso
+    library/dialect/hprolog library/dialect/sicstus library/dialect/sicstus4 library/dialect/iso
     library/dialect/yap library/dialect/xsb library/theme library/iri_scheme
     demo)
 
@@ -167,13 +167,14 @@ set(SWIPL_DATA_library_dcg basics.pl high_order.pl)
 set(SWIPL_DATA_library_unicode blocks.pl unicode_data.pl)
 
 set(SWIPL_DATA_library_dialect bim.pl commons.pl hprolog.pl ifprolog.pl
-    sicstus.pl yap.pl xsb.pl)
+    sicstus.pl sicstus4.pl yap.pl xsb.pl)
 
 set(SWIPL_DATA_library_dialect_swi syspred_options.pl)
 set(SWIPL_DATA_library_dialect_eclipse test_util_iso.pl)
 set(SWIPL_DATA_library_dialect_hprolog format.pl)
 set(SWIPL_DATA_library_dialect_sicstus arrays.pl block.pl lists.pl
     README.TXT sockets.pl swipl-lfr.pl system.pl terms.pl timeout.pl)
+set(SWIPL_DATA_library_dialect_sicstus4 lists.pl system.pl terms.pl timeout.pl)
 set(SWIPL_DATA_library_dialect_iso iso_predicates.pl)
 set(SWIPL_DATA_library_dialect_yap README.TXT)
 set(SWIPL_DATA_library_dialect_xsb README.md source.pl basics.pl machine.pl


### PR DESCRIPTION
As discussed [on Discourse](https://swi-prolog.discourse.group/t/expects-dialect-sicstus-how-to-handle-sicstus-3-vs-4-api-conflicts/3381), it's not possible to properly emulate SICStus 3 and 4 as a single dialect, because of some API changes that would lead to name conflicts. This PR adds a separate `sicstus4` dialect that emulates just SICStus 4, and moves the few SICStus 4-only features from the `sicstus` dialect to `sicstus4`.

The SICStus 4 emulation reuses/re-exports many parts of the SICStus 3 emulation. I've made small changes to the term/goal expansions in library/dialect/sicstus.pl so that they take effect in both SICStus 3 and 4 mode. It's not very nice that the `sicstus` (3) dialect now has code in it that's only used by the `sicstus4` dialect, but this way the term/goal expansions don't need to be implemented twice.

The SICStus 4 emulation doesn't have many new features yet - it mostly just re-exports the unchanged predicates from the SICStus 3 emulation. I did add a few simple SICStus 4-only predicates in `library(lists)` and `library(terms)`.

The first few commits in this PR are small fixes and comment updates in the SICStus 3 emulation. Some of them are not directly related to the SICStus 4 emulation and are just small issues that I came across while preparing this PR.