### PR TITLE
Do not install WIN32 dlls if WIN32_DLLS=""

### DIFF
--- a/packages/cmake/PrologPackage.cmake
+++ b/packages/cmake/PrologPackage.cmake
@@ -216,6 +216,7 @@ endfunction(swipl_plugin)
 
 function(install_dll)
 if(WIN32)
+if(NOT WIN32_DLLS STRMATCH "")
   set(dlls)
 
   foreach(lib ${ARGN})
@@ -251,6 +252,7 @@ if(WIN32)
        DESTINATION ${CMAKE_BINARY_DIR}/src)
   install(FILES ${dlls}
 	  DESTINATION ${SWIPL_INSTALL_ARCH_EXE})
+endif()
 endif()
 endfunction()
 


### PR DESCRIPTION
I am currently preparing a PKGBUILD for MSYS2/MinGW, and the package installation tries to overwrite the existing zlib1.dll et al. of the MSYS2 system. So whenever WIN32DLLS is set to "" during the cmake build, install_dll does nothing.