### PR TITLE
Early/better debug output

### DIFF
--- a/src/os/pl-file.c
+++ b/src/os/pl-file.c
@@ -859,7 +859,11 @@ getOutputStream__LD(term_t t, s_type text, IOSTREAM **stream ARG_LD)
   atom_t tp;
 
   if ( t == 0 )
-  { if ( (s = getStream(Scurout)) )
+  { if ( (s = getStream(
+#ifdef O_DEBUG
+                        LD->internal_debug.depth > 0 ? Serror :
+#endif
+                        Scurout)) )
       goto ok;
     no_stream(t, ATOM_current_output);
     return FALSE;

--- a/src/os/pl-stream.c
+++ b/src/os/pl-stream.c
@@ -2113,15 +2113,9 @@ next_chr(const char **s, IOENC enc)
   }
 }
 
-#ifdef O_DEBUG
-#define OUTCHR(s, c)	do { printed++; last_char = (c); \
-			     if ( Sputcode(last_char, (s)) < 0 ) goto error; \
-			   } while(0)
-#else
 #define OUTCHR(s, c)	do { printed++; \
 			     if ( Sputcode((c), (s)) < 0 ) goto error; \
 			   } while(0)
-#endif
 #define valdigit(c)	((c) - '0')
 #define A_LEFT	0			/* left-aligned field */
 #define A_RIGHT 1			/* right-aligned field */
@@ -2160,9 +2154,6 @@ Svfprintf(IOSTREAM *s, const char *fm, va_list args)
   char buf[TMPBUFSIZE];
   int tmpbuf;
   char *fs_malloced = NULL;
-#ifdef O_DEBUG
-  int last_char = 0;
-#endif
 
   SLOCK(s);
 
@@ -2440,7 +2431,7 @@ Svfprintf(IOSTREAM *s, const char *fm, va_list args)
   }
 
 #ifdef O_DEBUG
-  if (s == Serror && last_char == '\n') debug_new_output_line = 1;
+  if (s == Serror && s->lastc == '\n') debug_new_output_line = 1;
 #endif
 
   if ( tmpbuf )

--- a/src/os/pl-stream.h
+++ b/src/os/pl-stream.h
@@ -146,4 +146,11 @@ S__destroyed(IOSTREAM *s)
 
 #endif /*O_DEBUG_STREAM_REFERENCES*/
 
+#ifdef O_DEBUG
+#ifndef Sdprintf
+#define Sdprintf(fmt...) Sdprintf_ex(NULL, __FILE__, __LINE__, fmt)
+#endif
+int Sdprintf_ex(const char *channel, const char *file, int line, const char *fm, ...);
+#endif
+
 #endif /*PL_STREAM_H_INCLUDED*/

--- a/src/pl-builtin.h
+++ b/src/pl-builtin.h
@@ -210,12 +210,26 @@ is also printed if stdio is not available.
 
 #if O_DEBUG
 #define DEBUG(n, g) do { if ((n <= DBG_LEVEL9 && GD->debug_level >= (n)) || \
-                             (n > DBG_LEVEL9 && GD->debug_topics && \
-                              true_bit(GD->debug_topics, n))) \
-                         { g; } } while(0)
+                             (n > DBG_LEVEL9 && DEBUGGING(n))) \
+                         { ENTER_DEBUG(n) g; EXIT_DEBUG(n) } } while(0)
+#define ENTER_DEBUG(n) pl_internaldebugstatus_t __orig_ld_debug = GLOBAL_LD->internal_debug; \
+                         int __new_ld_depth = ((GLOBAL_LD->internal_debug.channel = prolog_debug_topic_name(n)), \
+                                              ++GLOBAL_LD->internal_debug.depth);
+#define EXIT_DEBUG(n) if (GLOBAL_LD->internal_debug.depth != __new_ld_depth) \
+                        Sdprintf("DEBUG stack depth mismatch! %d != %d\n", GLOBAL_LD->internal_debug.depth, __new_ld_depth); \
+                      GLOBAL_LD->internal_debug = __orig_ld_debug;
 #define DEBUGGING(n) (GD->debug_topics && true_bit(GD->debug_topics, n))
+
+/* We want to use the version of Sdprintf with the debug channel, if possible */
+#undef Sdprintf
+#define Sdprintf(fmt...) Sdprintf_ex(GLOBAL_LD->internal_debug.channel, __FILE__, __LINE__, fmt)
+int Sdprintf_ex(const char *channel, const char *file, int line, const char *fm, ...);
+
 #else
 #define DEBUG(a, b) ((void)0)
+#define ENTER_DEBUG(n) ;
+#define EXIT_DEBUG(n) ;
+#define DEBUGGING(n) FALSE
 #endif
 
 #if O_SECURE

--- a/src/pl-debug.c
+++ b/src/pl-debug.c
@@ -288,6 +288,26 @@ prolog_debug_topic(const char *topic, int flag)
   return TRUE;
 }
 
+const char *
+prolog_debug_topic_name(unsigned code)
+{ static unsigned last_code = -1;
+  static const char *last_name = NULL;
+  const debug_topic *dt;
+
+  if (code == last_code)
+    return last_name;
+
+  last_code = code;
+
+  for (dt=debug_topics; dt->name; dt++)
+  { if ( dt->code == code )
+      return last_name = dt->name;
+  }
+
+  Sdprintf("ERROR: Unknown debug code: %d\n", code);
+  return last_name = NULL;
+}
+
 
 int
 prolog_debug_from_string(const char *spec, int flag)

--- a/src/pl-debug.c
+++ b/src/pl-debug.c
@@ -312,6 +312,9 @@ prolog_debug_topic_name(unsigned code)
 int
 prolog_debug_from_string(const char *spec, int flag)
 { const char *end;
+  bool quiet = (flag < 0);
+  if (quiet)
+    flag = ~flag;
 
   while((end=strchr(spec, ',')))
   { if ( end-spec < MAX_TOPIC_LEN )
@@ -320,18 +323,22 @@ prolog_debug_from_string(const char *spec, int flag)
       strncpy(buf, spec, end-spec);
       buf[end-spec] = EOS;
       if ( !prolog_debug_topic(buf, flag) )
-      { Sdprintf("ERROR: Unknown debug topic: %s\n", buf);
+      { if (quiet)
+          return FALSE;
+	Sdprintf("ERROR: Unknown debug topic: %s\n", buf);
 	PL_halt(1);
       }
 
       spec = end+1;
-    } else
+    } else if (!quiet)
     { Sdprintf("ERROR: Invalid debug topic: %s\n", spec);
     }
   }
 
   if ( !prolog_debug_topic(spec, flag) )
-  { Sdprintf("ERROR: Unknown debug topic: %s\n", spec);
+  { if (quiet)
+      return FALSE;
+    Sdprintf("ERROR: Unknown debug topic: %s\n", spec);
     PL_halt(1);
   }
 

--- a/src/pl-debug.h
+++ b/src/pl-debug.h
@@ -235,5 +235,6 @@ typedef struct debug_topic
 
 COMMON(void)	cleanupDebug(void);
 COMMON(int)	prolog_debug_from_string(const char *spec, int flag);
+COMMON(const char *) prolog_debug_topic_name(unsigned code);
 
 #endif /*PL_DEBUG_INCLUDED*/

--- a/src/pl-global.h
+++ b/src/pl-global.h
@@ -697,6 +697,7 @@ struct PL_local_data
   pl_shift_status_t shift_status;	/* Stack shifter status */
   pl_debugstatus_t _debugstatus;	/* status of the debugger */
   struct btrace *btrace_store;		/* C-backtraces */
+  pl_internaldebugstatus_t internal_debug; /* status of C-level debug flags */
 
 #ifdef O_PLMT
   struct

--- a/src/pl-incl.h
+++ b/src/pl-incl.h
@@ -2404,6 +2404,11 @@ typedef struct debuginfo
   intptr_t	retryFrame;		/* Frame to retry (local stack offset) */
 } pl_debugstatus_t;
 
+typedef struct internaldebuginfo
+{ int depth;           /* how many nested DEBUG() calls we are in */
+  const char *channel; /* string representation of the debug channel */
+} pl_internaldebugstatus_t;
+
 #define FT_ATOM		0		/* atom feature */
 #define FT_BOOL		1		/* boolean feature (true, false) */
 #define FT_INTEGER	2		/* integer feature */

--- a/src/pl-init.c
+++ b/src/pl-init.c
@@ -1010,6 +1010,10 @@ PL_initialise(int argc, char **argv)
   if ( GD->initialised )
     succeed;
 
+  /* Initialize debug flag early, if first argument */
+  if (argc > 2 && strcmp(argv[1],"-d") == 0)
+		prolog_debug_from_string(argv[2], TRUE);
+
   initAlloc();
   initPrologThreads();			/* initialise thread system */
   SinitStreams();

--- a/src/pl-init.c
+++ b/src/pl-init.c
@@ -1012,7 +1012,8 @@ PL_initialise(int argc, char **argv)
 
   /* Initialize debug flag early, if first argument */
   if (argc > 2 && strcmp(argv[1],"-d") == 0)
-		prolog_debug_from_string(argv[2], TRUE);
+    /* One's complement tells p_d_f_s not to bail on error, just return */
+    prolog_debug_from_string(argv[2], ~TRUE);
 
   initAlloc();
   initPrologThreads();			/* initialise thread system */

--- a/src/pl-wam.c
+++ b/src/pl-wam.c
@@ -194,6 +194,7 @@ DbgPrintInstruction(LocalFrame FR, Code PC)
 
   if ( DEBUGGING(MSG_VMI) )
   { GET_LD
+    ENTER_DEBUG(MSG_VMI)
 
     if ( ofr != FR )
     { Sfprintf(Serror, "#%ld at [%ld] predicate %s\n",
@@ -218,6 +219,7 @@ DbgPrintInstruction(LocalFrame FR, Code PC)
 
       Sdprintf("\t%4ld %s\n", (long)(PC-relto), codeTable[decode(*PC)].name);
     }
+    EXIT_DEBUG(MSG_VMI)
   }
 }
 

--- a/src/pl-wic.c
+++ b/src/pl-wic.c
@@ -4085,6 +4085,7 @@ compileFile(wic_state *state, const char *file)
       break;
 
     DEBUG(MSG_QLF_BOOT_READ,
+	  Sdprintf(""); /* To output line header */
 	  PL_write_term(Serror, t, 1200, PL_WRT_NUMBERVARS);
 	  Sdprintf("\n"));
 


### PR DESCRIPTION
Initialize the global debug_level as soon as possible if "-d" is passed
first on the command line, to avoid missing early debug lines. Also,
track use of the DEBUG() macro on a per-thread basis and use Serror
as the default output stream when inside a DEBUG clause, so that
statements that mix e.g. Sdprintf() and write_term() will get printed
to a single output. Finally, prefix debug lines with the debug channel
and the file/line source.