### PR TITLE
MODIFIED: fixing SIG_PROLOG_OFFSET at 32, per docs

### DIFF
--- a/src/pl-fli.c
+++ b/src/pl-fli.c
@@ -4685,11 +4685,8 @@ PL_raise(int sig)
 
 int
 PL_clearsig(DECL_LD int sig)
-{ if ( sig > 0 && sig <= MAXSIGNAL && HAS_LD )
-  { int off  = (sig-1)/32;
-    int mask = 1 << ((sig-1)%32);
-
-    ATOMIC_AND(&LD->signal.pending[off], ~mask);
+{ if ( IS_VALID_SIGNAL(sig) && HAS_LD )
+  { WSIGMASK_CLEAR(LD->signal.pending, sig);
     updateAlerted(LD);
     return TRUE;
   }

--- a/src/pl-global.h
+++ b/src/pl-global.h
@@ -110,7 +110,7 @@ struct PL_global_data
   } resources;
 
   struct
-  { sig_handler handlers[MAXSIGNAL];	/* How Prolog preceives signals */
+  { sig_handler handlers[NUM_SIGNALS];	/* How Prolog receives signals */
 #ifdef SIG_ALERT
     int		sig_alert;		/* our alert signal */
 #endif
@@ -452,7 +452,7 @@ struct PL_local_data
   struct PL_local_data *next_free;	/* see maybe_free_local_data() */
 
   struct
-  { int		pending[2];		/* PL_raise() pending signals */
+  { wsigmask_t	pending;		/* PL_raise() pending signals */
     int		current;		/* currently processing signal */
     int		is_sync;		/* current signal is synchronous */
 #ifndef __unix__

--- a/src/pl-inline.h
+++ b/src/pl-inline.h
@@ -496,7 +496,11 @@ linkValI(DECL_LD Word p)
 #define is_signalled(_) LDFUNC(is_signalled, _)
 static inline int
 is_signalled(DECL_LD)
-{ return HAS_LD && unlikely((LD->signal.pending[0]|LD->signal.pending[1]) != 0);
+{ if (!HAS_LD) return FALSE;
+  for (int i = 0; i < SIGMASK_WORDS; i++)
+  { if (unlikely(LD->signal.pending[i] != 0)) return TRUE;
+  }
+  return FALSE;
 }
 
 #define register_attvar(gp) LDFUNC(register_attvar, gp)

--- a/src/pl-thread.c
+++ b/src/pl-thread.c
@@ -1570,7 +1570,7 @@ int
 PL_w32thread_raise(DWORD id, int sig)
 { int i;
 
-  if ( sig < 0 || sig > MAXSIGNAL )
+  if ( !IS_VALID_SIGNAL(sig) )
     return FALSE;			/* illegal signal */
 
   PL_LOCK(L_THREAD);
@@ -1706,10 +1706,10 @@ thread_wait_signal(DECL_LD)
 #endif
   }
 
-  for(i=0; i<2; i++)
+  for(i=0; i<SIGMASK_WORDS; i++)
   { while( LD->signal.pending[i] )
-    { int sig = 1+32*i;
-      int mask = 1;
+    { int sig = MINSIGNAL+SIGMASK_WIDTH*i;
+      sigmask_t mask = 1;
 
       for( ; mask ; mask <<= 1, sig++ )
       { if ( LD->signal.pending[i] & mask )

--- a/src/pl-wam.c
+++ b/src/pl-wam.c
@@ -316,12 +316,10 @@ updateAlerted(PL_local_data_t *ld)
 
 int
 raiseSignal(PL_local_data_t *ld, int sig)
-{ if ( sig > 0 && sig <= MAXSIGNAL && ld )
-  { int off = (sig-1) / 32;
-    int mask = (1 << ((sig-1)%32));
-    int alerted;
+{ if ( IS_VALID_SIGNAL(sig) && ld )
+  { int alerted;
 
-    ATOMIC_OR(&ld->signal.pending[off], mask);
+    WSIGMASK_SET(ld->signal.pending, sig);
 
     do
     { alerted = ld->alerted;
@@ -336,11 +334,8 @@ raiseSignal(PL_local_data_t *ld, int sig)
 
 int
 pendingSignal(PL_local_data_t *ld, int sig)
-{ if ( sig > 0 && sig <= MAXSIGNAL && ld )
-  { int off  = (sig-1)/32;
-    int mask = 1 << ((sig-1)%32);
-
-    return (ld->signal.pending[off] & mask) ? TRUE : FALSE;
+{ if ( IS_VALID_SIGNAL(sig) && ld )
+  { return WSIGMASK_ISSET(ld->signal.pending, sig) ? TRUE : FALSE;
   }
 
   return -1;


### PR DESCRIPTION
This also introduces a set of macros to interact with the pending signal
mask which should hopefully ease refactoring if and when we change which
signals swipl supports, like adding support for system signals over 31.