### PR TITLE
PORT: First attempt to support MacOs M1 with brew deps in /opt/homebrew

### DIFF
--- a/cmake/port/Darwin.cmake
+++ b/cmake/port/Darwin.cmake
@@ -1,10 +1,13 @@
 if(APPLE)
 
+set(CMAKE_FIND_APPBUNDLE NEVER) # Make sure cmake does not find the Apple gui version of GIT
 if(NOT MACOSX_DEPENDENCIES_FROM)
   if(EXISTS /opt/local/bin/port)
     set(MACOSX_DEPENDENCIES_FROM Macports)
   elseif(EXISTS /usr/local/bin/brew)
-    set(MACOSX_DEPENDENCIES_FROM Homebrew)
+	  set(MACOSX_DEPENDENCIES_FROM HomebrewLocal)
+  elseif(EXISTS /opt/homebrew)
+	  set(MACOSX_DEPENDENCIES_FROM HomebrewOpt)
   else()
     set(MACOSX_DEPENDENCIES_FROM None)
     message(WARNING "Could not find Macport or Homebrew to provide dependencies \
@@ -20,7 +23,7 @@ if(MACOSX_DEPENDENCIES_FROM STREQUAL "Macports")
       /opt/local/lib)
   set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH}
       /opt/local/include)
-elseif(MACOSX_DEPENDENCIES_FROM STREQUAL "Homebrew")
+elseif(MACOSX_DEPENDENCIES_FROM STREQUAL "HomebrewLocal")
   message("-- Using Homebrew packages from /usr/local")
   set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH}
       /usr/local/lib)
@@ -37,6 +40,17 @@ elseif(MACOSX_DEPENDENCIES_FROM STREQUAL "Homebrew")
 
   set(LibArchive_ROOT /usr/local/opt/libarchive)
   set(Readline_ROOT /usr/local/opt/readline)
+elseif(MACOSX_DEPENDENCIES_FROM STREQUAL "HomebrewOpt")
+  message("-- Using Homebrew packages from /opt/homebrew")
+  set(CMAKE_LIBRARY_PATH ${CMAKE_LIBRARY_PATH}
+      /opt/homebrew/lib)
+  set(CMAKE_INCLUDE_PATH ${CMAKE_INCLUDE_PATH}
+      /opt/homebrew/include)
+
+  # This is all too fragile but I cannot see how this should be done
+  set(OPENSSL_ROOT_DIR /opt/homebrew/Cellar/openssl@3/3.0.0_1)
+  set(LibArchive_ROOT /opt/homebrew/Cellar/libarchive/3.5.2)
+  set(Readline_ROOT /opt/homebrew/Cellar/readline/8.1.1/)
 elseif(MACOSX_DEPENDENCIES_FROM STREQUAL None)
   message("-- Trying to build without Macports or Homebrew dependencies")
 elseif(MACOSX_DEPENDENCIES_FROM MATCHES "/.*")


### PR DESCRIPTION
I tried to split the homebrew code in a version for a (Intel) homebrew prefix /usr/local  and a (ARM/M1) prefix /opt/homebrew.

This is ugly but should be ok.

I'm a bit worried about the pathnames including the exact version of the archive, ssl and readline packages:
  set(OPENSSL_ROOT_DIR /opt/homebrew/Cellar/openssl@3/3.0.0_1)
  set(LibArchive_ROOT /opt/homebrew/Cellar/libarchive/3.5.2)
  set(Readline_ROOT /opt/homebrew/Cellar/readline/8.1.1/)

Suggestions welcome.