### PR TITLE
BUILD: Moved pl-alloc/index/fli out of pl-wam

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,7 +73,7 @@ set(SRC_CORE pl-atom.c pl-wam.c pl-arith.c pl-bag.c pl-error.c
     pl-copyterm.c pl-debug.c pl-cont.c pl-ressymbol.c pl-dict.c
     pl-trie.c pl-indirect.c pl-tabling.c pl-rsort.c pl-mutex.c
     pl-allocpool.c pl-wrap.c pl-event.c pl-transaction.c
-    pl-undo.c)
+    pl-undo.c pl-alloc.c pl-index.c pl-fli.c)
 
 set(LIBSWIPL_SRC
     ${SRC_CORE}

--- a/src/pl-alloc-inline.h
+++ b/src/pl-alloc-inline.h
@@ -1,0 +1,55 @@
+#ifndef _PL_ALLOC_INLINE_H
+#define _PL_ALLOC_INLINE_H
+
+ALLOC_INLINE(size_t)					/* size in cells */
+gsizeIndirectFromCode(Code pc)
+{ return wsizeofInd(pc[0]) + 2;
+}
+
+struct word_and_Code {
+	word word;
+	Code code;
+};
+#define WORD_AND_CODE(w,c) ((struct word_and_Code){(w),(c)})
+
+/* The VM_ alternatives of these functions pass and return pc, to avoid needing to
+ * store it in a memory address */
+ALLOC_INLINE(struct word_and_Code)
+VM_globalIndirectFromCode(Code pc ARG_LD)
+{ word m = *pc++;
+  size_t n = wsizeofInd(m);
+  Word p = allocGlobal(n+2);
+
+  if ( p )
+  { word r = consPtr(p, tag(m)|STG_GLOBAL);
+
+    *p++ = m;
+    while(n-- > 0)
+      *p++ = *pc++;
+    *p++ = m;
+
+    return WORD_AND_CODE(r, pc);
+  } else
+    return WORD_AND_CODE(0, pc);
+}
+
+ALLOC_INLINE(struct word_and_Code)				/* used in pl-wam.c */
+VM_equalIndirectFromCode(word a, Code pc ARG_LD)
+{ Code orig_pc = pc;
+  Word pa = addressIndirect(a);
+
+  if ( *pc == *pa )
+  { size_t n = wsizeofInd(*pc);
+
+    while(n-- > 0)
+    { if ( *++pc != *++pa )
+	return WORD_AND_CODE(FALSE, orig_pc);
+    }
+    pc++;
+    return WORD_AND_CODE(TRUE, pc);
+  }
+
+  return WORD_AND_CODE(FALSE, orig_pc);
+}
+
+#endif

--- a/src/pl-alloc.h
+++ b/src/pl-alloc.h
@@ -119,7 +119,7 @@ COMMON(int)		put_int64(Word p, int64_t i, int flags ARG_LD);
 COMMON(int64_t)		valBignum__LD(word w ARG_LD);
 #endif
 COMMON(int)		equalIndirect(word r1, word r2);
-COMMON(size_t)		gsizeIndirectFromCode(Code PC);
+ALLOC_INLINE(size_t)	gsizeIndirectFromCode(Code PC);
 COMMON(word)		globalIndirectFromCode(Code *PC);
 COMMON(void *)		tmp_malloc(size_t req);
 COMMON(void *)		tmp_realloc(void *mem, size_t req);

--- a/src/pl-fli-inline.h
+++ b/src/pl-fli-inline.h
@@ -1,0 +1,114 @@
+#ifndef _PL_FLI_INLINE_H
+#define _PL_FLI_INLINE_H
+
+#include "pl-codelist.h"
+#define setHandle(h, w)		(*valTermRef(h) = (w))
+#define valHandleP(h)		valTermRef(h)
+
+FLI_INLINE(int)
+PL_get_atom__LD(term_t t, atom_t *a ARG_LD)
+{ word w = valHandle(t);
+
+  if ( isAtom(w) )
+  { *a = (atom_t) w;
+    succeed;
+  }
+  fail;
+}
+
+FLI_INLINE(int)
+PL_is_variable__LD(term_t t ARG_LD)
+{ word w = valHandle(t);
+
+  return canBind(w) ? TRUE : FALSE;
+}
+
+FLI_INLINE(int)
+PL_is_atom__LD(term_t t ARG_LD)
+{ word w = valHandle(t);
+
+  if ( isTextAtom(w) )
+    return TRUE;
+
+  return FALSE;
+}
+
+FLI_INLINE(int)
+PL_is_functor__LD(term_t t, functor_t f ARG_LD)
+{ word w = valHandle(t);
+
+  if ( hasFunctor(w, f) )
+    succeed;
+
+  fail;
+}
+
+FLI_INLINE(int)
+PL_is_atomic__LD(term_t t ARG_LD)
+{ word w = valHandle(t);
+
+  return !!isAtomic(w);
+}
+
+FLI_INLINE(int)
+PL_put_variable__LD(term_t t ARG_LD)
+{ Word p = valTermRef(t);
+
+  setVar(*p);
+  return TRUE;
+}
+
+FLI_INLINE(int)
+PL_put_atom__LD(term_t t, atom_t a ARG_LD)
+{ setHandle(t, a);
+  return TRUE;
+}
+
+FLI_INLINE(int)
+PL_put_int64__LD(term_t t, int64_t i ARG_LD)
+{ word w = consInt(i);
+
+  if ( valInt(w) != i &&
+       put_int64(&w, i, ALLOW_GC PASS_LD) != TRUE )
+    return FALSE;
+
+  setHandle(t, w);
+  return TRUE;
+}
+
+FLI_INLINE(int)
+PL_put_integer__LD(term_t t, long i ARG_LD)
+{ return PL_put_int64__LD(t, i PASS_LD);
+}
+
+FLI_INLINE(int)
+PL_put_intptr__LD(term_t t, intptr_t i ARG_LD)
+{ return PL_put_int64__LD(t, i PASS_LD);
+}
+
+FLI_INLINE(predicate_t)
+_PL_predicate(const char *name, int arity, const char *module,
+	      predicate_t *bin)
+{ if ( !*bin )
+    *bin = PL_predicate(name, arity, module);
+
+  return *bin;
+}
+
+FLI_INLINE(except_class)
+classify_exception__LD(term_t exception ARG_LD)
+{ Word p;
+
+  if ( !exception )
+    return EXCEPT_NONE;
+
+  p = valTermRef(exception);
+  return classify_exception_p(p);
+}
+
+FLI_INLINE(int)
+PL_pending__LD(int sig ARG_LD)
+{ return pendingSignal(LD, sig);
+}
+
+#endif /* _PL_FLI_INLINE_H */

--- a/src/pl-fli.c
+++ b/src/pl-fli.c
@@ -40,8 +40,16 @@
 #include "os/pl-ctype.h"
 #include "os/pl-utf8.h"
 #include "os/pl-text.h"
+#include "os/pl-cstack.h"
 #include "pl-codelist.h"
+#include "pl-dict.h"
+#include "pl-arith.h"
+#include "pl-wrap.h"
+#include "pl-comp.h"
 #include <errno.h>
+
+/* Emit the non-inline definitions here */
+#include "pl-fli-inline.h"
 
 #ifdef __SANITIZE_ADDRESS__
 #include <sanitizer/lsan_interface.h>
@@ -88,8 +96,6 @@ Prolog int) is used by the garbage collector to update the stack frames.
 #endif
 #endif
 
-#define setHandle(h, w)		(*valTermRef(h) = (w))
-#define valHandleP(h)		valTermRef(h)
 #define VALID_INT_ARITY(a) \
 	{ if ( arity < 0 || arity > INT_MAX ) \
 	    fatalError("Arity out of range: %lld", (int64_t)arity); \
@@ -1441,17 +1447,7 @@ PL_get_bool(term_t t, int *b)
 }
 
 
-int
-PL_get_atom__LD(term_t t, atom_t *a ARG_LD)
-{ word w = valHandle(t);
-
-  if ( isAtom(w) )
-  { *a = (atom_t) w;
-    succeed;
-  }
-  fail;
-}
-
+/* PL_get_atom__LD(term_t t, atom_t *a ARG_LD) moved to pl-fli-inline.h */
 
 #undef PL_get_atom
 int
@@ -2277,13 +2273,7 @@ _PL_get_xpce_reference(term_t t, xpceref_t *ref)
 		 *		IS-*		*
 		 *******************************/
 
-int
-PL_is_variable__LD(term_t t ARG_LD)
-{ word w = valHandle(t);
-
-  return canBind(w) ? TRUE : FALSE;
-}
-
+/* PL_is_variable__LD(term_t t ARG_LD) moved to pl-fli-inline.h */
 
 #undef PL_is_variable
 int
@@ -2296,15 +2286,7 @@ PL_is_variable(term_t t)
 #define PL_is_variable(t) PL_is_variable__LD(t PASS_LD)
 
 
-int
-PL_is_atom__LD(term_t t ARG_LD)
-{ word w = valHandle(t);
-
-  if ( isTextAtom(w) )
-    return TRUE;
-
-  return FALSE;
-}
+/* PL_is_atom__LD(term_t t ARG_LD) moved to pl-fli-inline.h */
 
 
 #undef PL_is_atom
@@ -2409,17 +2391,7 @@ PL_is_callable(term_t t)
   return isCallable(valHandle(t) PASS_LD);
 }
 
-
-int
-PL_is_functor__LD(term_t t, functor_t f ARG_LD)
-{ word w = valHandle(t);
-
-  if ( hasFunctor(w, f) )
-    succeed;
-
-  fail;
-}
-
+/* PL_is_functor__LD(term_t t, functor_t f ARG_LD) moved to pl-fli-inline.h */
 
 #undef PL_is_functor
 int
@@ -2453,12 +2425,7 @@ PL_is_pair(term_t t)
 }
 
 
-int
-PL_is_atomic__LD(term_t t ARG_LD)
-{ word w = valHandle(t);
-
-  return !!isAtomic(w);
-}
+/* PL_is_atomic__LD(term_t t ARG_LD) moved to pl-fli-inline.h */
 
 
 #undef PL_is_atomic
@@ -2518,13 +2485,6 @@ PL_unify_string_nchars(term_t t, size_t len, const char *s)
 		 *             PUT-*		*
 		 *******************************/
 
-int
-PL_put_variable__LD(term_t t ARG_LD)
-{ Word p = valTermRef(t);
-
-  setVar(*p);
-  return TRUE;
-}
 
 
 #undef PL_put_variable
@@ -2537,12 +2497,7 @@ PL_put_variable(term_t t)
 #define PL_put_variable(t) PL_put_variable__LD(t PASS_LD)
 
 
-int
-PL_put_atom__LD(term_t t, atom_t a ARG_LD)
-{ setHandle(t, a);
-  return TRUE;
-}
-
+/* PL_put_atom__LD(term_t t, atom_t a ARG_LD) moved to pl-fli-inline.h */
 
 #undef PL_put_atom
 int
@@ -2724,29 +2679,9 @@ PL_put_list_chars(term_t t, const char *chars)
 }
 
 
-int
-PL_put_int64__LD(term_t t, int64_t i ARG_LD)
-{ word w = consInt(i);
-
-  if ( valInt(w) != i &&
-       put_int64(&w, i, ALLOW_GC PASS_LD) != TRUE )
-    return FALSE;
-
-  setHandle(t, w);
-  return TRUE;
-}
-
-
-int
-PL_put_integer__LD(term_t t, long i ARG_LD)
-{ return PL_put_int64__LD(t, i PASS_LD);
-}
-
-
-int
-PL_put_intptr__LD(term_t t, intptr_t i ARG_LD)
-{ return PL_put_int64__LD(t, i PASS_LD);
-}
+/* PL_put_int64__LD(term_t t, int64_t i ARG_LD) moved to pl-fli-inline.h */
+/* PL_put_integer__LD(term_t t, long i ARG_LD) moved to pl-fli-inline.h */
+/* PL_put_intptr__LD(term_t t, intptr_t i ARG_LD) moved to pl-fli-inline.h */
 
 
 int
@@ -4265,14 +4200,7 @@ PL_predicate(const char *name, int arity, const char *module)
 }
 
 
-predicate_t
-_PL_predicate(const char *name, int arity, const char *module,
-	      predicate_t *bin)
-{ if ( !*bin )
-    *bin = PL_predicate(name, arity, module);
-
-  return *bin;
-}
+/* _PL_predicate(const char *name, int arity, const char *module, moved to pl-fli-inline.h */
 
 
 int
@@ -4360,7 +4288,7 @@ PL_foreign_context_predicate(control_t h)
   return isCurrentProcedure(def->functor->functor, def->module);
 }
 
-static int
+int
 has_emergency_space(void *sv, size_t needed)
 { Stack s = (Stack) sv;
   ssize_t lacking = ((char*)s->top + needed) - (char*)s->max;
@@ -4452,16 +4380,7 @@ classify_exception_p__LD(Word p ARG_LD)
 }
 
 
-except_class
-classify_exception__LD(term_t exception ARG_LD)
-{ Word p;
-
-  if ( !exception )
-    return EXCEPT_NONE;
-
-  p = valTermRef(exception);
-  return classify_exception_p(p);
-}
+/* classify_exception__LD(term_t exception ARG_LD) moved to pl-fli-inline.h */
 
 
 int
@@ -4864,10 +4783,7 @@ PL_raise(int sig)
 }
 
 
-int
-PL_pending__LD(int sig ARG_LD)
-{ return pendingSignal(LD, sig);
-}
+/* PL_pending__LD(int sig ARG_LD) moved to pl-fli-inline.h */
 
 
 int

--- a/src/pl-funcs.h
+++ b/src/pl-funcs.h
@@ -69,6 +69,7 @@ COMMON(fid_t)		PL_open_foreign_frame__LD(ARG1_LD);
 COMMON(void)		PL_close_foreign_frame__LD(fid_t id ARG_LD);
 COMMON(fid_t)		PL_open_signal_foreign_frame(int sync);
 COMMON(int)		foreignWakeup(term_t ex ARG_LD);
+COMMON(void)		resumeAfterException(int clear, Stack outofstack);
 COMMON(void)		updateAlerted(PL_local_data_t *ld);
 COMMON(int)		raiseSignal(PL_local_data_t *ld, int sig);
 COMMON(int)		pendingSignal(PL_local_data_t *ld, int sig);
@@ -160,7 +161,7 @@ COMMON(word)		linkValG__LD(Word p ARG_LD);
 COMMON(word)		linkValNoG__LD(Word p ARG_LD);
 COMMON(void)		bArgVar(Word ap, Word vp ARG_LD);
 COMMON(int)		_PL_put_number__LD(term_t t, Number n ARG_LD);
-COMMON(predicate_t)	_PL_predicate(const char *name, int arity,
+FLI_INLINE(predicate_t)	_PL_predicate(const char *name, int arity,
 				      const char *module, predicate_t *bin);
 COMMON(void)		initialiseForeign(int argc, char **argv);
 COMMON(void)		cleanupInitialiseHooks(void);
@@ -174,6 +175,7 @@ COMMON(int)		_PL_get_arg__LD(size_t index, term_t t, term_t a ARG_LD);
 COMMON(term_t)		PL_new_term_ref__LD(ARG1_LD);
 COMMON(term_t)		PL_new_term_ref_noshift__LD(ARG1_LD);
 COMMON(term_t)		PL_new_term_refs__LD(int n ARG_LD);
+COMMON(int)		globalize_term_ref__LD(term_t t ARG_LD);
 COMMON(void)		PL_reset_term_refs__LD(term_t r ARG_LD);
 COMMON(term_t)		PL_copy_term_ref__LD(term_t from ARG_LD);
 COMMON(int)		PL_unify__LD(term_t t1, term_t t2 ARG_LD);
@@ -182,15 +184,16 @@ COMMON(int)		PL_unify_integer__LD(term_t t1, intptr_t i ARG_LD);
 COMMON(int)		PL_unify_int64__LD(term_t t1, int64_t ARG_LD);
 COMMON(int)		PL_unify_int64_ex__LD(term_t t1, int64_t ARG_LD);
 COMMON(int)		PL_unify_functor__LD(term_t t, functor_t f ARG_LD);
-COMMON(int)		PL_get_atom__LD(term_t t1, atom_t *a ARG_LD);
+FLI_INLINE(int)		PL_get_atom__LD(term_t t1, atom_t *a ARG_LD);
 COMMON(int)		PL_get_text_as_atom(term_t t, atom_t *a, int flags);
-COMMON(int)		PL_put_variable__LD(term_t t1 ARG_LD);
-COMMON(int)		PL_put_atom__LD(term_t t1, atom_t a ARG_LD);
-COMMON(int)		PL_put_integer__LD(term_t t1, long i ARG_LD);
-COMMON(int)		PL_put_intptr__LD(term_t t1, intptr_t i ARG_LD);
-COMMON(int)		PL_is_atomic__LD(term_t t ARG_LD);
-COMMON(int)		PL_is_functor__LD(term_t t, functor_t f ARG_LD);
-COMMON(int)		PL_is_variable__LD(term_t t ARG_LD);
+FLI_INLINE(int)		PL_put_variable__LD(term_t t1 ARG_LD);
+FLI_INLINE(int)		PL_put_atom__LD(term_t t1, atom_t a ARG_LD);
+FLI_INLINE(int)		PL_put_integer__LD(term_t t1, long i ARG_LD);
+FLI_INLINE(int)		PL_put_int64__LD(term_t t, int64_t i ARG_LD);
+FLI_INLINE(int)		PL_put_intptr__LD(term_t t1, intptr_t i ARG_LD);
+FLI_INLINE(int)		PL_is_atomic__LD(term_t t ARG_LD);
+FLI_INLINE(int)		PL_is_functor__LD(term_t t, functor_t f ARG_LD);
+FLI_INLINE(int)		PL_is_variable__LD(term_t t ARG_LD);
 COMMON(int)		PL_strip_module__LD(term_t q, module_t *m,
 					    term_t t, int flags ARG_LD) WUNUSED;
 COMMON(int)		PL_strip_module_ex__LD(term_t raw, module_t *m,
@@ -210,7 +213,7 @@ COMMON(int)		PL_get_uintptr(term_t t, size_t *i);
 COMMON(int)		PL_unify_atom__LD(term_t t, atom_t a ARG_LD);
 COMMON(int)		PL_unify_pointer__LD(term_t t, void *ptr ARG_LD);
 COMMON(int)		PL_get_list__LD(term_t l, term_t h, term_t t ARG_LD);
-COMMON(int)		PL_is_atom__LD(term_t t ARG_LD);
+FLI_INLINE(int)		PL_is_atom__LD(term_t t ARG_LD);
 COMMON(int)		PL_unify_list__LD(term_t l, term_t h, term_t t ARG_LD);
 COMMON(int)		PL_cons_list__LD(term_t l, term_t head, term_t tail
 					 ARG_LD);
@@ -227,11 +230,12 @@ COMMON(void)            bindExtensions(const char *module,
 				       const PL_extension *ext);
 COMMON(void)		initForeign(void);
 COMMON(int)		PL_rethrow(void);
-COMMON(int)		PL_pending__LD(int sig ARG_LD);
+FLI_INLINE(int)		PL_pending__LD(int sig ARG_LD);
 COMMON(int)		PL_clearsig__LD(int sig ARG_LD);
 COMMON(void)		cleanupCodeToAtom(void);
 COMMON(void)		PL_clear_foreign_exception(LocalFrame fr);
-COMMON(except_class)    classify_exception__LD(term_t ex ARG_LD);
+COMMON(int)		has_emergency_space(void *sv, size_t needed);
+FLI_INLINE(except_class) classify_exception__LD(term_t ex ARG_LD);
 COMMON(except_class)    classify_exception_p__LD(Word p ARG_LD);
 COMMON(void)		PL_abort_process(void) NORETURN;
 

--- a/src/pl-incl.h
+++ b/src/pl-incl.h
@@ -403,6 +403,12 @@ A common basis for C keywords.
 #define MAY_ALIAS
 #endif
 
+#if defined(__GNUC__) && !defined(MAYBE_UNUSED)
+#define MAYBE_UNUSED __attribute__ ((unused))
+#else
+#define MAYBE_UNUSED
+#endif
+
 #ifdef HAVE___BUILTIN_EXPECT
 #define likely(x)       __builtin_expect((x), 1)
 #define unlikely(x)     __builtin_expect((x), 0)
@@ -2550,6 +2556,26 @@ decrease).
 #include "pl-atom.ih"
 #include "pl-funct.ih"
 
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Some functions can be inlined for some files only. These functions get
+declared with usual attributes for most files, including their original
+sources; files that want the inlines can define USE_XYZ_INLINES prior to
+including pl-incl.h, and for that file the function will be declared as
+static. This may cause a small amount of code bloat in object files, but
+with any luck LTO could address that.
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+#if USE_FLI_INLINES
+# define FLI_INLINE(type) static type MAYBE_UNUSED
+#else
+# define FLI_INLINE COMMON
+#endif
+#if USE_ALLOC_INLINES
+# define ALLOC_INLINE(type) static type MAYBE_UNUSED
+#else
+# define ALLOC_INLINE COMMON
+#endif
+
 #include "pl-alloc.h"			/* Allocation primitives */
 #include "pl-init.h"			/* Declarations needed by pl-init.c */
 #include "pl-error.h"			/* Exception generation */
@@ -2577,4 +2603,11 @@ decrease).
 #undef try
 #endif
 
+/* include the appropriate inlines, when requested */
+#if USE_FLI_INLINES
+#include "pl-fli-inline.h"
+#endif
+#if USE_ALLOC_INLINES
+#include "pl-alloc-inline.h"
+#endif
 #endif /*_PL_INCLUDE_H*/

--- a/src/pl-wam.c
+++ b/src/pl-wam.c
@@ -36,6 +36,9 @@
 */
 
 /*#define O_DEBUG 1*/
+#define USE_FLI_INLINES 1
+#define USE_ALLOC_INLINES 1
+
 #include "pl-incl.h"
 #include "pl-comp.h"
 #include "pl-arith.h"
@@ -229,10 +232,6 @@ DbgPrintInstruction(LocalFrame FR, Code PC)
 #endif
 
 
-
-
-#include "pl-alloc.c"
-#include "pl-index.c"
 
 
 		 /*******************************
@@ -1762,7 +1761,7 @@ TBD: In these modern days we can  probably   do  GC. Still, if it is not
 needed why would we?
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
-static void
+void
 resumeAfterException(int clear, Stack outofstack)
 { GET_LD
 
@@ -1809,8 +1808,6 @@ exceptionUnwindGC(void)
 		 /*******************************
 		 *   FOREIGN-LANGUAGE INTERFACE *
 		 *******************************/
-
-#include "pl-fli.c"
 
 #ifdef O_DEBUGGER
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
**[NOTE: this is an alternative to PR #843. If the performance issues in that one can't be resolved but this one works, this is a perfectly acceptable alternative.]**

This adds USE_*_INLINES as a flag that can be set before including
pl-incl.h, to include some of the function definitions from various
files in a "can-inline" context. It also separates the majority of
pl-alloc.c, pl-index.c, and pl-fli.c out into their own object files,
to speed up the build.

This may result in a slight (1-2% at max, in my testing) performance
loss since the pl-wam compilation doesn't have access to *all* the
function definitions in those three files, but enabling LTO on the
build (which I have not yet, since it currently generates warnings)
avoids the performance drop entirely by allowing the linker itself
to perform any applicable cross-file inlining.