### PR TITLE
A few more misc SICStus emulation updates

### DIFF
--- a/library/dialect/sicstus.pl
+++ b/library/dialect/sicstus.pl
@@ -472,13 +472,15 @@ vars_by_goal(Goal) -->
 	[ VarSet-Goal ].
 */
 
-%%	trimcore
+%%	trimcore is det.
 %
-%	Trims the stacks.  Other tasks of the SICStus trimcore/0 are
-%	automatically scheduled by SWI-Prolog.
+%	Trims the stacks and releases unused heap memory to the
+%	operating system where possible. Other tasks of the SICStus
+%	trimcore/0 are automatically scheduled by SWI-Prolog.
 
 trimcore :-
-	trim_stacks.
+	trim_stacks,
+	trim_heap.
 
 
 		 /*******************************

--- a/library/dialect/sicstus4.pl
+++ b/library/dialect/sicstus4.pl
@@ -52,7 +52,6 @@
 	      read_line/2,
 	      trimcore/0,
 	      prolog_flag/3,
-	      prolog_flag/2,
 	      op(1150, fx, (block)),
 	      op(1150, fx, (mode)),
 	      op(900, fy, (spy)),


### PR DESCRIPTION
Uses the new `trim_heap/0` in the emulated `trimcore/0`, and fixes some problems with emulating Quintus/SICStus-specific Prolog flags.