### PR TITLE
ADDED: on_signal/3 now takes value 'ignore'

### DIFF
--- a/man/builtin.doc
+++ b/man/builtin.doc
@@ -3373,8 +3373,9 @@ in module <Module>. The handler is called with a single argument:
 the name of the signal as an atom. The Prolog names for signals are
 explained below.
 
-Three names have special meaning. \const{throw} implies Prolog will map
+Four names have special meaning. \const{throw} implies Prolog will map
 the signal onto a Prolog exception as described in \secref{exception},
+\const{ignore} causes Prolog to ignore the signal entirely,
 \const{debug} specifies the debug interrupt prompt that is initially
 bound to \const{SIGINT} (Control-C) and \const{default} resets the
 handler to the settings active before SWI-Prolog manipulated the
@@ -3406,6 +3407,8 @@ and start the tracer.
 Bound to an empty signal handler used to make blocking system calls
 return.  This allows thread_signal/2 to interrupt threads blocked in
 a system call.  See also prolog_alert_signal/2.
+    \definition{pipe}
+Ignored.
     \definition{hup, term, abrt, quit}
 Causes normal Prolog cleanup (e.g., at_halt/1) before terminating the
 process with the same signal.

--- a/src/SWI-Prolog.h
+++ b/src/SWI-Prolog.h
@@ -1101,6 +1101,7 @@ PL_EXPORT(PL_agc_hook_t)	PL_agc_hook(PL_agc_hook_t);
 #define PLSIG_THROW     0x0002		/* throw signal(num, name) */
 #define PLSIG_SYNC      0x0004		/* call synchronously */
 #define PLSIG_NOFRAME   0x0008		/* Do not create a Prolog frame */
+#define PLSIG_IGNORE    0x0010		/* ignore signal entirely */
 
 
 


### PR DESCRIPTION
This allows for requesting the SIG_IGN disposition, and also unifies the
SIGPIPE behavior with the other initially-prepared signals. Technically,
this could be considered a backwards-incompatible change. However, for
this to actually affect someone's working code, they would have to

1. Redefine the system predicate ignore/1,
2. Call `on_signal(Sig, _, ignore)`, AND
3. Expect `ignore(Signal)` to do something besides ignoring Signal;

and in that case I think we can all agree they've brought this trouble
upon themselves. :)

Also adds SIGPIPE's default disposition to the docs.