### PR TITLE
Add max_member/3 and min_member/3 (with an order predicate argument) to library(lists)

### DIFF
--- a/library/dialect/sicstus4/lists.pl
+++ b/library/dialect/sicstus4/lists.pl
@@ -86,6 +86,8 @@
 	      sum_list/2 as sumlist,
 	      max_member/2,
 	      min_member/2,
+	      max_member/3,
+	      min_member/3,
 	      clumped/2
 	    ]).
 :- reexport('../../apply',
@@ -127,8 +129,6 @@ sicstus4:rename_module(lists, sicstus4_lists).
 	* include/[4,5]
 	* group/[3,4,5]
 	* ordered/[1,2]
-	* max_member/3
-	* min_member/3
 	* select_min/[3,4]
 	* select_max/[3,4]
 	* increasing_prefix/[3,4]

--- a/library/lists.pl
+++ b/library/lists.pl
@@ -61,6 +61,8 @@
                                         % Ordered operations
           max_member/2,                 % -Max, +List
           min_member/2,                 % -Min, +List
+          max_member/3,                 % :Pred, -Max, +List
+          min_member/3,                 % :Pred, -Min, +List
 
                                         % Lists of numbers
           sum_list/2,                   % +List, -Sum
@@ -573,6 +575,50 @@ min_member_([H|T], Min0, Min) =>
     (   H @>= Min0
     ->  min_member_(T, Min0, Min)
     ;   min_member_(T, H, Min)
+    ).
+
+
+%!  max_member(:Pred, -Max, +List) is semidet.
+%
+%   True when Max is the largest member according to Pred, which must be
+%   a 2-argument callable that behaves like (@=<)/2.
+%   Fails if List is empty.
+%
+%   @see max_list/2 for the maximum of a list of numbers.
+
+max_member(Pred, Max, [H|T]) =>
+    max_member_(T, Pred, H, Max).
+max_member(_, _, []) =>
+    fail.
+
+max_member_([], _, Max0, Max) =>
+    Max = Max0.
+max_member_([H|T], Pred, Max0, Max) =>
+    (   call(Pred, H, Max0)
+    ->  max_member_(T, Pred, Max0, Max)
+    ;   max_member_(T, Pred, H, Max)
+    ).
+
+
+%!  min_member(:Pred, -Min, +List) is semidet.
+%
+%   True when Min is the smallest member according to Pred, which must
+%   be a 2-argument callable that behaves like (@=<)/2.
+%   Fails if List is empty.
+%
+%   @see min_list/2 for the minimum of a list of numbers.
+
+min_member(Pred, Min, [H|T]) =>
+    min_member_(T, Pred, H, Min).
+min_member(_, _, []) =>
+    fail.
+
+min_member_([], _, Min0, Min) =>
+    Min = Min0.
+min_member_([H|T], Pred, Min0, Min) =>
+    (   call(Pred, Min0, H)
+    ->  min_member_(T, Pred, Min0, Min)
+    ;   min_member_(T, Pred, H, Min)
     ).
 
 


### PR DESCRIPTION
These predicates are compatible with SICStus 4.