### PR TITLE
Shared-inline functions, pl-wam cleanup

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,7 +73,7 @@ set(SRC_CORE pl-atom.c pl-wam.c pl-arith.c pl-bag.c pl-error.c
     pl-copyterm.c pl-debug.c pl-cont.c pl-ressymbol.c pl-dict.c
     pl-trie.c pl-indirect.c pl-tabling.c pl-rsort.c pl-mutex.c
     pl-allocpool.c pl-wrap.c pl-event.c pl-transaction.c
-    pl-undo.c)
+    pl-undo.c pl-inline.c)
 
 set(LIBSWIPL_SRC
     ${SRC_CORE}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,7 +73,7 @@ set(SRC_CORE pl-atom.c pl-wam.c pl-arith.c pl-bag.c pl-error.c
     pl-copyterm.c pl-debug.c pl-cont.c pl-ressymbol.c pl-dict.c
     pl-trie.c pl-indirect.c pl-tabling.c pl-rsort.c pl-mutex.c
     pl-allocpool.c pl-wrap.c pl-event.c pl-transaction.c
-    pl-undo.c pl-inline.c)
+    pl-undo.c pl-inline.c pl-alloc.c pl-index.c pl-fli.c)
 
 set(LIBSWIPL_SRC
     ${SRC_CORE}

--- a/src/os/pl-buffer.h
+++ b/src/os/pl-buffer.h
@@ -105,7 +105,7 @@ int	growBuffer(Buffer b, size_t minfree);
 #define allocFromBuffer(b, bytes) \
 	f__allocFromBuffer((Buffer)(b), (bytes))
 
-static inline void*
+PL_INLINE void*
 f__allocFromBuffer(Buffer b, size_t bytes)
 { if ( b->top + bytes <= b->max ||
        growBuffer(b, bytes) )
@@ -142,13 +142,13 @@ f__allocFromBuffer(Buffer b, size_t bytes)
 	((b)->top -= sizeof(type), (type*)(b)->top)
 #define discardBuffer(b)	 discardBuffer_((Buffer)(b))
 
-static inline void
+PL_INLINE void
 discardBuffer_(Buffer b)
 { if ( b->base && b->base != b->static_buffer )
     tmp_free(b->base);
 }
 
-static inline void
+PL_INLINE void
 emptyBuffer_(Buffer b, size_t discardsize, size_t emptysize)
 { if ( b->max - b->base < discardsize )
   { b->top = b->base;

--- a/src/os/pl-stream.c
+++ b/src/os/pl-stream.c
@@ -67,6 +67,7 @@ locking is required.
 #endif
 
 #define PL_KERNEL 1
+#define PL_INLINE inline
 #define O_LOCALE 1
 #include <wchar.h>
 #define NEEDS_SWINSOCK

--- a/src/os/pl-table.h
+++ b/src/os/pl-table.h
@@ -87,7 +87,7 @@ COMMON(int)		htable_iter(Table ht, KVS kvs, int *idx,
 				    void **name, void **value);
 COMMON(size_t)		sizeofTable(Table ht);
 
-static inline int
+PL_INLINE int
 htable_valid_kv(void *kv)
 { intptr_t kvi = (intptr_t)kv;		/* avoid NULL, HTABLE_TOMBSTONE */
   return kvi > 0 || kvi	< -2;		/* and HTABLE_SENTINEL */

--- a/src/os/pl-text.h
+++ b/src/os/pl-text.h
@@ -93,7 +93,7 @@ COMMON(int)		get_atom_ptr_text(Atom atom, PL_chars_t *text);
 COMMON(int)		get_atom_text(atom_t atom, PL_chars_t *text);
 COMMON(int)		get_string_text(atom_t atom, PL_chars_t *text ARG_LD);
 
-static inline int
+PL_INLINE int
 text_get_char(const PL_chars_t *t, size_t i)
 { assert(t->canonical);
   return t->encoding == ENC_ISO_LATIN_1 ? t->text.t[i]&0xff
@@ -101,7 +101,7 @@ text_get_char(const PL_chars_t *t, size_t i)
 }
 
 
-static inline size_t
+PL_INLINE size_t
 text_chr(const PL_chars_t *t, int chr)
 { assert(t->canonical);
   if ( t->encoding == ENC_ISO_LATIN_1 )

--- a/src/os/pl-utf8.c
+++ b/src/os/pl-utf8.c
@@ -35,6 +35,7 @@
 */
 
 #include <string.h>			/* get size_t */
+#define PL_INLINE inline
 #include "pl-utf8.h"
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/os/pl-utf8.h
+++ b/src/os/pl-utf8.h
@@ -88,7 +88,7 @@ extern unicode_type_t _PL__utf8_type(const char *in0, size_t len);
 		 *	 INLINE FUNCTIONS	*
 		 *******************************/
 
-static inline int
+PL_INLINE int
 PL_utf8_code_point(const char **i, const char *e, int *cp)
 { unsigned char c = (unsigned char)**i;
 
@@ -100,7 +100,7 @@ PL_utf8_code_point(const char **i, const char *e, int *cp)
     return _PL__utf8_code_point(i, e, cp);
 }
 
-static inline char *
+PL_INLINE char *
 utf8_skip_char(const char *in)
 { if ( !(in[0]&0x80) )
   { return (char*)in+1;
@@ -112,7 +112,7 @@ utf8_skip_char(const char *in)
   }
 }
 
-static inline char *
+PL_INLINE char *
 utf8_skip_char_e(const char *in, const char *end)
 { if ( !(in[0]&0x80) )
   { return (char*)in+1;
@@ -124,14 +124,14 @@ utf8_skip_char_e(const char *in, const char *end)
   }
 }
 
-static inline char *
+PL_INLINE char *
 utf8_backskip_char(const char *start, const char *s)
 { for(s--; s>start && ISUTF8_CB(*s); s--)
     ;
   return (char*)s;
 }
 
-static inline int
+PL_INLINE int
 utf8_code_bytes(int chr)
 { if ( chr < 0x80 ) return 1;
   if ( chr < 0x800 ) return 2;

--- a/src/pl-alloc-inline.h
+++ b/src/pl-alloc-inline.h
@@ -1,0 +1,55 @@
+#ifndef _PL_ALLOC_INLINE_H
+#define _PL_ALLOC_INLINE_H
+
+ALLOC_INLINED size_t					/* size in cells */
+gsizeIndirectFromCode(Code pc)
+{ return wsizeofInd(pc[0]) + 2;
+}
+
+struct word_and_Code {
+	word word;
+	Code code;
+};
+#define WORD_AND_CODE(w,c) ((struct word_and_Code){(w),(c)})
+
+/* The VM_ alternatives of these functions pass and return pc, to avoid needing to
+ * store it in a memory address */
+ALLOC_INLINED COMMON(struct word_and_Code)
+VM_globalIndirectFromCode(Code pc ARG_LD)
+{ word m = *pc++;
+  size_t n = wsizeofInd(m);
+  Word p = allocGlobal(n+2);
+
+  if ( p )
+  { word r = consPtr(p, tag(m)|STG_GLOBAL);
+
+    *p++ = m;
+    while(n-- > 0)
+      *p++ = *pc++;
+    *p++ = m;
+
+    return WORD_AND_CODE(r, pc);
+  } else
+    return WORD_AND_CODE(0, pc);
+}
+
+ALLOC_INLINED COMMON(struct word_and_Code)				/* used in pl-wam.c */
+VM_equalIndirectFromCode(word a, Code pc ARG_LD)
+{ Code orig_pc = pc;
+  Word pa = addressIndirect(a);
+
+  if ( *pc == *pa )
+  { size_t n = wsizeofInd(*pc);
+
+    while(n-- > 0)
+    { if ( *++pc != *++pa )
+	return WORD_AND_CODE(FALSE, orig_pc);
+    }
+    pc++;
+    return WORD_AND_CODE(TRUE, pc);
+  }
+
+  return WORD_AND_CODE(FALSE, orig_pc);
+}
+
+#endif

--- a/src/pl-alloc.h
+++ b/src/pl-alloc.h
@@ -119,6 +119,7 @@ COMMON(int)		put_int64(Word p, int64_t i, int flags ARG_LD);
 COMMON(int64_t)		valBignum__LD(word w ARG_LD);
 #endif
 COMMON(int)		equalIndirect(word r1, word r2);
+ALLOC_INLINED
 COMMON(size_t)		gsizeIndirectFromCode(Code PC);
 COMMON(word)		globalIndirectFromCode(Code *PC);
 COMMON(void *)		tmp_malloc(size_t req);

--- a/src/pl-arith.h
+++ b/src/pl-arith.h
@@ -83,7 +83,7 @@ COMMON(double)		PL_nan(void);
 		 *	 INLINE FUNCTIONS	*
 		 *******************************/
 
-static inline Number
+PL_INLINE Number
 allocArithStack(ARG1_LD)
 { if ( unlikely(LD->arith.stack.top == LD->arith.stack.max) )
     return growArithStack(PASS_LD1);
@@ -91,26 +91,26 @@ allocArithStack(ARG1_LD)
   return LD->arith.stack.top++;
 }
 
-static inline void
+PL_INLINE void
 pushArithStack(Number n ARG_LD)
 { Number np = allocArithStack(PASS_LD1);
 
   *np = *n;				/* structure copy */
 }
 
-static inline void
+PL_INLINE void
 resetArithStack(ARG1_LD)
 { LD->arith.stack.top = LD->arith.stack.base;
 }
 
-static inline Number
+PL_INLINE Number
 argvArithStack(int n ARG_LD)
 { DEBUG(0, assert(LD->arith.stack.top - n >= LD->arith.stack.base));
 
   return LD->arith.stack.top - n;
 }
 
-static inline void
+PL_INLINE void
 popArgvArithStack(int n ARG_LD)
 { DEBUG(0, assert(LD->arith.stack.top - n >= LD->arith.stack.base));
 
@@ -124,7 +124,7 @@ popArgvArithStack(int n ARG_LD)
 		 *	      MPZ/MPQ		*
 		 *******************************/
 
-static inline int
+PL_INLINE int
 isMPQNum__LD(word w ARG_LD)
 { if ( tagex(w) == (TAG_INTEGER|STG_GLOBAL) )
   { Word p = addressIndirect(w);
@@ -139,7 +139,7 @@ isMPQNum__LD(word w ARG_LD)
   return FALSE;
 }
 
-static inline int
+PL_INLINE int
 isMPZNum__LD(word w ARG_LD)
 { if ( tagex(w) == (TAG_INTEGER|STG_GLOBAL) )
   { Word p = addressIndirect(w);

--- a/src/pl-codelist.h
+++ b/src/pl-codelist.h
@@ -46,7 +46,7 @@ pl-file.c. These functions are used in pl-text.c.
 
 #define setHandle(h, w)		(*valTermRef(h) = (w))
 
-static inline word
+PL_INLINE word
 valHandle__LD(term_t r ARG_LD)
 { Word p = valTermRef(r);
 
@@ -63,13 +63,13 @@ valHandle__LD(term_t r ARG_LD)
 #define CLOSE_SEQ_STRING(p, p0, tail, term, l) \
 	CLOSE_SEQ_STRING__LD(p, p0, tail, term, l PASS_LD)
 
-static inline Word
+PL_INLINE Word
 INIT_SEQ_STRING__LD(size_t n ARG_LD)
 { return allocGlobal(n*3);
 }
 
 
-static inline Word
+PL_INLINE Word
 EXTEND_SEQ_CODES__LD(Word p, int c ARG_LD)
 { *p++ = FUNCTOR_dot2;
   *p++ = consInt(c);
@@ -79,7 +79,7 @@ EXTEND_SEQ_CODES__LD(Word p, int c ARG_LD)
 }
 
 
-static inline Word
+PL_INLINE Word
 EXTEND_SEQ_CHARS__LD(Word p, int c ARG_LD)
 { *p++ = FUNCTOR_dot2;
   *p++ = codeToAtom(c);
@@ -89,7 +89,7 @@ EXTEND_SEQ_CHARS__LD(Word p, int c ARG_LD)
 }
 
 
-static inline int
+PL_INLINE int
 CLOSE_SEQ_STRING__LD(Word p, Word p0, term_t tail, term_t term, term_t l ARG_LD)
 { setHandle(l, consPtr(p0, TAG_COMPOUND|STG_GLOBAL));
   p--;

--- a/src/pl-comp.h
+++ b/src/pl-comp.h
@@ -70,7 +70,7 @@ COMMON(int)		unify_functor(term_t t, functor_t fd, int how);
 COMMON(void)		vm_list(Code code, Code end);
 COMMON(Module)		clauseBodyContext(const Clause cl);
 
-static inline code
+PL_INLINE code
 fetchop(Code PC)
 { code op = decode(*PC);
 
@@ -80,7 +80,7 @@ fetchop(Code PC)
   return op;
 }
 
-static inline code			/* caller must hold the L_BREAK lock */
+PL_INLINE code			/* caller must hold the L_BREAK lock */
 fetchop_unlocked(Code PC)
 { code op = decode(*PC);
 
@@ -90,7 +90,7 @@ fetchop_unlocked(Code PC)
   return op;
 }
 
-static inline Code
+PL_INLINE Code
 stepPC(Code PC)
 { code op = fetchop(PC++);
 
@@ -101,7 +101,7 @@ stepPC(Code PC)
 }
 
 
-static inline Code
+PL_INLINE Code
 stepPC_unlocked(Code PC)
 { code op = fetchop_unlocked(PC++);
 

--- a/src/pl-dict.h
+++ b/src/pl-dict.h
@@ -56,7 +56,7 @@ COMMON(int)	  resortDictsInClause(Clause clause);
 COMMON(void)	  resortDictsInTerm(term_t t);
 
 #define termIsDict(w) termIsDict__LD(w PASS_LD)
-static inline int
+PL_INLINE int
 termIsDict__LD(word w ARG_LD)
 { Functor f = valueTerm(w);
   FunctorDef fd = valueFunctor(f->definition);
@@ -64,7 +64,7 @@ termIsDict__LD(word w ARG_LD)
   return ( fd->name == ATOM_dict && fd->arity%2 == 1 );
 }
 
-static inline int
+PL_INLINE int
 is_dict_key(word w)
 { return isAtom(w) || isTaggedInt(w);
 }

--- a/src/pl-event.h
+++ b/src/pl-event.h
@@ -101,7 +101,7 @@ COMMON(int)	retractall_event(Definition def, term_t head, atom_t start
 
 GLOBAL const event_type PL_events[PLEV_THIS_THREAD_EXIT+2];
 
-static inline event_list**
+PL_INLINE event_list**
 event_list_location(pl_event_type ev)
 { if ( likely(!PL_events[ev].local) )
   { return PL_events[ev].location;
@@ -112,7 +112,7 @@ event_list_location(pl_event_type ev)
 }
 
 
-static inline int WUNUSED
+PL_INLINE int WUNUSED
 callEventHook(pl_event_type ev, ...)
 { event_list **listp = event_list_location(ev);
 

--- a/src/pl-fli-inline.h
+++ b/src/pl-fli-inline.h
@@ -1,0 +1,114 @@
+#ifndef _PL_FLI_INLINE_H
+#define _PL_FLI_INLINE_H
+
+#include "pl-codelist.h"
+#define setHandle(h, w)		(*valTermRef(h) = (w))
+#define valHandleP(h)		valTermRef(h)
+
+FLI_INLINED int
+PL_get_atom__LD(term_t t, atom_t *a ARG_LD)
+{ word w = valHandle(t);
+
+  if ( isAtom(w) )
+  { *a = (atom_t) w;
+    succeed;
+  }
+  fail;
+}
+
+FLI_INLINED int
+PL_is_variable__LD(term_t t ARG_LD)
+{ word w = valHandle(t);
+
+  return canBind(w) ? TRUE : FALSE;
+}
+
+FLI_INLINED int
+PL_is_atom__LD(term_t t ARG_LD)
+{ word w = valHandle(t);
+
+  if ( isTextAtom(w) )
+    return TRUE;
+
+  return FALSE;
+}
+
+FLI_INLINED int
+PL_is_functor__LD(term_t t, functor_t f ARG_LD)
+{ word w = valHandle(t);
+
+  if ( hasFunctor(w, f) )
+    succeed;
+
+  fail;
+}
+
+FLI_INLINED int
+PL_is_atomic__LD(term_t t ARG_LD)
+{ word w = valHandle(t);
+
+  return !!isAtomic(w);
+}
+
+FLI_INLINED int
+PL_put_variable__LD(term_t t ARG_LD)
+{ Word p = valTermRef(t);
+
+  setVar(*p);
+  return TRUE;
+}
+
+FLI_INLINED int
+PL_put_atom__LD(term_t t, atom_t a ARG_LD)
+{ setHandle(t, a);
+  return TRUE;
+}
+
+FLI_INLINED int
+PL_put_int64__LD(term_t t, int64_t i ARG_LD)
+{ word w = consInt(i);
+
+  if ( valInt(w) != i &&
+       put_int64(&w, i, ALLOW_GC PASS_LD) != TRUE )
+    return FALSE;
+
+  setHandle(t, w);
+  return TRUE;
+}
+
+FLI_INLINED int
+PL_put_integer__LD(term_t t, long i ARG_LD)
+{ return PL_put_int64__LD(t, i PASS_LD);
+}
+
+FLI_INLINED int
+PL_put_intptr__LD(term_t t, intptr_t i ARG_LD)
+{ return PL_put_int64__LD(t, i PASS_LD);
+}
+
+FLI_INLINED predicate_t
+_PL_predicate(const char *name, int arity, const char *module,
+	      predicate_t *bin)
+{ if ( !*bin )
+    *bin = PL_predicate(name, arity, module);
+
+  return *bin;
+}
+
+FLI_INLINED except_class
+classify_exception__LD(term_t exception ARG_LD)
+{ Word p;
+
+  if ( !exception )
+    return EXCEPT_NONE;
+
+  p = valTermRef(exception);
+  return classify_exception_p(p);
+}
+
+FLI_INLINED int
+PL_pending__LD(int sig ARG_LD)
+{ return pendingSignal(LD, sig);
+}
+
+#endif /* _PL_FLI_INLINE_H */

--- a/src/pl-fli.c
+++ b/src/pl-fli.c
@@ -40,8 +40,16 @@
 #include "os/pl-ctype.h"
 #include "os/pl-utf8.h"
 #include "os/pl-text.h"
+#include "os/pl-cstack.h"
 #include "pl-codelist.h"
+#include "pl-dict.h"
+#include "pl-arith.h"
+#include "pl-wrap.h"
+#include "pl-comp.h"
 #include <errno.h>
+
+/* Emit the non-inline definitions here */
+#include "pl-fli-inline.h"
 
 #ifdef __SANITIZE_ADDRESS__
 #include <sanitizer/lsan_interface.h>
@@ -88,8 +96,6 @@ Prolog int) is used by the garbage collector to update the stack frames.
 #endif
 #endif
 
-#define setHandle(h, w)		(*valTermRef(h) = (w))
-#define valHandleP(h)		valTermRef(h)
 #define VALID_INT_ARITY(a) \
 	{ if ( arity < 0 || arity > INT_MAX ) \
 	    fatalError("Arity out of range: %lld", (int64_t)arity); \
@@ -1441,17 +1447,7 @@ PL_get_bool(term_t t, int *b)
 }
 
 
-int
-PL_get_atom__LD(term_t t, atom_t *a ARG_LD)
-{ word w = valHandle(t);
-
-  if ( isAtom(w) )
-  { *a = (atom_t) w;
-    succeed;
-  }
-  fail;
-}
-
+/* PL_get_atom__LD(term_t t, atom_t *a ARG_LD) moved to pl-fli-inline.h */
 
 #undef PL_get_atom
 int
@@ -2277,13 +2273,7 @@ _PL_get_xpce_reference(term_t t, xpceref_t *ref)
 		 *		IS-*		*
 		 *******************************/
 
-int
-PL_is_variable__LD(term_t t ARG_LD)
-{ word w = valHandle(t);
-
-  return canBind(w) ? TRUE : FALSE;
-}
-
+/* PL_is_variable__LD(term_t t ARG_LD) moved to pl-fli-inline.h */
 
 #undef PL_is_variable
 int
@@ -2296,15 +2286,7 @@ PL_is_variable(term_t t)
 #define PL_is_variable(t) PL_is_variable__LD(t PASS_LD)
 
 
-int
-PL_is_atom__LD(term_t t ARG_LD)
-{ word w = valHandle(t);
-
-  if ( isTextAtom(w) )
-    return TRUE;
-
-  return FALSE;
-}
+/* PL_is_atom__LD(term_t t ARG_LD) moved to pl-fli-inline.h */
 
 
 #undef PL_is_atom
@@ -2409,17 +2391,7 @@ PL_is_callable(term_t t)
   return isCallable(valHandle(t) PASS_LD);
 }
 
-
-int
-PL_is_functor__LD(term_t t, functor_t f ARG_LD)
-{ word w = valHandle(t);
-
-  if ( hasFunctor(w, f) )
-    succeed;
-
-  fail;
-}
-
+/* PL_is_functor__LD(term_t t, functor_t f ARG_LD) moved to pl-fli-inline.h */
 
 #undef PL_is_functor
 int
@@ -2453,12 +2425,7 @@ PL_is_pair(term_t t)
 }
 
 
-int
-PL_is_atomic__LD(term_t t ARG_LD)
-{ word w = valHandle(t);
-
-  return !!isAtomic(w);
-}
+/* PL_is_atomic__LD(term_t t ARG_LD) moved to pl-fli-inline.h */
 
 
 #undef PL_is_atomic
@@ -2518,13 +2485,6 @@ PL_unify_string_nchars(term_t t, size_t len, const char *s)
 		 *             PUT-*		*
 		 *******************************/
 
-int
-PL_put_variable__LD(term_t t ARG_LD)
-{ Word p = valTermRef(t);
-
-  setVar(*p);
-  return TRUE;
-}
 
 
 #undef PL_put_variable
@@ -2537,12 +2497,7 @@ PL_put_variable(term_t t)
 #define PL_put_variable(t) PL_put_variable__LD(t PASS_LD)
 
 
-int
-PL_put_atom__LD(term_t t, atom_t a ARG_LD)
-{ setHandle(t, a);
-  return TRUE;
-}
-
+/* PL_put_atom__LD(term_t t, atom_t a ARG_LD) moved to pl-fli-inline.h */
 
 #undef PL_put_atom
 int
@@ -2724,29 +2679,9 @@ PL_put_list_chars(term_t t, const char *chars)
 }
 
 
-int
-PL_put_int64__LD(term_t t, int64_t i ARG_LD)
-{ word w = consInt(i);
-
-  if ( valInt(w) != i &&
-       put_int64(&w, i, ALLOW_GC PASS_LD) != TRUE )
-    return FALSE;
-
-  setHandle(t, w);
-  return TRUE;
-}
-
-
-int
-PL_put_integer__LD(term_t t, long i ARG_LD)
-{ return PL_put_int64__LD(t, i PASS_LD);
-}
-
-
-int
-PL_put_intptr__LD(term_t t, intptr_t i ARG_LD)
-{ return PL_put_int64__LD(t, i PASS_LD);
-}
+/* PL_put_int64__LD(term_t t, int64_t i ARG_LD) moved to pl-fli-inline.h */
+/* PL_put_integer__LD(term_t t, long i ARG_LD) moved to pl-fli-inline.h */
+/* PL_put_intptr__LD(term_t t, intptr_t i ARG_LD) moved to pl-fli-inline.h */
 
 
 int
@@ -4265,14 +4200,7 @@ PL_predicate(const char *name, int arity, const char *module)
 }
 
 
-predicate_t
-_PL_predicate(const char *name, int arity, const char *module,
-	      predicate_t *bin)
-{ if ( !*bin )
-    *bin = PL_predicate(name, arity, module);
-
-  return *bin;
-}
+/* _PL_predicate(const char *name, int arity, const char *module, moved to pl-fli-inline.h */
 
 
 int
@@ -4360,7 +4288,7 @@ PL_foreign_context_predicate(control_t h)
   return isCurrentProcedure(def->functor->functor, def->module);
 }
 
-static int
+int
 has_emergency_space(void *sv, size_t needed)
 { Stack s = (Stack) sv;
   ssize_t lacking = ((char*)s->top + needed) - (char*)s->max;
@@ -4452,16 +4380,7 @@ classify_exception_p__LD(Word p ARG_LD)
 }
 
 
-except_class
-classify_exception__LD(term_t exception ARG_LD)
-{ Word p;
-
-  if ( !exception )
-    return EXCEPT_NONE;
-
-  p = valTermRef(exception);
-  return classify_exception_p(p);
-}
+/* classify_exception__LD(term_t exception ARG_LD) moved to pl-fli-inline.h */
 
 
 int
@@ -4864,10 +4783,7 @@ PL_raise(int sig)
 }
 
 
-int
-PL_pending__LD(int sig ARG_LD)
-{ return pendingSignal(LD, sig);
-}
+/* PL_pending__LD(int sig ARG_LD) moved to pl-fli-inline.h */
 
 
 int

--- a/src/pl-funcs.h
+++ b/src/pl-funcs.h
@@ -69,6 +69,7 @@ COMMON(fid_t)		PL_open_foreign_frame__LD(ARG1_LD);
 COMMON(void)		PL_close_foreign_frame__LD(fid_t id ARG_LD);
 COMMON(fid_t)		PL_open_signal_foreign_frame(int sync);
 COMMON(int)		foreignWakeup(term_t ex ARG_LD);
+COMMON(void)		resumeAfterException(int clear, Stack outofstack);
 COMMON(void)		updateAlerted(PL_local_data_t *ld);
 COMMON(int)		raiseSignal(PL_local_data_t *ld, int sig);
 COMMON(int)		pendingSignal(PL_local_data_t *ld, int sig);
@@ -160,6 +161,7 @@ COMMON(word)		linkValG__LD(Word p ARG_LD);
 COMMON(word)		linkValNoG__LD(Word p ARG_LD);
 COMMON(void)		bArgVar(Word ap, Word vp ARG_LD);
 COMMON(int)		_PL_put_number__LD(term_t t, Number n ARG_LD);
+FLI_INLINED
 COMMON(predicate_t)	_PL_predicate(const char *name, int arity,
 				      const char *module, predicate_t *bin);
 COMMON(void)		initialiseForeign(int argc, char **argv);
@@ -174,6 +176,7 @@ COMMON(int)		_PL_get_arg__LD(size_t index, term_t t, term_t a ARG_LD);
 COMMON(term_t)		PL_new_term_ref__LD(ARG1_LD);
 COMMON(term_t)		PL_new_term_ref_noshift__LD(ARG1_LD);
 COMMON(term_t)		PL_new_term_refs__LD(int n ARG_LD);
+COMMON(int)		globalize_term_ref__LD(term_t t ARG_LD);
 COMMON(void)		PL_reset_term_refs__LD(term_t r ARG_LD);
 COMMON(term_t)		PL_copy_term_ref__LD(term_t from ARG_LD);
 COMMON(int)		PL_unify__LD(term_t t1, term_t t2 ARG_LD);
@@ -182,14 +185,24 @@ COMMON(int)		PL_unify_integer__LD(term_t t1, intptr_t i ARG_LD);
 COMMON(int)		PL_unify_int64__LD(term_t t1, int64_t ARG_LD);
 COMMON(int)		PL_unify_int64_ex__LD(term_t t1, int64_t ARG_LD);
 COMMON(int)		PL_unify_functor__LD(term_t t, functor_t f ARG_LD);
+FLI_INLINED
 COMMON(int)		PL_get_atom__LD(term_t t1, atom_t *a ARG_LD);
 COMMON(int)		PL_get_text_as_atom(term_t t, atom_t *a, int flags);
+FLI_INLINED
 COMMON(int)		PL_put_variable__LD(term_t t1 ARG_LD);
+FLI_INLINED
 COMMON(int)		PL_put_atom__LD(term_t t1, atom_t a ARG_LD);
+FLI_INLINED
 COMMON(int)		PL_put_integer__LD(term_t t1, long i ARG_LD);
+FLI_INLINED
+COMMON(int)		PL_put_int64__LD(term_t t, int64_t i ARG_LD);
+FLI_INLINED
 COMMON(int)		PL_put_intptr__LD(term_t t1, intptr_t i ARG_LD);
+FLI_INLINED
 COMMON(int)		PL_is_atomic__LD(term_t t ARG_LD);
+FLI_INLINED
 COMMON(int)		PL_is_functor__LD(term_t t, functor_t f ARG_LD);
+FLI_INLINED
 COMMON(int)		PL_is_variable__LD(term_t t ARG_LD);
 COMMON(int)		PL_strip_module__LD(term_t q, module_t *m,
 					    term_t t, int flags ARG_LD) WUNUSED;
@@ -210,6 +223,7 @@ COMMON(int)		PL_get_uintptr(term_t t, size_t *i);
 COMMON(int)		PL_unify_atom__LD(term_t t, atom_t a ARG_LD);
 COMMON(int)		PL_unify_pointer__LD(term_t t, void *ptr ARG_LD);
 COMMON(int)		PL_get_list__LD(term_t l, term_t h, term_t t ARG_LD);
+FLI_INLINED
 COMMON(int)		PL_is_atom__LD(term_t t ARG_LD);
 COMMON(int)		PL_unify_list__LD(term_t l, term_t h, term_t t ARG_LD);
 COMMON(int)		PL_cons_list__LD(term_t l, term_t head, term_t tail
@@ -227,10 +241,13 @@ COMMON(void)            bindExtensions(const char *module,
 				       const PL_extension *ext);
 COMMON(void)		initForeign(void);
 COMMON(int)		PL_rethrow(void);
+FLI_INLINED
 COMMON(int)		PL_pending__LD(int sig ARG_LD);
 COMMON(int)		PL_clearsig__LD(int sig ARG_LD);
 COMMON(void)		cleanupCodeToAtom(void);
 COMMON(void)		PL_clear_foreign_exception(LocalFrame fr);
+COMMON(int)		has_emergency_space(void *sv, size_t needed);
+FLI_INLINED
 COMMON(except_class)    classify_exception__LD(term_t ex ARG_LD);
 COMMON(except_class)    classify_exception_p__LD(Word p ARG_LD);
 COMMON(void)		PL_abort_process(void) NORETURN;

--- a/src/pl-gmp.h
+++ b/src/pl-gmp.h
@@ -71,22 +71,22 @@ COMMON(void)	mpq_set_double(mpq_t q, double f);
 #define clearNumber(n) \
 	do { if ( (n)->type != V_INTEGER ) clearGMPNumber(n); } while(0)
 
-static inline word
+PL_INLINE word
 mpz_size_stack(int sz)
 { return ((word)sz<<1) & ~(word)MP_RAT_MASK;
 }
 
-static inline word
+PL_INLINE word
 mpq_size_stack(int sz)
 { return ((word)sz<<1) | MP_RAT_MASK;
 }
 
-static inline int
+PL_INLINE int
 mpz_stack_size(word w)
 { return (int)w>>1;
 }
 
-static inline int
+PL_INLINE int
 mpq_stack_size(word w)
 { return (int)w>>1;
 }

--- a/src/pl-incl.h
+++ b/src/pl-incl.h
@@ -2607,6 +2607,28 @@ decrease).
 #include "pl-atom.ih"
 #include "pl-funct.ih"
 
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Some functions can be inlined for some files only. These functions get
+declared with usual attributes for most files, including their original
+sources; files that want the inlines can define USE_XYZ_INLINES prior to
+including pl-incl.h, and for that file the function will be defined as
+"inline" - not "static inline" or "extern inline" but just "inline".
+What that means is that the function won't be compiled into a standalone
+code block in that file, and if the compiler decides not to inline it,
+it will emit a reference to the library-shared version of the function.
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+#if USE_FLI_INLINES
+# define FLI_INLINED inline
+#else
+# define FLI_INLINED 
+#endif
+#if USE_ALLOC_INLINES
+# define ALLOC_INLINED inline
+#else
+# define ALLOC_INLINED 
+#endif
+
 #include "pl-alloc.h"			/* Allocation primitives */
 #include "pl-init.h"			/* Declarations needed by pl-init.c */
 #include "pl-error.h"			/* Exception generation */
@@ -2634,4 +2656,11 @@ decrease).
 #undef try
 #endif
 
+/* include the appropriate inlines, when requested */
+#if USE_FLI_INLINES
+#include "pl-fli-inline.h"
+#endif
+#if USE_ALLOC_INLINES
+#include "pl-alloc-inline.h"
+#endif
 #endif /*_PL_INCLUDE_H*/

--- a/src/pl-inline.c
+++ b/src/pl-inline.c
@@ -1,0 +1,26 @@
+
+/* This file contains implementations of the usually-inlined functions
+ * in pl-inline.h (and other header files). If every usage of a PL_INLINE
+ * function does get inlined, it will get stripped out of the final library.
+ * If not, however, all non-inlined references will call the same function.
+ */
+
+#define EMIT_SHARED_INLINES
+
+/* This list of headers MUST include all files with a PL_INLINE declaration */
+#include "pl-incl.h"
+#include "pl-arith.h"
+#include "pl-codelist.h"
+#include "pl-comp.h"
+#include "pl-dict.h"
+#include "pl-event.h"
+#include "pl-gmp.h"
+#include "pl-inline.h"
+#include "pl-privitf.h"
+#include "pl-segstack.h"
+#include "pl-thread.h"
+#include "pl-trie.h"
+#include "os/pl-buffer.h"
+#include "os/pl-table.h"
+#include "os/pl-text.h"
+#include "os/pl-utf8.h"

--- a/src/pl-inline.h
+++ b/src/pl-inline.h
@@ -72,7 +72,7 @@
 */
 
 #define HAVE_MSB 1
-static inline int
+PL_INLINE int
 MSB(size_t i)
 { unsigned long index;
 #if SIZEOF_VOIDP == 8
@@ -88,7 +88,7 @@ MSB(size_t i)
 
 #if SIZEOF_VOIDP == 8
 #define HAVE_MSB64 1
-static inline int
+PL_INLINE int
 MSB64(int64_t i)
 { unsigned long index;
   _BitScanReverse64(&index, i);
@@ -100,7 +100,7 @@ MSB64(int64_t i)
 #define MEMORY_RELEASE() MemoryBarrier()
 #define MEMORY_BARRIER() MemoryBarrier()
 
-static inline size_t
+PL_INLINE size_t
 __builtin_popcount(size_t sz)
 {
 #if SIZEOF_VOIDP == 4
@@ -142,39 +142,39 @@ __builtin_popcount(size_t sz)
 	__atomic_compare_exchange_n(at, &(from), to, FALSE, \
 				    __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST)
 
-static inline int
+PL_INLINE int
 COMPARE_AND_SWAP_PTR(void *at, void *from, void *to)
 { void **ptr = at;
 
   return __COMPARE_AND_SWAP(ptr, from, to);
 }
 
-static inline int
+PL_INLINE int
 COMPARE_AND_SWAP_INT64(int64_t *at, int64_t from, int64_t to)
 { return __COMPARE_AND_SWAP(at, from, to);
 }
 
-static inline int
+PL_INLINE int
 COMPARE_AND_SWAP_UINT64(uint64_t *at, uint64_t from, uint64_t to)
 { return __COMPARE_AND_SWAP(at, from, to);
 }
 
-static inline int
+PL_INLINE int
 COMPARE_AND_SWAP_INT(int *at, int from, int to)
 { return __COMPARE_AND_SWAP(at, from, to);
 }
 
-static inline int
+PL_INLINE int
 COMPARE_AND_SWAP_UINT(unsigned int *at, unsigned int from, unsigned int to)
 { return __COMPARE_AND_SWAP(at, from, to);
 }
 
-static inline int
+PL_INLINE int
 COMPARE_AND_SWAP_SIZE(size_t *at, size_t from, size_t to)
 { return __COMPARE_AND_SWAP(at, from, to);
 }
 
-static inline int
+PL_INLINE int
 COMPARE_AND_SWAP_WORD(word *at, word from, word to)
 { return __COMPARE_AND_SWAP(at, from, to);
 }
@@ -198,7 +198,7 @@ COMPARE_AND_SWAP_WORD(word *at, word from, word to)
 
 #ifndef HAVE_MSB
 #define HAVE_MSB 1
-static inline int
+PL_INLINE int
 MSB(size_t i)
 { int j = 0;
 
@@ -218,7 +218,7 @@ MSB(size_t i)
 
 #ifndef HAVE_MSB64
 #define HAVE_MSB64 1
-static inline int
+PL_INLINE int
 MSB64(int64_t i)
 { int j = 0;
 
@@ -244,13 +244,13 @@ MSB64(int64_t i)
 		 *	 ATOMS/FUNCTORS		*
 		 *******************************/
 
-static inline void
+PL_INLINE void
 initAtoms(void)
 { if ( !likely(GD->atoms.initialised) )
     do_init_atoms();
 }
 
-static inline Atom
+PL_INLINE Atom
 fetchAtomArray(size_t index)
 { int idx = MSB(index);
 
@@ -258,14 +258,14 @@ fetchAtomArray(size_t index)
 }
 
 
-static inline FunctorDef
+PL_INLINE FunctorDef
 fetchFunctorArray(size_t index)
 { int idx = MSB(index);
 
   return GD->functors.array.blocks[idx][index];
 }
 
-static inline void
+PL_INLINE void
 pushVolatileAtom__LD(atom_t a ARG_LD)
 { LD->atoms.unregistering = a;
   if ( GD->atoms.gc_active )
@@ -290,12 +290,12 @@ typedef struct bit_vector
 #define offset(s, f) ((size_t)(&((struct s *)NULL)->f))
 #endif
 
-static inline size_t
+PL_INLINE size_t
 sizeof_bitvector(size_t bits)
 { return offset(bit_vector, chunk[(bits+BITSPERE-1)/BITSPERE]);
 }
 
-static inline void
+PL_INLINE void
 init_bitvector(bit_vector *v, size_t bits)
 { size_t bytes = offset(bit_vector, chunk[(bits+BITSPERE-1)/BITSPERE]);
 
@@ -303,7 +303,7 @@ init_bitvector(bit_vector *v, size_t bits)
   v->size = bits;
 }
 
-static inline bit_vector *
+PL_INLINE bit_vector *
 new_bitvector(size_t size)
 { size_t bytes = offset(bit_vector, chunk[(size+BITSPERE-1)/BITSPERE]);
   bit_vector *v = allocHeapOrHalt(bytes);
@@ -313,28 +313,28 @@ new_bitvector(size_t size)
   return v;
 }
 
-static inline void
+PL_INLINE void
 free_bitvector(bit_vector *v)
 { size_t bytes = offset(bit_vector, chunk[(v->size+BITSPERE-1)/BITSPERE]);
 
   freeHeap(v, bytes);
 }
 
-static inline void
+PL_INLINE void
 clear_bitvector(bit_vector *v)
 { size_t chunks = (v->size+BITSPERE-1)/BITSPERE;
 
   memset(v->chunk, 0, chunks*sizeof(bitv_chunk));
 }
 
-static inline void
+PL_INLINE void
 setall_bitvector(bit_vector *v)
 { size_t chunks = (v->size+BITSPERE-1)/BITSPERE;
 
   memset(v->chunk, 0xff, chunks*sizeof(bitv_chunk));
 }
 
-static inline void
+PL_INLINE void
 set_bit(bit_vector *v, size_t which)
 { size_t e = which/BITSPERE;
   size_t b = which%BITSPERE;
@@ -342,7 +342,7 @@ set_bit(bit_vector *v, size_t which)
   v->chunk[e] |= ((bitv_chunk)1<<b);
 }
 
-static inline void
+PL_INLINE void
 clear_bit(bit_vector *v, size_t which)
 { size_t e = which/BITSPERE;
   size_t b = which%BITSPERE;
@@ -350,7 +350,7 @@ clear_bit(bit_vector *v, size_t which)
   v->chunk[e] &= ~((bitv_chunk)1<<b);
 }
 
-static inline int
+PL_INLINE int
 true_bit(bit_vector *v, size_t which)
 { size_t e = which/BITSPERE;
   size_t b = which%BITSPERE;
@@ -358,7 +358,7 @@ true_bit(bit_vector *v, size_t which)
   return (v->chunk[e]&((bitv_chunk)1<<b)) != 0;
 }
 
-static inline size_t
+PL_INLINE size_t
 popcount_bitvector(const bit_vector *v)
 { const bitv_chunk *p = v->chunk;
   int cnt = (int)(v->size+BITSPERE-1)/BITSPERE;
@@ -378,7 +378,7 @@ popcount_bitvector(const bit_vector *v)
 static int	  same_type_numbers(Number n1, Number n2) WUNUSED;
 static Definition lookupDefinition(functor_t f, Module m) WUNUSED;
 
-static inline int
+PL_INLINE int
 same_type_numbers(Number n1, Number n2)
 { if ( n1->type == n2->type )
     return TRUE;
@@ -386,7 +386,7 @@ same_type_numbers(Number n1, Number n2)
 }
 
 
-static inline Definition
+PL_INLINE Definition
 lookupDefinition(functor_t f, Module m)
 { Procedure proc = lookupProcedure(f, m);
 
@@ -400,7 +400,7 @@ value need not be trailed.
 Note that the local stack is always _above_ the global stack.
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-static inline void
+PL_INLINE void
 Trail__LD(Word p, word v ARG_LD)
 { DEBUG(CHK_SECURE, assert(tTop+1 <= tMax));
 
@@ -410,7 +410,7 @@ Trail__LD(Word p, word v ARG_LD)
 }
 
 
-static inline void
+PL_INLINE void
 bindConst__LD(Word p, word c ARG_LD)
 { DEBUG(0, assert(hasGlobalSpace(0)));
 
@@ -430,7 +430,7 @@ bindConst__LD(Word p, word c ARG_LD)
 }
 
 
-static inline word
+PL_INLINE word
 consPtr__LD(void *p, uintptr_t base, word ts ARG_LD)
 { uintptr_t v = (uintptr_t) p;
 
@@ -441,7 +441,7 @@ consPtr__LD(void *p, uintptr_t base, word ts ARG_LD)
 
 
 #if ALIGNOF_DOUBLE != ALIGNOF_VOIDP
-static inline double
+PL_INLINE double
 valFloat__LD(word w ARG_LD)
 { Word p = valIndirectP(w);
   double d;
@@ -458,7 +458,7 @@ checking (unless compiled for debugging) and fetches the base address of
 the global stack only once.
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-static inline word
+PL_INLINE word
 linkValI__LD(Word p ARG_LD)
 { word w = *p;
   uintptr_t gb = LD->bases[STG_GLOBAL];
@@ -480,12 +480,12 @@ linkValI__LD(Word p ARG_LD)
   }
 }
 
-static inline int
+PL_INLINE int
 is_signalled(ARG1_LD)
 { return HAS_LD && unlikely((LD->signal.pending[0]|LD->signal.pending[1]) != 0);
 }
 
-static inline void
+PL_INLINE void
 register_attvar(Word gp ARG_LD)
 { if ( LD->attvar.attvars )
   { *gp = makeRefG(LD->attvar.attvars);
@@ -500,7 +500,7 @@ register_attvar(Word gp ARG_LD)
   LD->attvar.attvars = gp;
 }
 
-static inline int
+PL_INLINE int
 visibleClause__LD(Clause cl, gen_t gen ARG_LD)
 { gen_t c, e;
 
@@ -523,7 +523,7 @@ visibleClause__LD(Clause cl, gen_t gen ARG_LD)
   return FALSE;
 }
 
-static inline int
+PL_INLINE int
 visibleClauseCNT__LD(Clause cl, gen_t gen ARG_LD)
 { if ( likely(visibleClause__LD(cl, gen PASS_LD)) )
     return TRUE;
@@ -531,12 +531,12 @@ visibleClauseCNT__LD(Clause cl, gen_t gen ARG_LD)
   return FALSE;
 }
 
-static inline gen_t
+PL_INLINE gen_t
 global_generation(void)
 { return GD->_generation;
 }
 
-static inline gen_t
+PL_INLINE gen_t
 current_generation(Definition def ARG_LD)
 { if ( unlikely(!!LD->transaction.generation) && def && true(def, P_DYNAMIC) )
   { return LD->transaction.generation;
@@ -545,7 +545,7 @@ current_generation(Definition def ARG_LD)
   }
 }
 
-static inline gen_t
+PL_INLINE gen_t
 next_generation(Definition def ARG_LD)
 { if ( unlikely(!!LD->transaction.generation) && def && true(def, P_DYNAMIC) )
   { if ( LD->transaction.generation < LD->transaction.gen_max )
@@ -562,7 +562,7 @@ next_generation(Definition def ARG_LD)
   }
 }
 
-static inline gen_t
+PL_INLINE gen_t
 max_generation(Definition def ARG_LD)
 { if ( unlikely(!!LD->transaction.generation) && def && true(def, P_DYNAMIC) )
     return LD->transaction.gen_max;
@@ -581,7 +581,7 @@ global_generation()  and  storing  the  generation  in  our  frame,  our
 generation is updated and thus no harm is done.
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-static inline void
+PL_INLINE void
 setGenerationFrame__LD(LocalFrame fr ARG_LD)
 { if ( unlikely(LD->transaction.generation &&
 		true(fr->predicate, P_DYNAMIC)) )
@@ -596,7 +596,7 @@ setGenerationFrame__LD(LocalFrame fr ARG_LD)
   }
 }
 
-static inline int
+PL_INLINE int
 ensureLocalSpace__LD(size_t bytes ARG_LD)
 { int rc;
 
@@ -609,7 +609,7 @@ ensureLocalSpace__LD(size_t bytes ARG_LD)
   return raiseStackOverflow(rc);
 }
 
-static inline int
+PL_INLINE int
 ensureStackSpace__LD(size_t gcells, size_t tcells, int flags ARG_LD)
 { gcells += BIND_GLOBAL_SPACE;
   tcells += BIND_TRAIL_SPACE;
@@ -626,7 +626,7 @@ ensureStackSpace__LD(size_t gcells, size_t tcells, int flags ARG_LD)
 		 *******************************/
 
 #ifdef O_PLMT
-static inline PL_local_data_t *
+PL_INLINE PL_local_data_t *
 acquire_ldata__LD(PL_thread_info_t *info ARG_LD)
 { PL_local_data_t *ld = info->thread_data;
   LD->thread.info->access.ldata = ld;
@@ -650,7 +650,7 @@ it is divided by 4 and the low 2   bits  are placed at the top (they are
 normally 0). longToPointer() does the inverse operation.
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-static inline uintptr_t
+PL_INLINE uintptr_t
 pointerToInt(void *ptr)
 {
 #if SIZEOF_VOIDP == 8
@@ -667,7 +667,7 @@ pointerToInt(void *ptr)
 }
 
 
-static inline void *
+PL_INLINE void *
 intToPointer(uintptr_t p)
 {
 #if SIZEOF_VOIDP == 8

--- a/src/pl-privitf.h
+++ b/src/pl-privitf.h
@@ -71,7 +71,7 @@ typedef struct list_ctx
   Word gstore;
 } list_ctx;
 
-static inline void
+PL_INLINE void
 addAtomicList__LD(list_ctx *ctx, word value ARG_LD)
 { ctx->gstore[0] = consPtr(&ctx->gstore[1], TAG_COMPOUND|STG_GLOBAL);
   ctx->gstore[1] = FUNCTOR_dot2;

--- a/src/pl-segstack.h
+++ b/src/pl-segstack.h
@@ -67,7 +67,7 @@ typedef struct
 } segstack;
 
 
-static inline int
+PL_INLINE int
 emptySegStack(segstack *s)
 { return (s->top == s->base) &&
 	 (s->last == NULL || s->last->previous == NULL);
@@ -105,14 +105,14 @@ COMMON(void)	clearSegStack_(segstack *s);
 		 *	       INLINE		*
 		 *******************************/
 
-static inline void
+PL_INLINE void
 clearSegStack(segstack *s)
 { if ( s->first )
     clearSegStack_(s);
 }
 
 
-static inline void
+PL_INLINE void
 topsOfSegStack(segstack *stack, int count, void **tops)
 { char *p = stack->top - stack->unit_size;
   char *base = stack->base;
@@ -140,7 +140,7 @@ topsOfSegStack(segstack *stack, int count, void **tops)
    addition synchronization in that case.
 */
 
-static inline int
+PL_INLINE int
 quickPopTopOfSegStack(segstack *stack)
 { if ( stack->top >= stack->base + stack->unit_size )
   { stack->top -= stack->unit_size;
@@ -151,14 +151,14 @@ quickPopTopOfSegStack(segstack *stack)
 }
 
 
-static inline void
+PL_INLINE void
 popTopOfSegStack(segstack *stack)
 { if ( !quickPopTopOfSegStack(stack) )
     popTopOfSegStack_(stack);
 }
 
 
-static inline void
+PL_INLINE void
 initSegStack(segstack *stack, size_t unit_size, size_t len, void *data)
 { stack->unit_size = unit_size;
 

--- a/src/pl-thread.h
+++ b/src/pl-thread.h
@@ -244,7 +244,7 @@ compile-time
 
 #define IF_MT(id, g) if ( id == L_THREAD || GD->thread.enabled ) g
 
-static inline void
+PL_INLINE void
 countingMutexLock(counting_mutex *cm)
 {
 #if O_CONTENTION_STATISTICS
@@ -260,7 +260,7 @@ countingMutexLock(counting_mutex *cm)
   cm->lock_count++;
 }
 
-static inline void
+PL_INLINE void
 countingMutexUnlock(counting_mutex *cm)
 { assert(cm->lock_count > 0);
   cm->lock_count--;

--- a/src/pl-trie.h
+++ b/src/pl-trie.h
@@ -202,7 +202,7 @@ COMMON(void *)	map_trie_node(trie_node *n,
 			      void* (*map)(trie_node *n, void *ctx), void *ctx);
 COMMON(atom_t)	compile_trie(Definition def, trie *trie ARG_LD);
 
-static inline int
+PL_INLINE int
 trie_lookup(trie *trie, trie_node *node, trie_node **nodep,
 	    Word k, int add, TmpBuffer vars ARG_LD)
 { return trie_lookup_abstract(trie, node, nodep, k, add,

--- a/src/pl-wam.c
+++ b/src/pl-wam.c
@@ -36,6 +36,9 @@
 */
 
 /*#define O_DEBUG 1*/
+#define USE_FLI_INLINES 1
+#define USE_ALLOC_INLINES 1
+
 #include "pl-incl.h"
 #include "pl-comp.h"
 #include "pl-arith.h"
@@ -229,10 +232,6 @@ DbgPrintInstruction(LocalFrame FR, Code PC)
 #endif
 
 
-
-
-#include "pl-alloc.c"
-#include "pl-index.c"
 
 
 		 /*******************************
@@ -1762,7 +1761,7 @@ TBD: In these modern days we can  probably   do  GC. Still, if it is not
 needed why would we?
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-static void
+void
 resumeAfterException(int clear, Stack outofstack)
 { GET_LD
 
@@ -1809,8 +1808,6 @@ exceptionUnwindGC(void)
 		 /*******************************
 		 *   FOREIGN-LANGUAGE INTERFACE *
 		 *******************************/
-
-#include "pl-fli.c"
 
 #ifdef O_DEBUGGER
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
This changes how functions in pl-inline.h are declared and compiled without affecting the inline semantics, and also separates the compilation of pl-wam.c from the compilation of all the other .c files (except for pl-vmi.c).