### PR TITLE
Cleanup: Code of library(statistics) clarified; plunit code added

### DIFF
--- a/src/Tests/library/test_statistics.pl
+++ b/src/Tests/library/test_statistics.pl
@@ -1,0 +1,280 @@
+:- module(test_statistics,
+          [ test_statistics/0
+          ]).
+:- use_module(library(plunit)).
+:- use_module(library(statistics)).
+
+test_statistics :-
+    run_tests([statistics]).
+
+
+% Running some tests of call_time/2 and call_time/3.
+% We collect the "number of inferences" determined by call_time/N
+% and possibly the reified outcome and compare what has been obtained
+% against what should have been obtained. If the goal about whcih we
+% collect statistics is nondet, all its solutions are collected and
+% the respective inference counts and reified outcomes are collected
+% as "pairs in a bag".
+%
+% The inference count may differ slight between SWI-Prolog version,
+% between the first and subsequent runs on the the same SWI-Prolog
+% version (sometimes heavily, must be JIT compilation). Additionally,
+% the build test seems to run each test three times, with slightly
+% differing count among tests.
+%
+% Assertions are accordingly lenient.
+%
+% The predicate report/2 prints out what has been found.
+%
+% In SWI-Prolog 8.3.22, inference counts are as follows:
+%
+% STAT_01: 1 but 0 on second execution
+% STAT_04: 1
+% STAT_05: 1
+% STAT_06: 0
+% STAT_07: 0
+% STAT_09: 0
+% STAT_10: 1
+% STAT_11: -1  (!FIXME!)
+% STAT_12: 1
+% STAT_13: [[104,true],[7,false]] but [[0,true],[6,false]] on second execution
+% STAT_14: [[3,true]]
+% STAT_15: [[0,true],[3,true],[4,true]]
+% STAT_16: [[4,false]]
+% STAT_17: [[0,true],[3,true],[4,true]]
+% STAT_19: 7709
+% STAT_20: 9992
+% STAT_21: [[1,true],[4,false]]
+% STAT_22: [[7,true],[4,false]]
+% STAT_23: [[3,true]]
+% STAT_24: [[2,true],[4,false]]
+%
+% In SWI-Prolog 8.3.23, inference counts are the same except for:
+%
+% STAT_13: [[24299,true],[7,false]] but [[0,true],[6,false]] afterwards
+%
+% In SWI-Prolog 8.3.23 with modified library(statistics), there is some "less by 1" going on:
+%
+% STAT_01: 1 but 0 on second execution
+% STAT_04: 1
+% STAT_05: 1
+% STAT_06: 0
+% STAT_07: 0
+% STAT_09: 0
+% STAT_10: 1
+% STAT_11: -1 (!FIXME!)
+% STAT_12: 1
+% STAT_13: [[24299,true],[6,false]] but [[0,true],[5,false]] on second execution
+% STAT_14: [[3,true]]
+% STAT_15: [[0,true],[2,true],[3,true]]
+% STAT_16: [[4,false]]
+% STAT_17: [[0,true],[2,true],[3,true]]
+% STAT_19: 7709
+% STAT_20: 9992
+% STAT_21: [[1,true],[3,false]]
+% STAT_22: [[7,true],[3,false]]
+% STAT_23: [[3,true]]
+% STAT_24: [[2,true],[3,false]]
+
+
+:- begin_tests(statistics).
+
+report(X,Where) :-
+   format(user_error,"~s: ~q~n",[X,Where]).
+
+test("STAT_01: calling true, reified result already instantiated to true") :-
+   call_time(true,Usage,true),
+   report("STAT_01",Usage.inferences),
+   assertion(
+      (Usage.inferences == 0 ;
+       Usage.inferences == 1 ;
+       Usage.inferences == 2)).
+
+% This erroneously succeeds in SWI-Prolog 8.3.23
+test("STAT_02: calling true, reified result already (wrongly) instantiated to false",fail) :-
+   call_time(true,_Usage,false).
+
+test("STAT_03: calling false, reified result already (wrongly) instantiated to true",fail) :-
+   call_time(false,_Usage,true).
+
+test("STAT_04: calling false, reified result already instantiated to false") :-
+   call_time(false,Usage,false),
+   report("STAT_04",Usage.inferences),
+   assertion(Usage.inferences == 1).
+
+test("STAT_05: calling false, reified result is captured") :-
+   call_time(false,Usage,Result),
+   report("STAT_05",Usage.inferences),
+   assertion(
+      (Usage.inferences == 0 ;
+       Usage.inferences == 1)),
+   assertion(Result == false).
+
+test("STAT_06: calling true, reified result is captured") :-
+   call_time(true,Usage,Result),
+   report("STAT_06",Usage.inferences),
+   assertion(
+      (Usage.inferences == 0 ;
+       Usage.inferences == 1)),
+   assertion(Result == true).
+
+test("STAT_07: calling true") :-
+   call_time(true,Usage),
+   report("STAT_07",Usage.inferences),
+   assertion(
+      (Usage.inferences == 0 ;
+       Usage.inferences == 1)).
+
+test("STAT_08: calling false", fail) :-
+   call_time(false,_Usage).
+
+test("STAT_09: calling true, result reified") :-
+   call_time(true,Usage,true),
+   report("STAT_09",Usage.inferences),
+   assertion(
+      (Usage.inferences == 0 ;
+       Usage.inferences == 1)).
+
+test("STAT_10: calling false, result reified") :-
+   call_time(false,Usage,false),
+   report("STAT_10",Usage.inferences),
+   assertion(Usage.inferences == 1).
+
+test("STAT_11: calling a conjunction of true, result reified") :-
+   call_time((true,true,true,true,true,true),Usage,true),
+   report("STAT_11",Usage.inferences),
+   assertion(
+      (Usage.inferences == -1 ;  % BAD
+       Usage.inferences ==  0)).
+
+test("STAT_12: calling a conjunction of true with one false, result reified") :-
+   call_time((true,true,true,false,true,true),Usage,false),
+   report("STAT_12",Usage.inferences),
+   assertion(Usage.inferences == 1).
+
+test("STAT_13: calling member(1,[1,2,3])") :-
+   bagof([Inferences,Result],Usage^(call_time(member(1,[1,2,3]),Usage,Result),Inferences = Usage.inferences),Bag),
+   report("STAT_13",Bag),
+   assertion(
+     (Bag == [[0, true], [6, false]]  ;
+      Bag == [[1, true], [6, false]]  ;
+      Bag == [[24241,true],[7,false]] ;
+      Bag == [[24299,true],[6,false]] ;
+      Bag == [[24299,true],[7,false]] ;
+      Bag == [[0, true], [5, false]]  ;
+      Bag == [[1, true], [5, false]] )).
+
+test("STAT_14: calling member(3,[1,2,3])") :-
+   bagof([Inferences,Result],Usage^(call_time(member(3,[1,2,3]),Usage,Result),Inferences = Usage.inferences),Bag),
+   report("STAT_14",Bag),
+   assertion(
+      (Bag == [[3, true]] ;
+       Bag == [[4, true]])).
+
+test("STAT_15: calling member(3,[3,3,3])") :-
+   bagof([Inferences,Result],Usage^(call_time(member(3,[3,3,3]),Usage,Result),Inferences = Usage.inferences),Bag),
+   report("STAT_15",Bag),
+   assertion(
+      ( Bag == [[0, true], [2, true], [3, true]] ;
+        Bag == [[0, true], [3, true], [4, true]] ;
+        Bag == [[1, true], [3, true], [4, true]] )).
+
+test("STAT_16: calling member(4,[1,2,3])") :-
+   bagof([Inferences,Result],Usage^(call_time(member(4,[1,2,3]),Usage,Result),Inferences = Usage.inferences),Bag),
+   report("STAT_16",Bag),
+   assertion(Bag == [[4, false]]).
+
+test("STAT_17: calling member(X,[1,2,3])") :-
+   bagof([Inferences,Result],X^Usage^(call_time(member(X,[1,2,3]),Usage,Result),Inferences = Usage.inferences),Bag),
+   report("STAT_17",Bag),
+   assertion(
+      ( Bag == [[0, true], [2, true], [3, true]] ;
+        Bag == [[0, true], [3, true], [4, true]] ;
+        Bag == [[1, true], [3, true], [4, true]] )).
+
+% "throwing" means a report will be printed by the exception will be rethrown in any case
+% the test below will emit the text
+% % 12 inferences, 0.000 CPU in 0.000 seconds (100% CPU, 87774 Lips)
+% on stderr
+
+test("STAT_18: called goal throws",[error(type_error(x,y))]) :-
+   call_time(type_error(x,y),_Usage,_Result).
+
+% test for collatz property
+
+collatz(1)     :- !.
+collatz(N) :- N mod 2 =:= 0, !, NN is N // 2, collatz(NN).
+collatz(N) :- N mod 2 =:= 1, !, NN is 3 * N + 1, collatz(NN).
+
+test("STAT_19: collatz(931386509544713451)") :-
+   call_time(collatz(931386509544713451),Usage),
+   report("STAT_19",Usage.inferences),
+   assertion(
+      (Usage.inferences == 7709 ;  % SWI-Prolog 8.3.23
+       Usage.inferences == 7710)). % SWI-Prolog 8.3.23 build tests
+
+% test for collatz property with non-tail recursive step counting
+
+collatz(1,0)     :- !.
+collatz(N,Steps) :- N mod 2 =:= 0, !, NN is N // 2, collatz(NN,StepsN), Steps is StepsN+1.
+collatz(N,Steps) :- N mod 2 =:= 1, !, NN is 3 * N + 1, collatz(NN,StepsN), Steps is StepsN+1.
+
+test("STAT_20: collatz_sc(931386509544713451)") :-
+   call_time(collatz(931386509544713451,Steps),Usage),
+   report("STAT_20",Usage.inferences),
+   assertion(
+      (Usage.inferences == 9993 ;
+       Usage.inferences == 9992)),
+   assertion(Steps == 2283).
+
+% playing around with a weird predicate; not sure about the resulting inference counts
+
+foo([_-x|_])  :- !.
+foo([_|More]) :- foo(More).
+foo([x-_|_])  :- !.
+
+test("STAT_21: foo 1") :-
+   bagof(
+      [Inf,Res],
+      U^(call_time(foo([a-a,a-a,a-x]),U,Res),Inf = U.inferences),
+      Bag),
+   report("STAT_21",Bag),
+   assertion(
+      (Bag == [[1, true], [3, false]] ;
+       Bag == [[2, true], [3, false]] ;
+       Bag == [[1, true], [4, false]])).
+
+test("STAT_22: foo 2") :-
+   bagof(
+      [Inf,Res],
+      U^(call_time(foo([a-a,a-a,a-a,a-a,a-a,a-a,a-a,a-a,a-x]),U,Res),Inf = U.inferences),
+      Bag),
+   report("STAT_22",Bag),
+   assertion(
+      (Bag == [[7, true], [3, false]] ;
+       Bag == [[8, true], [3, false]] ;
+       Bag == [[7, true], [4, false]])).
+
+test("STAT_23: foo 3") :-
+   bagof(
+      [Inf,Res],
+      U^(call_time(foo([x-a,a-a,a-a]),U,Res),Inf = U.inferences),
+      Bag),
+   report("STAT_23",Bag),
+   assertion(
+      (Bag == [[3, true]] ;
+       Bag == [[4, true]])).
+
+test("STAT_24: foo 4") :-
+   bagof(
+      [Inf,Res],
+      U^(call_time(foo([a-a,x-a,a-a]),U,Res),Inf = U.inferences),
+      Bag),
+   report("STAT_24",Bag),
+   assertion(
+      (Bag == [[2, true], [3, false]] ;
+       Bag == [[2, true], [4, false]] ;
+       Bag == [[3, true], [3, false]])).
+
+:- end_tests(statistics).
+


### PR DESCRIPTION
This is a review of library(statistics):

# Nicer output for statistics/0 which uses kilo/mega/giga prefix for LIPS and inferences and uses SI units for byte counts

```
?- statistics.
% Started at Mon May  3 21:26:47 2021
% 0.240 seconds cpu time for 479 kilo-inferences
% 5,720 atoms, 4,409 functors, 3,382 predicates, 48 modules, 136,766 VM-codes
% 
%                      Limit    Allocated       In use
% Local  stack:            -      116 KiB    2,128   B
% Global stack:            -      128 KiB   17,696   B
% Trail  stack:            -      130 KiB      408   B
%        Total:    1,024 MiB      374 KiB       20 KiB
% 
% 3 garbage collections gained 237 KiB in 0.000 seconds.
% 7 atom garbage collections gained 1,544 atoms in 0.002 seconds.
% 9 clause garbage collections gained 208 clauses in 0.000 seconds.
% Stack shifts: 3 local, 5 global, 3 trail in 0.001 seconds
% 2 threads, 0 finished threads used 0.000 seconds
```

instead of

```
?- statistics.
% Started at Mon May  3 21:28:00 2021
% 0.126 seconds cpu time for 246,156 inferences
% 5,998 atoms, 4,195 functors, 3,037 predicates, 39 modules, 119,345 VM-codes
% 
%                     Limit   Allocated      In use
% Local  stack:           -       20 Kb    2,216  b
% Global stack:           -       32 Kb   13,144  b
% Trail  stack:           -       34 Kb      416  b
%        Total:    1,024 Mb       86 Kb   15,776  b
% 
% 2 garbage collections gained 180,064 bytes in 0.000 seconds.
% 2 atom garbage collections gained 700 atoms in 0.001 seconds.
% 4 clause garbage collections gained 94 clauses in 0.000 seconds.
% Stack shifts: 2 local, 2 global, 1 trail in 0.000 seconds
% 2 threads, 0 finished threads used 0.000 seconds
```

The code for printing the above also been made more readable (I hope).

Similarly for the output of time/1:

```
?- time(member(1,[2,3,4,5,6,7,1])).
% 8 inferences, 0.000 CPU in 0.000 seconds (86% CPU, 347 kilo-LIPS)
true.
```

instead of previously

```
?- time(member(1,[2,3,4,5,6,7,1])).
% 9 inferences, 0.000 CPU in 0.000 seconds (88% CPU, 714229 Lips)
true.
```

# Consolidation of code for time/1 and call_time/2 and call_time/3

For some reason, the code repeated itself, was very hard to understand and generally gave off messy vibes.

Streamlined into a single set of predicates that provide all the functionality for time/1 and call_time/N, by virtue of being able to switch "reporting to stderr" on or off depending on the use case.

There was an error in call_time/3 whereby a failing goal with reified outcome bound to "true" would actually succeed:

```
call_time(true,_Usage,false).
```

would succeed even tough the expected outcome given by the third argument is `false`. Fixed that.

The values to be shave off the inference counts are now all in the same predicate, too. 

Unfortunately I haven' been able to fully reproduced the previous inference counts. More on this in

# library(statistics) unit tests added

Unit tests may need to be lenient: they checks inference counts obtained ... but these may differ between the first run and subsequent runs. They also seem to be different at build time, where they are executed thrice with. 

In one case, the inference count is actually be -1! That probably needs fixing.

I will just copy the commentary from the newly added file `test_statistics.pl`:

```
% Running some tests of call_time/2 and call_time/3.
% We collect the "number of inferences" determined by call_time/N
% and possibly the reified outcome and compare what has been obtained
% against what should have been obtained. If the goal about whcih we
% collect statistics is nondet, all its solutions are collected and
% the respective inference counts and reified outcomes are collected
% as "pairs in a bag".
%
% The inference count may differ slight between SWI-Prolog version,
% between the first and subsequent runs on the the same SWI-Prolog
% version (sometimes heavily, must be JIT compilation). Additionally,
% the build test seems to run each test three times, with slightly
% differing count among tests.
%
% Assertions are accordingly lenient.
%
% The predicate report/2 prints out what has been found.
%
% In SWI-Prolog 8.3.22, inference counts are as follows:
%
% STAT_01: 1 but 0 on second execution
% STAT_04: 1
% STAT_05: 1
% STAT_06: 0
% STAT_07: 0
% STAT_09: 0
% STAT_10: 1
% STAT_11: -1  (!FIXME!)
% STAT_12: 1
% STAT_13: [[104,true],[7,false]] but [[0,true],[6,false]] on second execution
% STAT_14: [[3,true]]
% STAT_15: [[0,true],[3,true],[4,true]]
% STAT_16: [[4,false]]
% STAT_17: [[0,true],[3,true],[4,true]]
% STAT_19: 7709
% STAT_20: 9992
% STAT_21: [[1,true],[4,false]]
% STAT_22: [[7,true],[4,false]]
% STAT_23: [[3,true]]
% STAT_24: [[2,true],[4,false]]
%
% In SWI-Prolog 8.3.23, inference counts are the same except for:
%
% STAT_13: [[24299,true],[7,false]] but [[0,true],[6,false]] afterwards
%
% In SWI-Prolog 8.3.23 with modified library(statistics), there is some "less by 1" going on:
%
% STAT_01: 1 but 0 on second execution
% STAT_04: 1
% STAT_05: 1
% STAT_06: 0
% STAT_07: 0
% STAT_09: 0
% STAT_10: 1
% STAT_11: -1 (!FIXME!)
% STAT_12: 1
% STAT_13: [[24299,true],[6,false]] but [[0,true],[5,false]] on second execution
% STAT_14: [[3,true]]
% STAT_15: [[0,true],[2,true],[3,true]]
% STAT_16: [[4,false]]
% STAT_17: [[0,true],[2,true],[3,true]]
% STAT_19: 7709
% STAT_20: 9992
% STAT_21: [[1,true],[3,false]]
% STAT_22: [[7,true],[3,false]]
% STAT_23: [[3,true]]
% STAT_24: [[2,true],[3,false]]
```

It is unclear which of the results are "correct" (if any). Considering STAT_24 for example, with

```
foo([_-x|_])  :- !.
foo([_|More]) :- foo(More).
foo([x-_|_])  :- !.
```

A trace corresponding to the test goal is:

```
?- trace,foo([a-a,x-a,a-a]).
   Call: (11) foo([a-a, x-a, a-a]) ? creep
   Call: (12) foo([x-a, a-a]) ? creep
   Call: (13) foo([a-a]) ? creep
   Call: (14) foo([]) ? creep
   Fail: (14) foo([]) ? creep
   Redo: (13) foo([a-a]) ? creep
   Fail: (13) foo([a-a]) ? creep
   Redo: (12) foo([x-a, a-a]) ? creep
   Exit: (12) foo([x-a, a-a]) ? creep
   Exit: (11) foo([a-a, x-a, a-a]) ? creep
true ;
   Redo: (11) foo([a-a, x-a, a-a]) ? creep
   Fail: (11) foo([a-a, x-a, a-a]) ? creep
false.
```

It is unclear why the above trace means that there are 2 (or 3) inferences up to the first succes, and then 5.

```
?- call_time(foo([a-a,x-a,a-a]),U,Res).
U = time{cpu:2.330200000000282e-5, inferences:3, wall:2.47955322265625e-5},
Res = true ;
U = time{cpu:2.0405000000001117e-5, inferences:5, wall:2.2649765014648438e-5},
Res = false.
```

Does this need deeper correction?
