### PR TITLE
Fix silent failure in CLP(FD) domain calculation for truncated division

### DIFF
--- a/library/clp/clpfd.pl
+++ b/library/clp/clpfd.pl
@@ -1490,7 +1490,7 @@ domain_expand_more_(from_to(From0, To0), M, Op, D) :-
             )
         ;   Op = div ->
             From1 cis From0*n(M1),
-            To1 cis (To0+n(1))*n(M1)-sign(M)
+            To1 cis (To0+n(1))*n(M1)-sign(n(M))
         ),
         (   M < 0 -> domain_negate(from_to(From1,To1), D)
         ;   D = from_to(From1,To1)


### PR DESCRIPTION
Previously, expressions like this silently failed for no reason:

```prolog
?- A #= B div 3.
false.
```

I'm not a CLP(FD) expert, but this seems to be a simple typo in the code. With that fixed, it works as expected:

```prolog
?- A #= B div 3.
B div 3#=A.

?- A #= B div 3, A #= 5.
A = 5,
B in 15..17.

?- A #= B div 3, B #= 5.
A = 1,
B = 5.
```