### PR TITLE
sequence//3: commit before separator

### DIFF
--- a/library/dcg/high_order.pl
+++ b/library/dcg/high_order.pl
@@ -95,8 +95,15 @@ sequence_([], _) -->
 %
 %   See also sequence//5.
 
-sequence(OnElem, OnSep, List) -->
-    sequence_(List, OnElem, OnSep).
+sequence(OnElem, OnSep, L) --> sequence_1(OnElem, OnSep, L), !.
+sequence(_, _, []) --> [].
+
+sequence_1(OnElem, OnSep, [H|T]) -->
+    call(OnElem, H), !,
+    (
+        (OnSep, sequence_1(OnElem, OnSep, T))
+        ;{T=[]}
+    ).
 
 %!  sequence(:Start, :Element, :Sep, :End, ?List)// is semidet.
 %
@@ -117,42 +124,8 @@ sequence(OnElem, OnSep, List) -->
 
 sequence(Start, OnElem, OnSep, End, List) -->
     Start,
-    sequence_(List, OnElem, OnSep),
+    sequence(OnElem, OnSep, List),
     End, !.
-
-sequence_(List, OnElem, OnSep) -->
-    {var(List)},
-    !,
-    (   call(OnElem, H)
-    *-> (   OnSep
-        ->  !,
-            {List = [H|T]},
-            sequence_as(T, OnElem, OnSep)
-        ;   {List=[H]}
-        )
-    ;   {List=[]}
-    ).
-sequence_([H|T], OnElem, OnSep) -->
-    call(OnElem, H),
-    (   {T==[]}
-    ->  []
-    ;   OnSep,
-        sequence_(T, OnElem, OnSep)
-    ).
-sequence_([], _, _) -->
-    [].
-
-%!  sequence_as(?List, :OnElem, :OnSep)//
-%
-%   Matches: Elem, (Sep,Elem)*
-
-sequence_as([H|T], OnElem, OnSep) -->
-    call(OnElem, H),
-    (   OnSep
-    ->  !,
-        sequence_as(T, OnElem, OnSep)
-    ;   {T=[]}
-    ).
 
 %!  optional(:Match, :Default)// is det.
 %

--- a/src/Tests/library/test_dcg_high_order.pl
+++ b/src/Tests/library/test_dcg_high_order.pl
@@ -92,6 +92,7 @@ test('sequence//3 det element',
                      t(`a`, [a], []),
                      t(`x`, [], `x`),
                      t(`ax`, [a], `x`),
+                     t(`a,a,`, [a,a], `,`),
                      t(`a,a,a`, [a,a,a], ``),
                      t(`a,a,ax`, [a,a,a], `x`)
                     ])),
@@ -101,22 +102,14 @@ test('sequence//3 det element',
     L == Result,
     R == Rest.
 
-test('sequence//3 det element trailing sep', fail) :-
-    phrase(sequence(a, sep, L), `a,`, R),
-    L == [a],
-    R == `,`.
-
-test('sequence//3 det element trailing sep consumed silently', fail) :-
-    phrase(sequence(a, sep, L), `a,`, R),
-    L == [a],
-    R == [].
+test('sequence//3 chaining') :-
+    phrase((sequence(a, sep, [a,a]), sep, sequence(b, sep, [b1,b1])), `a,a,b,b`, []).
 
 test('sequence//3 separator only', fail) :-
     phrase(sequence(a, sep, _L), `,`).
 
 test('sequence//3 nondet element', all(L-R == [
-    [b1,b1]-[],
-    [b1,b2]-[]
+    [b1,b1]-[]
   ])) :-
     phrase(sequence(b, sep, L), `b,b`, R).
 

--- a/src/Tests/library/test_dcg_high_order.pl
+++ b/src/Tests/library/test_dcg_high_order.pl
@@ -114,10 +114,11 @@ test('sequence//3 det element trailing sep consumed silently', fail) :-
 test('sequence//3 separator only', fail) :-
     phrase(sequence(a, sep, _L), `,`).
 
-test('sequence//3 nondet element', nondet) :-
-    phrase(sequence(string, sep, L), `b,b`, R),
-    L == [`b`, `b`],
-    R == [].
+test('sequence//3 nondet element', all(L-R == [
+    [b1,b1]-[],
+    [b1,b2]-[]
+  ])) :-
+    phrase(sequence(b, sep, L), `b,b`, R).
 
 test('sequence//5 det element',
      [forall(member(t(Codes, Result, Rest),
@@ -138,9 +139,9 @@ test('sequence//5 det element trailing sep', fail) :-
 test('sequence//5 sep only', fail) :-
     phrase(sequence(start, a, sep, end, _L), `(,)`, _R).
 
-test('sequence//5 nondet element') :-
-    phrase(sequence(start, string, sep, end, L), `(b,b)`, R),
-    L == [`b`, `b`],
-    R == [].
+test('sequence//5 nondet element', all(L-R == [
+    [b1,b1]-[]
+  ])) :-
+phrase(sequence(start, b, sep, end, L), `(b,b)`, R).
 
 :- end_tests(sequence).


### PR DESCRIPTION
From https://swi-prolog.discourse.group/t/confusing-behavior-of-sequence-3-and-sequence-5-from-dcg-high-order/1607

Saw `ctest` pass.