### PR TITLE
Update README.md: Grammar and Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ## Forking, cloning and submitting patches
 
-This repositories uses many [Git
-submodules](https://git-scm.com/book/en/v1/Git-Tools-Submodules). This
+This repository uses many [Git
+submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules). This
 causes the common issue that __fork and clone doesn't work__. Instead, _clone_ from
 https://github.com/SWI-Prolog/swipl-devel.git and then associate your
 clone with your _fork_ (replace `me` with your github user name).
@@ -13,7 +13,7 @@ clone with your _fork_ (replace `me` with your github user name).
     git submodule update --init
     git remote add myfork git@github.com:me/swipl-devel.git
 
-See [How to submit a patch](http://www.swi-prolog.org/howto/SubmitPatch.html)
+See [How to submit a patch](https://www.swi-prolog.org/howto/SubmitPatch.html)
 for details.
 
 See also the discussion at
@@ -23,13 +23,13 @@ See also the discussion at
 
 See
 [CMAKE.md](https://github.com/SWI-Prolog/swipl-devel/blob/master/CMAKE.md)
-and [Build SWI-Prolog from source](http://www.swi-prolog.org/build/)
+and [Build SWI-Prolog from source](https://www.swi-prolog.org/build/)
 
 
 ## Web home
 
 Please find the up-to-date information on SWI-Prolog at
-http://www.swi-prolog.org.
+https://www.swi-prolog.org.
 
 ## Documentation
 
@@ -41,7 +41,7 @@ Documentation is available from several locations and in several formats.
   page](http://www.swi-prolog.org/download/devel).
 
   - Several tutorials can be accessed from the __Tutorials__ menu on
-  the [home page](http://www.swi-prolog.org)
+  the [home page](https://www.swi-prolog.org)
 
   - A HTML version of the documentation is in the `doc/Manual` directory
   of the installation.  Note that some packagers put this documentation


### PR DESCRIPTION
Minor changes for `README.md`:
- Correct grammar
- Update link to latest Pro Git book version
- Use https for links to swi-prolog.org