### PR TITLE
DOC: Remove obsolete reference of `break/1` trace port

### DIFF
--- a/man/hack.doc
+++ b/man/hack.doc
@@ -204,10 +204,6 @@ each parent frame of the frame generating the exception until the
 exception is caught or the user restarts normal computation using
 \const{retry}.  \arg{Except} is the pending exception term.
 
-    \termitem{break}{PC}
-A \const{break} instruction is executed.  \arg{PC} is program counter.
-This port is used by the graphical debugger.
-
     \termitem{cut_call}{PC}
 A cut is encountered at \arg{PC}. This port is used by the graphical
 debugger to visualise the effect of the cut.


### PR DESCRIPTION
The documentation implies that when a breakpoint triggers the tracer, `prolog_trace_interception/4` will be called with a `break(PC)` term as the `Port` argument, but this appears not to be the case since commit 8ffb94a2c49f4146ec9fcdaa85818730323dbbe8.