### PR TITLE
qsave: add missing load_module for shlib

### DIFF
--- a/library/qsave.pl
+++ b/library/qsave.pl
@@ -43,6 +43,7 @@
 :- use_module(library(option)).
 :- use_module(library(error)).
 :- use_module(library(apply)).
+:- use_module(library(shlib)).
 
 /** <module> Save current program as a state or executable
 


### PR DESCRIPTION
The predicate current_foreign_library is used which is from the module shlib. Unfortunately it is not imported though, which makes it impossible to use qsave without autoloading enabled.