### PR TITLE
MODIFIED: switching core libswipl code to C11

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -384,6 +384,7 @@ endif()
 
 add_library(swiplobjs${PGO_SUFFIX} OBJECT ${LIBSWIPL_SRC})
 set_property(TARGET swiplobjs${PGO_SUFFIX} PROPERTY C_VISIBILITY_PRESET hidden)
+set_property(TARGET swiplobjs${PGO_SUFFIX} PROPERTY C_STANDARD 11) # Core libswipl code conforms to C11
 if(CHECK_PROTOTYPES) # Can be defined on the command line
 target_compile_options(swiplobjs${PGO_SUFFIX} PRIVATE -Wmissing-prototypes -Wmissing-declarations)
 endif()

--- a/src/pl-builtin.h
+++ b/src/pl-builtin.h
@@ -281,32 +281,62 @@ typedef struct PL_global_data PL_global_data_t;
 
 #if (defined(O_PLMT) || defined(O_MULTIPLE_ENGINES)) && USE_LD_MACROS
 
-#ifdef __GNUC__
-# define _ASSERT_LD(cond) ({static_assert((cond), "Error: LOCAL_LD referenced without a local LD declaration in " __FILE__ ":" A_STRINGIFY(__LINE__)); NULL;})
-#else
-extern void* error_LOCAL_LD_referenced_without_a_local_LD_declaration(void);
-# define _ASSERT_LD(cond) ((cond)?NULL:error_LOCAL_LD_referenced_without_a_local_LD_declaration())
-#endif
-#ifdef HAVE___BUILTIN_CHOOSE_EXPR
-/* __builtin_choose_expr is basically a ternary operator for compile-time constants */
-# define _CHOOSE_EXPR(cond, iftrue, iffalse) __builtin_choose_expr((cond), (iftrue), (iffalse))
-#else
-# define _CHOOSE_EXPR(cond, iftrue, iffalse) ((cond) ? (iftrue) : (iffalse))
-#endif
-#ifdef HAVE___BUILTIN_TYPES_COMPATIBLE_P
-/* __builtin_types_compatible_p is stricter than a sizeof check */
-# define _IS_LDPTR(expr) __builtin_types_compatible_p(typeof(expr), PL_local_data_t*)
-#else
-# define _IS_LDPTR(expr) (sizeof(expr) == sizeof(PL_local_data_t*) && sizeof(*expr) == sizeof(PL_local_data_t))
-#endif
-#define _AS_LDPTR(expr) ((PL_local_data_t*)(expr))
-#define _TRY_LDPTR(expr, otherwise) _CHOOSE_EXPR(_IS_LDPTR(expr), _AS_LDPTR(expr), otherwise)
+/* These are defined in pl-setup.c, but they'll never actually get used.
+ * They're just here for scope-detection. */
+const extern intptr_t __PL_ld;
+const extern intptr_t PL__ctx;
 
-/* These will never be compiled, they are here simply for scope detection */
-extern char *__PL_ld;
-extern struct {char *engine;} *PL__ctx;
-#define _LD_WITH_FALLBACK(f) _TRY_LDPTR(__PL_ld, _TRY_LDPTR(PL__ctx->engine, f))
-#define LOCAL_LD  _LD_WITH_FALLBACK(_ASSERT_LD(_IS_LDPTR(__PL_ld) || _IS_LDPTR(PL__ctx->engine)))
+/* __FIND_LD uses the C11 _Generic operator to resolve to the first
+ * expression iff it is recognized as a PL_local_data_t* in the current
+ * context, otherwise the engine of the second iff it is a control_t,
+ * otherwise the third. Since the above const declarations are in global
+ * scope and have type intptr_t, they will fail this test safely (i.e.
+ * without causing an undefined reference or syntax error) if no shadowing
+ * declaration has been made at block scope. And, since they are concrete
+ * variables set to a constant -1, a debugger can use the actual __FIND_LD
+ * function defined in pl-setup.c to resolve LD or LD-based expressions at
+ * debug-time, even if (like GDB) it doesn't recognize the _Generic operator.
+ */
+PL_local_data_t* __FIND_LD(PL_local_data_t *pl_ld, control_t pl_ctx, PL_local_data_t *fallback);
+#define __FIND_LD(pl_ld, pl_ctx, fallback) \
+	_Generic \
+	( (pl_ld), \
+	  PL_local_data_t*: (PL_local_data_t*)(pl_ld), \
+	  default: _Generic \
+	  ( (pl_ctx), \
+	    control_t: ((control_t)(pl_ctx))->engine, \
+	    default: (fallback) \
+	  ) \
+	)
+
+/* Abusing a GCC idiosyncracy here (don't call it a bug, they might fix it)
+ * because I haven't found ANY documented way to exercise control over which
+ * macros are recorded in the object file at -g3. In GCC, when a macro def
+ * is pushed and then popped, it gets removed from the list of macros
+ * presented to the debugger. The debugger will then fall back to the real
+ * definition of __FIND_LD present in pl-setup.c rather than stumbling on
+ * the above.
+ */
+#ifdef __GNUC__
+# pragma push_macro("__FIND_LD")
+# pragma pop_macro("__FIND_LD")
+#endif
+
+#if defined(__GNUC__) && __has_attribute(error)
+/* If code references LOCAL_LD (either explicitly or by redefining LD as its
+ * alias) but the current function is neither an LDFUNC nor provides a GET_LD
+ * or similar, that's a programming error we want to report. With GCC, we can
+ * use the error attribute to force a failure at compile-time... */
+PL_local_data_t* __attribute__((error("LOCAL_LD referenced without a local LD declaration"))) no_local_ld(void);
+#else
+/* ...otherwise, we reference this nonexistent but descriptively-named
+ * function to cause the failure at link-time. */
+#define no_local_ld error_LOCAL_LD_referenced_without_a_local_LD_declaration
+extern PL_local_data_t* no_local_ld(void);
+#endif
+
+#define _LD_WITH_FALLBACK(f) __FIND_LD(__PL_ld, PL__ctx, f)
+#define LOCAL_LD  _LD_WITH_FALLBACK(no_local_ld())
 #define ANY_LD    _LD_WITH_FALLBACK(GLOBAL_LD)
 
 #define GET_LD	  PL_local_data_t *__PL_ld = GLOBAL_LD;

--- a/src/pl-setup.c
+++ b/src/pl-setup.c
@@ -1748,6 +1748,28 @@ freePrologLocalData(PL_local_data_t *ld)
 #endif
 }
 
+/* The following definitions aren't necessary for compiling, and in fact
+ * you could comment this whole section out without breaking the code.
+ * However, they don't take up much space in the binary and they assist
+ * in C-level debugging, so I'm leaving them in regardless of O_DEBUG. */
+
+const intptr_t __PL_ld = -1;
+const intptr_t PL__ctx = -1;
+
+inline PL_local_data_t*
+(__FIND_LD)(PL_local_data_t *pl_ld, control_t pl_ctx, PL_local_data_t *fallback)
+{ if ((intptr_t)pl_ld != -1)
+  { return pl_ld; }
+  if ((intptr_t)pl_ctx != -1)
+  { return pl_ctx->engine; }
+  return fallback;
+}
+
+#ifndef no_local_ld
+PL_local_data_t*
+no_local_ld(void)
+{ return NULL; }
+#endif
 
 
 		 /*******************************


### PR DESCRIPTION
This allows for a standards-compatible implementation of the LD macros
that is guaranteed to compile down to a simple reference even at -O0.
I've also added some code that, at least in my testing, makes
`print LD` work again in GDB and any debugger that uses it as a backend.