### PR TITLE
Avoid rerunning mkvmi repeatedly for no reason

### DIFF
--- a/src/defatom.c
+++ b/src/defatom.c
@@ -62,45 +62,11 @@ argument that specifies the source directory.
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 static int
-cmp_file(const char *from, const char *to)
-{ FILE *f1 = fopen(from, "r");
-  FILE *f2 = fopen(to, "r");
-  int rc = -1;
-
-  if ( f1 && f2 )
-  { char l1[1024];
-    char l2[1024];
-
-    while ( fgets(l1, sizeof(l1), f1) )
-    { if ( fgets(l2, sizeof(l2), f2) )
-      { if ( strcmp(l1, l2) == 0 )
-	  continue;
-      }
-      goto out;
-    }
-    if ( !fgets(l2, sizeof(l2), f2) )
-      rc = 0;
-  }
-
-out:
-  if ( f1 ) fclose(f1);
-  if ( f2 ) fclose(f2);
-  return rc;
-}
-
-
-static int
 update_file(const char *from, const char *to)
-{ if ( cmp_file(from, to) == 0 )
-  { if ( verbose )
-      fprintf(stderr, "\t%s: no change\n", to);
-    return remove(from);
-  } else
-  { remove(to);
-    if ( verbose )
-      fprintf(stderr, "\t%s: updated\n", to);
-    return rename(from, to);
-  }
+{ remove(to);
+  if ( verbose )
+    fprintf(stderr, "\t%s: updated\n", to);
+  return rename(from, to);
 }
 
 

--- a/src/mkvmi.c
+++ b/src/mkvmi.c
@@ -233,45 +233,11 @@ load_vmis(const char *file)
 
 
 static int
-cmp_file(const char *from, const char *to)
-{ FILE *f1 = fopen(from, "r");
-  FILE *f2 = fopen(to, "r");
-  int rc = -1;
-
-  if ( f1 && f2 )
-  { char l1[1024];
-    char l2[1024];
-
-    while ( fgets(l1, sizeof(l1), f1) )
-    { if ( fgets(l2, sizeof(l2), f2) )
-      { if ( strcmp(l1, l2) == 0 )
-	  continue;
-      }
-      goto out;
-    }
-    if ( !fgets(l2, sizeof(l2), f2) )
-      rc = 0;
-  }
-
-out:
-  if ( f1 ) fclose(f1);
-  if ( f2 ) fclose(f2);
-  return rc;
-}
-
-
-static int
 update_file(const char *from, const char *to)
-{ if ( cmp_file(from, to) == 0 )
-  { if ( verbose )
-      fprintf(stderr, "\t%s: no change\n", to);
-    return remove(from);
-  } else
-  { remove(to);
-    if ( verbose )
-      fprintf(stderr, "\t%s: updated\n", to);
-    return rename(from, to);
-  }
+{ remove(to);
+  if ( verbose )
+    fprintf(stderr, "\t%s: updated\n", to);
+  return rename(from, to);
 }
 
 


### PR DESCRIPTION
This is a pretty minor thing, but I noticed that every time I run `cmake --build`, it regenerates vmi-metadata.h for no apparent reason. The CMake scripts say that it depends only on pl-vmi.c and the mkvmi utility itself, neither of which should change on every build. So I debugged this further using `make -d` and found this in the output:

```
       Prerequisite `../../src/pl-vmi.c' is newer than target `src/vmi-metadata.h'.
       Prerequisite `src/mkvmi' is newer than target `src/vmi-metadata.h'.
      Must remake target `src/vmi-metadata.h'.
```

As it turns out, `mkvmi` tries to be smart - if the generated file already exists with identical contents, it doesn't overwrite the file to avoid touching the mtime. Unfortunately this causes problems here - `mkvmi` is being called because the output file is outdated, but then it doesn't actually update the output file's mtime, so on the next build the file is still considered outdated and `mkvmi` is called again, etc.

This PR removes the extra check and simply rewrites the output file every time, which fixes this problem. The downside is that now every time that pl-vmi.c changes, all dependents of vmi-metadata.h (i. e. most of the SWI-Prolog core) are rebuilt, even if the contents of vmi-metadata.h haven't actually changed.

The same problem applies to defatom, but it's less of an issue there, because changing the ATOMS input file will almost always cause a real change to the generated headers.