### PR TITLE
FIXED: dif/2 not firing after unifying with other attributed variables.

### DIFF
--- a/library/dif.pl
+++ b/library/dif.pl
@@ -247,7 +247,7 @@ attr_unify_hook(vardif(V1,V2),Other) :-
         ;   put_attr(Other, dif, vardif(CV1,CV2))
         )
     ;   var(Other)			% unrelated variable
-    ->  true
+    ->  put_attr(Other, dif, vardif(V1,V2))
     ;   verify_compounds(V1, Other),
         verify_compounds(V2, Other)
     ).

--- a/src/Tests/attvar/test_dif.pl
+++ b/src/Tests/attvar/test_dif.pl
@@ -123,6 +123,21 @@ test(no_dup, [P==[x, y, z, z], nondet]) :-
 	permutation_no_dup([x,y,Z,Z],P), P=[x,y,z,z].
 test(17) :-		% from Issue#17
 	dif(A,[_|B]),A=[[]|_],A=[B].
+test(other_atts) :-
+	call_residue_vars((
+		freeze(X, XDone = true),
+		freeze(Y, YDone = true),
+		dif(A, B),
+		X = A,
+		Y = B,
+		\+ X = Y,
+		X = 1,
+		\+ Y = 1,
+		Y = 2
+	), Vars),
+	Vars == [],
+	XDone == true,
+	YDone == true.
 
 :- end_tests(dif).
 


### PR DESCRIPTION
Before:

```prolog
?- dif(A, B), X = A, Y = B, X = Y.
false. % correct

?- freeze(X,true), freeze(Y,true), dif(A, B), X = A, Y = B, X = Y.
X = Y, Y = A, A = B,
freeze(B, true),
freeze(B, true). % no longer fails - bad

?- call_residue_vars((freeze(X,true), freeze(Y,true), dif(A, B), X = A, Y = B, X = Y), Vars).
X = Y, Y = A, A = B,
Vars = [_, B],
freeze(B, true),
freeze(B, true),
dif(B, B). % wat
```

After:

```prolog
?- dif(A, B), X = A, Y = B, X = Y.
false.
?- freeze(X,true), freeze(Y,true), dif(A, B), X = A, Y = B, X = Y.
false.
?- call_residue_vars((freeze(X,true), freeze(Y,true), dif(A, B), X = A, Y = B, X = Y), Vars).
false.
% all correct
```