### PR TITLE
FIXED: negative numerical argument for format from argument list

### DIFF
--- a/src/Tests/core/test_format.pl
+++ b/src/Tests/core/test_format.pl
@@ -67,5 +67,7 @@ test(radix, error(domain_error(radix, 1))) :-
 	format(string(_), '~1r', [5]).
 test(radix, error(domain_error(radix, 37))) :-
 	format(string(_), '~37r', [5]).
+test(asterisk, error(format('no or negative integer for `*\' argument'))) :-
+    format('~t~*|', [-1]).
 
 :- end_tests(format).

--- a/src/os/pl-fmt.c
+++ b/src/os/pl-fmt.c
@@ -427,7 +427,7 @@ do_format(IOSTREAM *fd, PL_chars_t *fmt, int argc, term_t argv, Module m)
 	    }
 	  } else if ( c == '*' )
 	  { NEED_ARG;
-	    if ( PL_get_integer(argv, &arg) )
+	    if ( PL_get_integer(argv, &arg) && arg >= 0 )
 	    { SHIFT;
 	    } else
 	      FMT_ERROR("no or negative integer for `*' argument");


### PR DESCRIPTION
Without this, I see silent success, tested on 8.3.24-31-g79ac16a36:

```
?- format('~`*t~*|', [-1]).
true.

?- format('~`*t~*+', [-1]).
********
true.
```