### PR TITLE
Debug wildcard and complement; DEBUG_IF

### DIFF
--- a/src/os/pl-stream.c
+++ b/src/os/pl-stream.c
@@ -110,18 +110,6 @@ locking is required.
 #include SYSLIB_H
 #endif
 
-#ifdef O_DEBUG
-#ifdef HAVE___THREAD
-/* It's not strictly necessary to have this in thread-local storage... */
-__thread
-#elif defined(O_PLMT)
-/* ...and the fail condition for a thread race just isn't that bad */
-volatile
-#endif
-/* Have we just emitted a newline? Should we print file/line on the next Sdprintf? */
-	 static int debug_new_output_line = 1;
-#endif
-
 #define ROUND(p, n) ((((p) + (n) - 1) & ~((n) - 1)))
 #define UNDO_SIZE ROUND(PL_MB_LEN_MAX, sizeof(wchar_t))
 
@@ -2433,10 +2421,6 @@ Svfprintf(IOSTREAM *s, const char *fm, va_list args)
     }
   }
 
-#ifdef O_DEBUG
-  if (s == Serror && s->lastc == '\n') debug_new_output_line = 1;
-#endif
-
   if ( tmpbuf )
   { if ( S__removebuf(s) < 0 )
       goto error;
@@ -2559,10 +2543,9 @@ Sdprintf_ex(const char *channel, const char *file, int line, const char *fm, ...
 { va_list args;
   int rval;
 
-  if ( debug_new_output_line && channel )
+  if ( Serror->position && Serror->position->linepos == 0 )
   { const char *logfmt = "[%s] %s:%d: ";
 
-    debug_new_output_line = 0;
     if (strncmp(channel, "DBG_LEVEL", 9) == 0)
     { channel += 9;
       logfmt = "<%s> %s:%d: ";

--- a/src/os/pl-stream.c
+++ b/src/os/pl-stream.c
@@ -2543,7 +2543,7 @@ Sdprintf_ex(const char *channel, const char *file, int line, const char *fm, ...
 { va_list args;
   int rval;
 
-  if ( Serror->position && Serror->position->linepos == 0 )
+  if ( Serror->position && Serror->position->linepos == 0 && channel)
   { const char *logfmt = "[%s] %s:%d: ";
 
     if (strncmp(channel, "DBG_LEVEL", 9) == 0)

--- a/src/pl-builtin.h
+++ b/src/pl-builtin.h
@@ -219,6 +219,9 @@ is also printed if stdio is not available.
                         Sdprintf("DEBUG stack depth mismatch! %d != %d\n", GLOBAL_LD->internal_debug.depth, __new_ld_depth); \
                       GLOBAL_LD->internal_debug = __orig_ld_debug;
 #define DEBUGGING(n) (GD->debug_topics && true_bit(GD->debug_topics, n))
+#define DEBUG_IF(cond, n) if (cond) for (pl_internaldebugstatus_t __orig_ld_debug = enter_debug(n); \
+					 __orig_ld_debug.depth >= 0; \
+					 exit_debug(n, __orig_ld_debug), __orig_ld_debug.depth = -1)
 
 /* We want to use the version of Sdprintf with the debug channel, if possible */
 #undef Sdprintf
@@ -230,6 +233,7 @@ int Sdprintf_ex(const char *channel, const char *file, int line, const char *fm,
 #define ENTER_DEBUG(n) ;
 #define EXIT_DEBUG(n) ;
 #define DEBUGGING(n) FALSE
+#define DEBUG_IF(cond, n) if (0)
 #endif
 
 #if O_SECURE

--- a/src/pl-gc.c
+++ b/src/pl-gc.c
@@ -4272,7 +4272,7 @@ garbageCollect(gc_reason_t reason)
   save_backtrace("GC");
 #endif
 
-  DEBUG_IF ( verbose, 0 )
+  if ( verbose )
     Sdprintf("%% GC: ");
 
   get_vmi_state(LD->query, &state);
@@ -4395,7 +4395,7 @@ garbageCollect(gc_reason_t reason)
 
   stats = gc_stat_end(&LD->gc.stats PASS_LD);
 
-  DEBUG_IF ( verbose, 0 )
+  if ( verbose )
     Sdprintf("gained (g+t) %zd+%zd in %.3f sec; used %zd+%zd; free %zd+%zd\n",
 	     stats->global_before - stats->global_after,
 	     stats->trail_before  - stats->trail_after,
@@ -5152,7 +5152,7 @@ grow_stacks(size_t l, size_t g, size_t t ARG_LD)
 
     DEBUG(MSG_SHIFT, verbose = TRUE);
 
-    DEBUG_IF ( verbose, MSG_SHIFT )
+    if ( verbose ) WITH_DEBUG_FOR(MSG_SHIFT)
     { const char *prefix;
       int tid = PL_thread_self();
 
@@ -5250,7 +5250,7 @@ grow_stacks(size_t l, size_t g, size_t t ARG_LD)
 	  } \
 	}
 
-    DEBUG_IF ( verbose, MSG_SHIFT )
+    if ( verbose ) WITH_DEBUG_FOR(MSG_SHIFT)
     { Sputchar('\n');
       PrintStackParms(global, "global", gb, gsize);
       PrintStackParms(local, "local", lb, lsize);
@@ -5275,7 +5275,7 @@ grow_stacks(size_t l, size_t g, size_t t ARG_LD)
 	    }
 	    gBase--;
 	  });
-    DEBUG_IF ( verbose, MSG_SHIFT )
+    if ( verbose ) WITH_DEBUG_FOR(MSG_SHIFT)
     { Sdprintf("l+g+t = %lld+%lld+%lld (%.3f sec)\n",
 	       (int64_t)lsize, (int64_t)gsize, (int64_t)tsize, time);
     }

--- a/src/pl-global.h
+++ b/src/pl-global.h
@@ -700,7 +700,9 @@ struct PL_local_data
   pl_shift_status_t shift_status;	/* Stack shifter status */
   pl_debugstatus_t _debugstatus;	/* status of the debugger */
   struct btrace *btrace_store;		/* C-backtraces */
+#if O_DEBUG
   pl_internaldebugstatus_t internal_debug; /* status of C-level debug flags */
+#endif
 
 #ifdef O_PLMT
   struct

--- a/src/pl-incl.h
+++ b/src/pl-incl.h
@@ -2413,10 +2413,12 @@ typedef struct debuginfo
   intptr_t	retryFrame;		/* Frame to retry (local stack offset) */
 } pl_debugstatus_t;
 
+#if O_DEBUG
 typedef struct internaldebuginfo
 { int depth;           /* how many nested DEBUG() calls we are in */
   const char *channel; /* string representation of the debug channel */
 } pl_internaldebugstatus_t;
+#endif
 
 #define FT_ATOM		0		/* atom feature */
 #define FT_BOOL		1		/* boolean feature (true, false) */

--- a/src/pl-inline.h
+++ b/src/pl-inline.h
@@ -393,21 +393,6 @@ lookupDefinition(functor_t f, Module m)
   return proc ? proc->definition : NULL;
 }
 
-/* Inline function versions of ENTER_DEBUG/EXIT_DEBUG */
-static inline pl_internaldebugstatus_t
-enter_debug(unsigned int code)
-{ ENTER_DEBUG(code);
-  (void) __new_ld_depth;
-  return __orig_ld_debug;
-}
-
-static inline void
-exit_debug(unsigned int code, pl_internaldebugstatus_t __orig_ld_debug)
-{ int __new_ld_depth = __orig_ld_debug.depth + 1;
-  EXIT_DEBUG(code);
-}
-
-
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Mark() sets LD->mark_bar, indicating  that   any  assignment  above this
 value need not be trailed.

--- a/src/pl-inline.h
+++ b/src/pl-inline.h
@@ -393,6 +393,20 @@ lookupDefinition(functor_t f, Module m)
   return proc ? proc->definition : NULL;
 }
 
+/* Inline function versions of ENTER_DEBUG/EXIT_DEBUG */
+static inline pl_internaldebugstatus_t
+enter_debug(unsigned int code)
+{ ENTER_DEBUG(code);
+  (void) __new_ld_depth;
+  return __orig_ld_debug;
+}
+
+static inline void
+exit_debug(unsigned int code, pl_internaldebugstatus_t __orig_ld_debug)
+{ int __new_ld_depth = __orig_ld_debug.depth + 1;
+  EXIT_DEBUG(code);
+}
+
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Mark() sets LD->mark_bar, indicating  that   any  assignment  above this

--- a/src/pl-wam.c
+++ b/src/pl-wam.c
@@ -193,9 +193,8 @@ static void
 DbgPrintInstruction(LocalFrame FR, Code PC)
 { static LocalFrame ofr = NULL;		/* not thread-safe */
 
-  if ( DEBUGGING(MSG_VMI) )
+  IF_DEBUGGING(MSG_VMI)
   { GET_LD
-    ENTER_DEBUG(MSG_VMI)
 
     if ( ofr != FR )
     { Sfprintf(Serror, "#%ld at [%ld] predicate %s\n",
@@ -220,7 +219,6 @@ DbgPrintInstruction(LocalFrame FR, Code PC)
 
       Sdprintf("\t%4ld %s\n", (long)(PC-relto), codeTable[decode(*PC)].name);
     }
-    EXIT_DEBUG(MSG_VMI)
   }
 }
 


### PR DESCRIPTION
The -d command line option now takes an optional asterisk (*) on the
end of a debug flag name to enable all flags that begin with that name.
Also, flag names can be prefixed with a caret (^) to disable that flag;
only particularly useful in combination with the wildcard, to silence
chatty channels. For example,

    swipl -d MSG_SHIFT*,^MSG_SHIFT_FRAME

will enable all MSG_SHIFT channels except for MSG_SHIFT_FRAME.

On the internal side, we now have the DEBUG_IF(cond, channel) macro,
which functions much like DEBUG(channel, statements) except it provides
more control over the conditions, and it avoids statements in a macro.
As a result, the statement

```c
DEBUG(MSG_CHANNEL, Sdprintf(...));
```

is (for a named channel, at least) equivalent to

```c
 int debug_active = DEBUGGING(MSG_CHANNEL);
 DEBUG_IF(debug_active, MSG_CHANNEL)
 { Sdprintf(...); }
```

which itself is roughly equivalent to:

```c
#if O_DEBUG
int debug_active = DEBUGGING(MSG_CHANNEL);
if (debug_active)
{ ENTER_DEBUG(MSG_CHANNEL);
  Sdprintf(...);
  EXIT_DEBUG(MSG_CHANNEL);
}
#endif
```

This commit also includes some improvements to the GC debug messaging.