### PR TITLE
Make `foldl/4` error outside its domain

### DIFF
--- a/library/apply.pl
+++ b/library/apply.pl
@@ -311,8 +311,8 @@ convlist_([H0|T0], ListOut, Goal) :-
 foldl(Goal, List, V0, V) :-
     foldl_(List, Goal, V0, V).
 
-foldl_([], _, V, V).
-foldl_([H|T], Goal, V0, V) :-
+foldl_([], _, V0, V) => V0 = V.
+foldl_([H|T], Goal, V0, V) =>
     call(Goal, H, V0, V1),
     foldl_(T, Goal, V1, V).
 


### PR DESCRIPTION
Use single-sided unification rules for `foldl/4` so that something like `foldl(not_a_list, Goal, In, Out)` is an exception instead of silently failing.  This would be a breaking change.

Some unresolved questions:

 - Is it a good change? I had to debug some code today where this would have told me the problem right away. However, it is a breaking change, so there is a chance that someone relies on this behavior.
 - `foldl/N` where `N > 4`? I originally also wanted to change the other `foldl`s, but decided against it, since it would break all the code that uses `foldl` like a kind of "`maplist` with state".
 - `scanl`? I think this change might be significantly *more* breaking for `scanl` than for `foldl`, so I didn't change `scanl`.
 - Unit tests: I didn't add any, since I'm not familiar with the test setup, but with guidance I would be happy to add one.