### PR TITLE
DOC: Correct mode of is/2 from (-,+) to (?,+)

### DIFF
--- a/man/builtin.doc
+++ b/man/builtin.doc
@@ -7642,7 +7642,7 @@ True if expression \arg{Expr1} evaluates to a number non-equal to
 True if expression \arg{Expr1} evaluates to a number equal to \arg{
 Expr2}.
 
-\infixop[ISO]{is}{-Number}{+Expr}
+\infixop[ISO]{is}{?Number}{+Expr}
 True when \arg{Number} is the value to which \arg{Expr} evaluates.
 Typically, is/2 should be used with unbound left operand. If equality is
 to be tested, \predref{=:=}{2} should be used. For example:


### PR DESCRIPTION
See ISO-Prolog standard Sec. 8.1.6.2. The point that the first argument should *usually* be a free variable is clarified enough by the documentation, IMO. Related doc page: https://www.swi-prolog.org/pldoc/doc_for?object=(is)/2