### PR TITLE
Fix help messages for trace commands p and w

### DIFF
--- a/src/pl-trace.c
+++ b/src/pl-trace.c
@@ -832,7 +832,8 @@ helpTrace(void)
     { "s",		   "skip over" },
     { "[level] S",	   "save goal [at level]" },
     { "u",		   "up (complete goal)" },
-    { "s",		   "(quoted) write goals" },
+    { "p",		   "print goals" },
+    { "w",		   "(quoted) write goals" },
     { "m",		   "exception details" },
     { "C",		   "toggle show context" },
   #if O_DEBUG


### PR DESCRIPTION
In the recent refactor of the trace help display, the name of the `w` command was accidentally changed to `s`, and the `p` command was dropped completely.