### PR TITLE
FIX: conditions for test_answer

### DIFF
--- a/src/Tests/core/test_answer.pl
+++ b/src/Tests/core/test_answer.pl
@@ -38,17 +38,7 @@
 	    test_answer/2
 	  ]).
 
-:- prolog_load_context(directory, Here),
-   atom_concat(Here, '../../../../packages/clib', ClibDir0),
-   absolute_file_name(ClibDir0, ClibDir),
-   asserta(user:file_search_path(library, ClibDir)),
-   asserta(user:file_search_path(foreign, ClibDir)).
-
-:- if(absolute_file_name(foreign(unix), _,
-			 [ file_type(executable),
-			   file_errors(fail),
-			   access(read)
-			 ])).
+:- if(exists_source(library(unix)).
 
 :- use_module(library(plunit)).
 :- use_module(library(unix)).


### PR DESCRIPTION
unsure if it is that simple, but it makes the "answer" tests execute and pass on my linux and skips them on my mingw