### PR TITLE
Fix CLP(FD) multiplication leaving a lot of residual variables

### DIFF
--- a/library/clp/clpfd.pl
+++ b/library/clp/clpfd.pl
@@ -165,6 +165,7 @@
                   fdset_complement/2
                  ]).
 
+:- meta_predicate with_local_attributes(?, ?, 0, ?).
 :- public                               % called from goal_expansion
         clpfd_equal/2,
         clpfd_geq/2.

--- a/library/clp/clpfd.pl
+++ b/library/clp/clpfd.pl
@@ -5555,16 +5555,14 @@ min_max_factor(L1, U1, L2, U2, L3, U3, Min, Max) :-
             L2 cis_lt n(0), U2 cis_gt n(0),
             L3 cis_lt n(0), U3 cis_gt n(0) ->
             maplist(in_(L1,U1), [Z1,Z2]),
-            with_local_attributes([X1,Y1], [], (
+            with_local_attributes([X1,Y1,X2,Y2], [], (
                 in_(L2, n(-1), X1), in_(n(1), U3, Y1),
                 (   X1*Y1 #= Z1 ->
                     (   fd_get(Y1, _, Inf1, Sup1, _) -> true
                     ;   Inf1 = n(Y1), Sup1 = n(Y1)
                     )
                 ;   Inf1 = inf, Sup1 = n(-1)
-                )
-            ), [Inf1,Sup1]),
-            with_local_attributes([X2,Y2], [], (
+                ),
                 in_(n(1), U2, X2), in_(L3, n(-1), Y2),
                 (   X2*Y2 #= Z2 ->
                     (   fd_get(Y2, _, Inf2, Sup2, _) -> true
@@ -5572,23 +5570,21 @@ min_max_factor(L1, U1, L2, U2, L3, U3, Min, Max) :-
                     )
                 ;   Inf2 = n(1), Sup2 = sup
                 )
-            ), [Inf2,Sup2]),
+            ), [Inf1,Sup1,Inf2,Sup2]),
             Min cis max(min(Inf1,Inf2), L3),
             Max cis min(max(Sup1,Sup2), U3)
         ;   L1 cis_gt n(0),
             L2 cis_lt n(0), U2 cis_gt n(0),
             L3 cis_lt n(0), U3 cis_gt n(0) ->
             maplist(in_(L1,U1), [Z1,Z2]),
-            with_local_attributes([X1,Y1], [], (
+            with_local_attributes([X1,Y1,X2,Y2], [], (
                 in_(L2, n(-1), X1), in_(L3, n(-1), Y1),
                 (   X1*Y1 #= Z1 ->
                     (   fd_get(Y1, _, Inf1, Sup1, _) -> true
                     ;   Inf1 = n(Y1), Sup1 = n(Y1)
                     )
                 ;   Inf1 = n(1), Sup1 = sup
-                )
-            ), [Inf1,Sup1]),
-            with_local_attributes([X2,Y2], [], (
+                ),
                 in_(n(1), U2, X2), in_(n(1), U3, Y2),
                 (   X2*Y2 #= Z2 ->
                     (   fd_get(Y2, _, Inf2, Sup2, _) -> true
@@ -5596,7 +5592,7 @@ min_max_factor(L1, U1, L2, U2, L3, U3, Min, Max) :-
                     )
                 ;   Inf2 = inf, Sup2 = n(-1)
                 )
-            ), [Inf2,Sup2]),
+            ), [Inf1,Sup1,Inf2,Sup2]),
             Min cis max(min(Inf1,Inf2), L3),
             Max cis min(max(Sup1,Sup2), U3)
         ;   min_factor(L1, U1, L2, U2, Min0),

--- a/library/clp/clpfd.pl
+++ b/library/clp/clpfd.pl
@@ -5555,40 +5555,48 @@ min_max_factor(L1, U1, L2, U2, L3, U3, Min, Max) :-
             L2 cis_lt n(0), U2 cis_gt n(0),
             L3 cis_lt n(0), U3 cis_gt n(0) ->
             maplist(in_(L1,U1), [Z1,Z2]),
-            in_(L2, n(-1), X1), in_(n(1), U3, Y1),
-            (   X1*Y1 #= Z1 ->
-                (   fd_get(Y1, _, Inf1, Sup1, _) -> true
-                ;   Inf1 = n(Y1), Sup1 = n(Y1)
+            with_local_attributes([X1,Y1], [], (
+                in_(L2, n(-1), X1), in_(n(1), U3, Y1),
+                (   X1*Y1 #= Z1 ->
+                    (   fd_get(Y1, _, Inf1, Sup1, _) -> true
+                    ;   Inf1 = n(Y1), Sup1 = n(Y1)
+                    )
+                ;   Inf1 = inf, Sup1 = n(-1)
                 )
-            ;   Inf1 = inf, Sup1 = n(-1)
-            ),
-            in_(n(1), U2, X2), in_(L3, n(-1), Y2),
-            (   X2*Y2 #= Z2 ->
-                (   fd_get(Y2, _, Inf2, Sup2, _) -> true
-                ;   Inf2 = n(Y2), Sup2 = n(Y2)
+            ), [Inf1,Sup1]),
+            with_local_attributes([X2,Y2], [], (
+                in_(n(1), U2, X2), in_(L3, n(-1), Y2),
+                (   X2*Y2 #= Z2 ->
+                    (   fd_get(Y2, _, Inf2, Sup2, _) -> true
+                    ;   Inf2 = n(Y2), Sup2 = n(Y2)
+                    )
+                ;   Inf2 = n(1), Sup2 = sup
                 )
-            ;   Inf2 = n(1), Sup2 = sup
-            ),
+            ), [Inf2,Sup2]),
             Min cis max(min(Inf1,Inf2), L3),
             Max cis min(max(Sup1,Sup2), U3)
         ;   L1 cis_gt n(0),
             L2 cis_lt n(0), U2 cis_gt n(0),
             L3 cis_lt n(0), U3 cis_gt n(0) ->
             maplist(in_(L1,U1), [Z1,Z2]),
-            in_(L2, n(-1), X1), in_(L3, n(-1), Y1),
-            (   X1*Y1 #= Z1 ->
-                (   fd_get(Y1, _, Inf1, Sup1, _) -> true
-                ;   Inf1 = n(Y1), Sup1 = n(Y1)
+            with_local_attributes([X1,Y1], [], (
+                in_(L2, n(-1), X1), in_(L3, n(-1), Y1),
+                (   X1*Y1 #= Z1 ->
+                    (   fd_get(Y1, _, Inf1, Sup1, _) -> true
+                    ;   Inf1 = n(Y1), Sup1 = n(Y1)
+                    )
+                ;   Inf1 = n(1), Sup1 = sup
                 )
-            ;   Inf1 = n(1), Sup1 = sup
-            ),
-            in_(n(1), U2, X2), in_(n(1), U3, Y2),
-            (   X2*Y2 #= Z2 ->
-                (   fd_get(Y2, _, Inf2, Sup2, _) -> true
-                ;   Inf2 = n(Y2), Sup2 = n(Y2)
+            ), [Inf1,Sup1]),
+            with_local_attributes([X2,Y2], [], (
+                in_(n(1), U2, X2), in_(n(1), U3, Y2),
+                (   X2*Y2 #= Z2 ->
+                    (   fd_get(Y2, _, Inf2, Sup2, _) -> true
+                    ;   Inf2 = n(Y2), Sup2 = n(Y2)
+                    )
+                ;   Inf2 = inf, Sup2 = n(-1)
                 )
-            ;   Inf2 = inf, Sup2 = n(-1)
-            ),
+            ), [Inf2,Sup2]),
             Min cis max(min(Inf1,Inf2), L3),
             Max cis min(max(Sup1,Sup2), U3)
         ;   min_factor(L1, U1, L2, U2, Min0),


### PR DESCRIPTION
Some CLP(FD) multiplications leave a lot of strange residual variables and constraints, which stay around even after all of the user-provided variables have been bound and a complete solution has been found. This is only visible when using `call_residue_vars/2`:

<details>
<summary>Example (long output)</summary>

```prolog
?- 10 #= Y * Z.
Y in -10.. -1\/1..10,
Y*Z#=10,
Z in -10.. -1\/1..10.

?- call_residue_vars((10 #= Y * Z), Vars).
Vars = [_37334, _37340, _37346, _37352, _37358, _37364, _37370, _37376, _37382, _37388, _37394, _37400, _37406, _37412, _37418, _37424, _37430, _37436, _37442, _37448, _37454, _37460, _37466, _37472|...],
Y in -10.. -1\/1..10,
Y*Z#=10,
Z in -10.. -1\/1..10,
_37334 in 1..10,
_37340*_37334#=10,
_37340 in 1..10,
_37346 in -10.. -1,
_37352*_37346#=10,
_37352 in -10.. -1,
_37358 in 1..10,
_37364*_37358#=10,
_37364 in 1..10,
_37370 in -10.. -1,
_37376*_37370#=10,
_37376 in -10.. -1,
_37382 in 1..10,
_37388*_37382#=10,
_37388 in 1..10,
_37394 in 1..10,
_37400*_37394#=10,
_37400 in 1..10,
_37406 in -10.. -1,
_37412*_37406#=10,
_37412 in -10.. -1,
_37418 in 1..10,
_37424*_37418#=10,
_37424 in 1..10,
_37430 in -10.. -1,
_37436*_37430#=10,
_37436 in -10.. -1,
_37442 in 1..10,
_37448*_37442#=10,
_37448 in 1..10,
_37454 in -10.. -1,
_37460*_37454#=10,
_37460 in -10.. -1,
_37466 in 1..10,
_37472*_37466#=10,
_37472 in 1..10,
_37478 in -10.. -1,
_37484*_37478#=10,
_37484 in -10.. -1,
_37490 in -10.. -1,
_37496*_37490#=10,
_37496 in -10.. -1,
_37502 in 1..10,
_37508*_37502#=10,
_37508 in 1..10,
_37514 in -10.. -1,
_37520*_37514#=10,
_37520 in -10.. -1.

?- call_residue_vars((10 #= Y * Z, Y = 5), Vars).
Y = 5,
Z = 2,
Vars = [_73224, _73230, _73236, _73242, _73248, _73254, _73260, _73266, _73272, _73278, _73284, _73290, _73296, _73302, _73308, _73314, _73320, _73326, _73332, _73338, _73344, _73350, _73356, _73362|...],
_73224 in 1..10,
_73230*_73224#=10,
_73230 in 1..10,
_73236 in -10.. -1,
_73242*_73236#=10,
_73242 in -10.. -1,
_73248 in 1..10,
_73254*_73248#=10,
_73254 in 1..10,
_73260 in -10.. -1,
_73266*_73260#=10,
_73266 in -10.. -1,
_73272 in 1..10,
_73278*_73272#=10,
_73278 in 1..10,
_73284 in 1..10,
_73290*_73284#=10,
_73290 in 1..10,
_73296 in -10.. -1,
_73302*_73296#=10,
_73302 in -10.. -1,
_73308 in 1..10,
_73314*_73308#=10,
_73314 in 1..10,
_73320 in -10.. -1,
_73326*_73320#=10,
_73326 in -10.. -1,
_73332 in 1..10,
_73338*_73332#=10,
_73338 in 1..10,
_73344 in -10.. -1,
_73350*_73344#=10,
_73350 in -10.. -1,
_73356 in 1..10,
_73362*_73356#=10,
_73362 in 1..10,
_73368 in -10.. -1,
_73374*_73368#=10,
_73374 in -10.. -1,
_73380 in -10.. -1,
_73386*_73380#=10,
_73386 in -10.. -1,
_73392 in 1..10,
_73398*_73392#=10,
_73398 in 1..10,
_73404 in -10.. -1,
_73410*_73404#=10,
_73410 in -10.. -1.
```
</details>

These variables come from `clpfd:min_max_factor/8`, which sets up some internal constraints and then inspects the domain of some of the involved variables. These constraints are apparently not meant to be actually solved - they are only used as a helper for calculating some domains and never used again afterwards.

This is a problem, because when variables appear in `call_residue_vars` and have visible constraints attached to them, that generally means that you don't know for sure if a solution satisfying these constraints actually exists, and that you need to bind/constrain variables further to get a definitive answer. With these helper constraints, this is not the case - as demonstrated above, you can have a fully solved multiplication constraint with all variables bound, and `call_residue_vars` will still return residual constraints, with no way for the user to do anything about them.

This PR attempts to fix the problem by wrapping the internal helper constraints/variables in `with_local_attributes`, so that the constraints are removed once the code has queried the variable domains that it needs. Although this *works*, it unfortunately slows down the multiplication by about 2.5x, which isn't very nice:

```prolog
% Without this fix
?- time((between(1, 1000, _), 10 #= Y * Z, fail)).
% 7,940,001 inferences, 1.120 CPU in 1.128 seconds (99% CPU, 7090901 Lips)
false.

% With this fix
?- time((between(1, 1000, _), 10 #= Y * Z, fail)).
% 16,452,001 inferences, 2.879 CPU in 2.942 seconds (98% CPU, 5713631 Lips)
false.
```

I'm sure there is some way to do this more efficiently, either by manually deleting some attributes from the variables in question, or by rewriting the code to not require these helper constraints at all. Unfortunately I don't understand SWI's CLP(FD) propagator internals well enough to implement either of these solutions correctly...