### PR TITLE
DOC: refer to pack `debug_adapter` in the GNU Emacs Interface page

### DIFF
--- a/man/overview.doc
+++ b/man/overview.doc
@@ -709,6 +709,10 @@ There are several alternatives though:
           Interact with SWI-Prolog directly in Emacs buffers.
     \item \url{https://www.metalevel.at/etrace/}\\
           Trace Prolog code with Emacs.
+    \item \url{https://emacs-lsp.github.io/dap-mode/page/configuration/#swi-prolog}\\
+          Debug Adapter Protocol (DAP) for SWI-Prolog with Emacs using
+          \exam{dap-mode} and the \exam{debug_adapter} pack from
+          \url{https://github.com/eshelyaron/debug_adapter}
 \end{shortlist}
 
 


### PR DESCRIPTION
Add a reference to [the `debug_adapter` pack](https://github.com/eshelyaron/debug_adapter) for GNU Emacs users.
I tried to keep the language concise in the spirit of the rest of the section, if more information is preferable I'll extend it.

See also https://github.com/SWI-Prolog/plweb-www/pull/47.
