### PR TITLE
_timezone under __WINDOWS__ or __CYGWIN__

### DIFF
--- a/src/os/pl-prologflag.c
+++ b/src/os/pl-prologflag.c
@@ -1714,7 +1714,7 @@ static void
 setTZPrologFlag(void)
 { tzset();
 
-#ifdef _MSC_VER
+#if defined(__WINDOWS__) || defined(__CYGWIN__)
 #define timezone _timezone
 #endif
 


### PR DESCRIPTION
solves a warning under MSYS2/Rtools42 compilation