### PR TITLE
Pair pclose, not fclose, with popen

### DIFF
--- a/src/os/pl-cstack.c
+++ b/src/os/pl-cstack.c
@@ -371,7 +371,7 @@ addr2line(const char *fname, uintptr_t offset, char *buf, size_t size)
 
       *o = '\0';
 
-      fclose(fd);
+      pclose(fd);
       return o > buf;
     }
   }


### PR DESCRIPTION
The pclose() call, in addition to calling fclose(), also calls wait() to avoid creating zombie processes.