### PR TITLE
Set MAXPATHLEN to PATH_MAX

### DIFF
--- a/src/config/wincfg.h
+++ b/src/config/wincfg.h
@@ -75,7 +75,7 @@
 #define O_NETBIOS 1
 
 /* Maximum length of a path-name.  Note XOS! */
-#define MAXPATHLEN 512
+#define MAXPATHLEN PATH_MAX
 
 /* Define if floats are IEEE754 */
 #define IEEE754 1


### PR DESCRIPTION
Avoids a warning on a refefinition of MAXPATHLEN in MinGW/RTools42 

/ucrt64/include/sys/param.h:41: warning: "MAXPATHLEN" redefined

In sys/param.h MAXPATHLEN actually refers to PATH_MAX defined in /crt64/include/limits.h where it is 260 not 512.