### PR TITLE
ADDED: binformat package, for binary format utils

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -118,3 +118,6 @@
 [submodule "packages/language_server"]
 	path = packages/language_server
 	url = ../packages-language_server.git
+[submodule "packages/binformat"]
+	path = packages/binformat
+	url = ../packages-binformat.git

--- a/cmake/PackageSelection.cmake
+++ b/cmake/PackageSelection.cmake
@@ -39,6 +39,7 @@ endforeach()
 # The pckages below do not depend on external libraries except for
 # the zlib package, but the core system already depends on zlib.
 set(SWIPL_PACKAGE_LIST_BASIC
+    binformat
     chr
     clib
     clpqr


### PR DESCRIPTION
Initial checkin of binformat package, with integer-conversion predicates. The repository at https://github.com/dmchurch/packages-binformat can be moved, obviously. 🙂

Todo:
1. Unit tests
2. Float/double primitives
3. Structure/array support (DCG compilation)