### PR TITLE
Reimplement SICStus `block` emulation using attvars to add custom goal representation

### DIFF
--- a/library/dialect/sicstus/block.pl
+++ b/library/dialect/sicstus/block.pl
@@ -236,19 +236,6 @@ triggers_goals([block_trigger(TriggerVar, BlockedGoal)|MoreTriggers]) -->
 	triggers_goals(MoreTriggers).
 
 
-block_wrapper((_Head :- GenBody)) :-
-	block_wrapper_body(GenBody).
-
-block_wrapper_body((var(_), MoreBody)) :-
-	!,
-	block_wrapper_body(MoreBody).
-block_wrapper_body((!, freeze(_, Wrapped), _)) :-
-	!,
-	compound(Wrapped),
-	functor(Wrapped, Name, _),
-	sub_atom(Name, 0, _, _, 'block ').
-
-
 %%	rename_clause(+Clause, +Prefix, -Renamed) is det.
 %
 %	Rename a clause by prefixing its old name wit h Prefix.
@@ -272,6 +259,5 @@ system:term_expansion((:- block(Spec)), Clauses) :-
 system:term_expansion(Term, Wrapper) :-
 	head(Term, Module:Head),
 	block_declaration(Head, Module),
-	\+ block_wrapper(Term),		% avoid recursion
 	wrap_block(Module:Head, Term, Wrapper).
 


### PR DESCRIPTION
On SICStus, blocked goals automatically have a nice representation in the toplevel and when returned from `frozen/2`, etc.:

```prolog
| ?- [user].
% compiling user...
| :- block foo(-).
| foo(X) :- format("unblocked! ~w~n", [X]).
| ^D
% compiled user in module user, 12 msec 37696 bytes
yes
| ?- foo(X).
user:foo(X) ? ;
no
| ?- foo(X), frozen(X, Goal).
Goal = user:foo(X),
user:foo(X) ? ;
no
```

SWI's `block` emulation as part of `expects_dialect(sicstus)` currently doesn't handle this - because `block` declarations are translated to wrapper predicates based on `freeze/2` or `when/2`, blocked goals are rendered as these generated `freeze`/`when` calls:

```prolog
?- expects_dialect(sicstus4).
true.

?- [user].
|: :- block foo(-).
|: foo(X) :- format("unblocked! ~w~n", [X]).
|: ^D% user://1 compiled 0.03 sec, 4 clauses
true.

?- foo(X).
freeze(X, 'block foo'(X)).

?- foo(X), frozen(X, Goal).
Goal = freeze(X, user:'block foo'(X)),
freeze(X, 'block foo'(X)).
```

In the toplevel this is a bit annoying, but not a huge problem - the `freeze`/`when` form is verbose, but readable enough. It's a bigger issue when looking up blocked goals programmatically. On SICStus, it's easy to use `frozen/2` to find out which goals are blocked on a certain variable, and to use that information to e. g. detect incompatible blocked goals early (for simple custom constraint solving, basically). With SWI's `block` emulation, there's no good way to do this currently - the closest solution is to look for `frozen`/`when` terms with a `'block ...'` compound in the second argument, but that would be very dependent on implementation details of the `block` emulation, which I'd like to avoid.

This PR reimplements the `block` emulation using attvars, so that it can define a custom `attribute_goals//1` for variables on which goals are blocked. This implementation seems to work for my purposes, although I haven't tested it *too* extensively yet. Also, I wrote this implementation before I properly looked into how SWI implements `when`, so it reimplements (badly, probably...) some of the same logic that `when` already uses. (This is the main reason why I'm marking this PR as a draft.) It can probably be implemented more compactly and efficiently by reusing the existing `when` infrastructure, but I'm not sure if it's even a good idea at all to have the `block` emulation depend on implementation details of `when`.