### PR TITLE
is_foreign_pack/2 in message(git_post_install)

### DIFF
--- a/library/prolog_pack.pl
+++ b/library/prolog_pack.pl
@@ -2107,7 +2107,7 @@ message(install_downloaded(File)) -->
     [ 'Install "~w" (~D bytes)'-[Base, Size] ].
 message(git_post_install(PackDir, Pack)) -->
     (   { is_foreign_pack(PackDir, Type) }
-    ->  [ 'Run post installation scripts for pack "~w" (~q)'-[Pack, Type] ]
+    ->  [ 'Run post installation scripts for pack "~w" (~w)'-[Pack, Type] ]
     ;   [ 'Activate pack "~w"'-[Pack] ]
     ).
 message(no_meta_data(BaseDir)) -->

--- a/library/prolog_pack.pl
+++ b/library/prolog_pack.pl
@@ -2106,8 +2106,8 @@ message(install_downloaded(File)) -->
       size_file(File, Size) },
     [ 'Install "~w" (~D bytes)'-[Base, Size] ].
 message(git_post_install(PackDir, Pack)) -->
-    (   { is_foreign_pack(PackDir) }
-    ->  [ 'Run post installation scripts for pack "~w"'-[Pack] ]
+    (   { is_foreign_pack(PackDir, Type) }
+    ->  [ 'Run post installation scripts for pack "~w" (~q)'-[Pack, Type] ]
     ;   [ 'Activate pack "~w"'-[Pack] ]
     ).
 message(no_meta_data(BaseDir)) -->


### PR DESCRIPTION
pack_install raised an error message because the 2nd argument Type in is_foreign_pack was omitted