### PR TITLE
Fixes the printing of duplicate package warning

### DIFF
--- a/boot/messages.pl
+++ b/boot/messages.pl
@@ -1635,7 +1635,7 @@ prolog_message(pack(attached(Pack, BaseDir))) -->
     [ 'Attached package ~w at ~q'-[Pack, BaseDir] ].
 prolog_message(pack(duplicate(Entry, OldDir, Dir))) -->
     [ 'Package ~w already attached at ~q.'-[Entry,OldDir], nl,
-      '\tIgnoring version from ~q'- [Entry, OldDir, Dir]
+      '\tIgnoring version from ~q'- [Dir]
     ].
 prolog_message(pack(no_arch(Entry, Arch))) -->
     [ 'Package ~w: no binary for architecture ~w'-[Entry, Arch] ].


### PR DESCRIPTION
Fixes message printing of the duplicate pack warning (format/3 contains too many arguments)