### PR TITLE
DOC: Added details to "foreign" section for blobs and streams

### DIFF
--- a/man/foreign.doc
+++ b/man/foreign.doc
@@ -318,6 +318,8 @@ Atoms are the central representation for textual constants in Prolog.
 The transformation of a character string $C$ to an atom implies a
 hash-table lookup.  If the same atom is needed often, it is advised
 to store its reference in a global variable to avoid repeated lookup.
+
+Blobs are also represented as atoms (see \ref{sec:blob}).
     \item[functor_t]
 A functor is the internal representation of a name/arity pair. They are
 used to find the name and arity of a compound term as well as to
@@ -510,7 +512,9 @@ my_function(term_t a0, term_t a1, control_t handle)
 
   switch( PL_foreign_control(handle) )
   { case PL_FIRST_CALL:
-        ctxt = malloc(sizeof(struct context));
+        ctxt = malloc(sizeof *ctxt);
+        if ( !ctxt )
+          return PL_resource_error("memory");
         ...
         PL_retry_address(ctxt);
     case PL_REDO:
@@ -624,7 +628,7 @@ read_or_block(term_t a0, int arity, void *context)
 
   char buf[BUFSIZE];
 
-  size_t n = Sfread(buf, sizeof(char), sizeof(buf)/sizeof(char), s);
+  size_t n = Sfread(buf, sizeof buf[0], sizeof buf / sizeof buf[0], s);
   if ( n == 0 )                     // timeout or error
   { if ( (s->flags&SIO_TIMEOUT) )
       PL_yield_address(s);	  // timeout: yield
@@ -796,11 +800,12 @@ strlen().
     \cfunction{const char*}{PL_atom_chars}{atom_t atom}
 Return a C-string for the text represented by the given atom. The
 returned text will not be changed by Prolog. It is not allowed to modify
-the contents, not even `temporary' as the string may reside in read-only
+the contents, not even `temporarily' as the string may reside in read-only
 memory. The returned string becomes invalid if the atom is
 garbage collected (see \secref{atomgc}).  Foreign functions that require
 the text from an atom passed in a \ctype{term_t} normally use
-PL_get_atom_chars() or PL_get_atom_nchars().
+PL_get_atom_chars() or PL_get_atom_nchars(). If the text can contain
+unicode, or is from a blob, then PL_atom_wchars() should be used.
 
     \cfunction{functor_t}{PL_new_functor}{atom_t name, int arity}
 Returns a {\em functor identifier}, a handle for the name/arity
@@ -1028,6 +1033,7 @@ With the introduction of wide characters (see \secref{encoding}), not
 all atoms can be converted into a \ctype{char*}.  This function fails
 if \arg{t} is of the wrong type, but also if the text cannot be
 represented.  See the \const{REP_*} flags below for details.
+See also PL_get_wchars().
 
 \begin{description}
     \termitem{CVT_ATOM}{}
@@ -1261,6 +1267,15 @@ an ISO-Latin-1 character, the returned pointer comes from Prolog's
 				   pl_wchar_t **s, unsigned flags}
 Wide-character version of PL_get_chars().  The \arg{flags} argument
 is the same as for PL_get_chars().
+
+Typically, a call to PL_get_wchars() uses \const{BUF_STACK}.
+For example, this will print the name of \var{my_atom}
+on stream \var{s}:
+\begin{code}
+PL_STRINGS_MARK();
+Sfprintf(s, "<my_atom>(%Ws)", PL_atom_wchars(my_atom, NULL));
+PL_STRINGS_RELEASE();
+\end{code}
 
     \cfunction{int}{PL_unify_wchars}{term_t t, int type,
 				     size_t len,
@@ -1586,7 +1601,7 @@ foreign_t
 pl_hostname(term_t name)
 { char buf[100];
 
-  if ( gethostname(buf, sizeof(buf)) )
+  if ( gethostname(buf, sizeof buf) )
   { term_t tmp = PL_new_term_ref();
 
     PL_put_atom_chars(tmp, buf);
@@ -1604,7 +1619,7 @@ foreign_t
 pl_hostname(term_t name)
 { char buf[100];
 
-  if ( gethostname(buf, sizeof(buf)) )
+  if ( gethostname(buf, sizeof buf) )
     return PL_unify_atom_chars(name, buf);
 
   PL_fail;
@@ -2118,7 +2133,7 @@ Java atoms,  Microsoft's COM objects, etc., providing safe combined
 garbage collection.
 
 To exploit these features safely and in an organised manner, the
-SWI-Prolog foreign interface allows for creating `atoms' with additional
+SWI-Prolog foreign interface allows creating `atoms' with additional
 type information. The type is represented by a structure holding C
 function pointers that tell Prolog how to handle releasing the atom,
 writing it, sorting it, etc. Two atoms created with different types can
@@ -2126,6 +2141,29 @@ represent the same sequence of bytes. Atoms are first ordered on the
 rank number of the type and then on the result of the
 \cfuncref{compare}{} function.  Rank numbers are assigned when the
 type is registered.
+
+Blobs are in the end atoms (or actually, the other way around). The
+blob handle is a tagged offset into a dynamic array of atoms
+structures. The atom content is malloc'ed (unless the blob uses the
+NOCOPY flag).
+
+So, neither are affected by stack shifts, GC, etc. Only atom-gc may
+invalidate an entry of the array, call the release hook to dispose of
+resources associated to the blob's content and finally call free() on
+the content. After invalidation, the handle may be reused. For Prolog,
+reuse is safe as we are guaranteed that the previous version was
+unreachable. Foreign code must use PL_register_atom() when storing the
+handle in some permanent location to prevent atom-GC reclaiming it.
+
+PL_get_atom() does not register the atom, because it is protected by
+the term you got it from.  PL_new_atom() returns a registered atom to
+avoid GC reclaiming it as soon as you created it (GC runs
+concurrently).
+
+It is not likely anything will ever change here. Memory-wise it would
+be interesting to maintain the content strings in something more
+clever than malloc() and shift them to avoid fragmentation. In a
+concurrent system this is very hard to do safely.
 
 
 \subsubsection{Defining a BLOB type}
@@ -2139,11 +2177,13 @@ displayed below. The structure contains additional fields at the
 typedef struct PL_blob_t
 { uintptr_t	magic;		/* PL_BLOB_MAGIC */
   uintptr_t	flags;		/* Bitwise or of PL_BLOB_* */
-  char *	name;		/* name of the type */
+  const char *	name;		/* name of the type */
   int		(*release)(atom_t a);
   int		(*compare)(atom_t a, atom_t b);
   int		(*write)(IOSTREAM *s, atom_t a, int flags);
   void		(*acquire)(atom_t a);
+  int		(*save)(atom_t a, IOSTREAM *s);
+  atom_t	(*load)(IOSTREAM *s);
   ...
 } PL_blob_t;
 \end{code}
@@ -2177,21 +2217,42 @@ behaviour of built-in atoms. Below are the defined member functions:
 
 \begin{description}
     \cfunction{void}{acquire}{atom_t a}
-Called if a new blob of this type is created through PL_put_blob()
-or PL_unify_blob().  This callback may be used together with the
-release hook to deal with reference-counted external objects.
+Called if a new blob of this type is created through PL_put_blob() or
+PL_unify_blob(). The call to \program{acquire} is done even if the
+PL_put_blob() or PL_unify_blob() fails.  This callback may be used
+together with the \program{release} hook to deal with
+reference-counted external objects. This function can retrieve the
+data of the blob using PL_blob_data().  Unification failure does not
+result in the \program{release} function being immediately called,
+so any resources allocated by the \program{acquire} will be held
+until atom garbage collection calls \program{release}.
 
     \cfunction{int}{release}{atom_t a}
-The blob (atom) \arg{a} is about to be released.  This function
-can retrieve the data of the blob using PL_blob_data().  If it
-returns \const{FALSE} the atom garbage collector will \emph{not}
-reclaim the atom.
+The blob (atom) \arg{a} is about to be released.  This function can
+retrieve the data of the blob using PL_blob_data().  If it returns
+\const{FALSE}, the atom garbage collector will \emph{not} reclaim the
+atom. There is no guarantee when or even if the \program{release}
+function will be called. If you need to release resources, you should
+supply a separate \predicate{close} predicate for the blob.
 
-    \cfunction{int}{compare}{atom_t a, atom_t b}
-Compare the blobs \arg{a} and \arg{b}, both of which are of the
-type associated to this blob type.  Return values are, as memcmp(),
-$< 0$ if \arg{a} is less than \arg{b}, $= 0$ if both are equal, and
-$> 0$ otherwise.
+    \cfunction{int}{compare}{atom_t a, atom_t b} Compare the blobs
+\arg{a} and \arg{b}, both of which are of the type associated to this
+blob type.  Return values are, as memcmp(), $< 0$ if \arg{a} is less
+than \arg{b}, $= 0$ if both are equal, and $> 0$ otherwise. The
+default implementation is a bitwise comparison of the blobs'
+contents. If you cannot guarantee that the blobs all have unique
+contents, then you should incorporate the blob address (the system
+guarantees that blobs are not shifted in memory after they are
+allocated). The following minimal compare function gives a stable
+total ordering:
+\begin{code}
+static int
+compare_my_blob(atom_t a, atom_t b)
+{ const struct my_blob_data *blob_a = PL_blob_data(a, NULL, NULL);
+  const struct my_blob_data *blob_b = PL_blob_data(b, NULL, NULL);
+  return (blob_a > blob_b) ?  1 :  (blob_a < blob_b) ? -1 : 0;
+}
+\end{code}
 
     \cfunction{int}{write}{IOSTREAM *s, atom_t a, int flags}
 Write the content of the blob \arg{a} to the stream \arg{s}
@@ -2199,7 +2260,8 @@ respecting the \arg{flags}.  The \arg{flags} are a bitwise
 \emph{or} of zero or more of the \const{PL_WRT_*} flags defined in
 \file{SWI-Prolog.h}. This prototype is available if the
 undocumented \file{SWI-Stream.h} is included \emph{before}
-\file{SWI-Prolog.h}.
+\file{SWI-Prolog.h}. This function can retrieve the data of the blob
+using PL_blob_data().
 
 If this function is not provided, write/1 emits the content
 of the blob for blobs of type \const{PL_BLOB_TEXT} or a
@@ -2240,6 +2302,31 @@ filled with the type of the blob.
 				   PL_blob_t *type}
 Unify \arg{t} to a new blob constructed from the given data and
 associated to the given type.  See also PL_unify_atom_nchars().
+The blob's \program{acquire} function is always called, even
+if unification fails.
+
+If your "create blob" foreign predicate allocates resources inside
+the blob, it can be complicated to ensure that things are freed up
+properly on failure. One way of simplifying this code like this
+(assuming the blob has not been defined with the NOCOPY flag:
+\begin{code}
+static foreign_t
+my_blob_open(term_t handle, ...)
+{ my_blob_t *my_blob_p;
+  { my_blob_t my_blob_local;
+    atom my_blob_a;
+    /* initialize my_blob_local's non-resource fields */
+    if ( !PL_unify_blob(handle, &my_blob_local, sizeof my_blob_local, &my_blob) ||
+         |PL_get_atom_ex(handle, &my_blob_a) )
+      return FALSE;
+    my_blob_p = PL_blob_data(my_blob_a, NULL, NULL);
+  }
+  /* From here on, any resources that are allocated in *my_blob_p
+     will be freed when atom garbage collection calls my_blob's
+     "release" function. */
+  ...
+}
+\end{code}
 
     \cfunction{int}{PL_put_blob}{term_t t, void *blob, size_t len,
 				 PL_blob_t *type}
@@ -2250,6 +2337,8 @@ deal with external objects having their own reference counts.  If the
 return is \const{TRUE} this reference count must be incremented, and it
 must be decremented on blob destruction callback.  See also
 PL_put_atom_nchars().
+The blob's \program{acquire} function is always called, even
+if PL_put_blob() returns false.
 
     \cfunction{int}{PL_get_blob}{term_t t, void **blob, size_t *len,
 				 PL_blob_t **type}
@@ -2264,6 +2353,44 @@ ignored.
 Get the data and type associated to a blob.  This function is mainly
 used from the callback functions described in \secref{blobtype}.
 \end{description}
+
+
+\subsection{Streams}
+\label{sec:streams}
+
+A stream is a system-defined blob. See \ref{sec:blob}.
+
+When a foreign predicate is passed a stream, it receives a
+\ctype{term_t}. This can be turned into the stream handle by
+PL_get_atom_ex(). To do IO with a stream, you must convert it to a
+\ctype{IOSTREAM} pointer, PL_acquire_stream, which also locks
+the stream from other threads. When you are finished with the
+stream, use PL_release_stream or PL_release_stream_noerror.
+If you have an \ctype{IOSTREAM} pointer, you can lock and unlock
+it with Sloc(), Strylock(), Sunlock().
+
+The predefined streams area available as \ctype{IOSTREAM} pointers,
+with names starting with "\chr{s}", for example \var{Suser_error}.
+Varianats on the standard C functions for I/O are provided, for example
+Sfprintf(). In addition, there are convenience functions such as
+Sdfprintf() for debug output.
+
+For constructing a string, you can use Sopenmem(). For example:
+\begin{code}
+char buf[1024];
+size_t bufsize = sizeof buf;
+char *s = buf;
+IOSTREAM *stream = Sopenmem(&s, &bufsize, "w");
+if (PL_write_term(stream, term, 1200, PL_WRT_QUOTED))
+{ Sflush(stream);
+  /* The text is in `s`, with `bufsize` */
+}
+Sclose(stream);
+if (s != buf)
+  Sfree(s);
+\end{code}
+
+See also \ref{sec:streamstat} and \ref{sec:cfilenames}.
 
 
 \subsection{Exchanging GMP numbers}
@@ -3071,7 +3198,7 @@ load_words(term_t name)
       return FALSE;
 
     if ( (fid = PL_open_foreign_frame()) )
-    { while(fgets(word, sizeof(word), fd))
+    { while(fgets(word, sizeof word, fd))
       { size_t len;
 
 	if ( (len=strlen(word)) )
@@ -4365,7 +4492,6 @@ of foreign code.
 \begin{code}
 /*  Include file depends on local installation */
 #include <SWI-Prolog.h>
-#include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
 
@@ -4378,6 +4504,8 @@ pl_lowercase(term_t u, term_t l)
   if ( !PL_get_atom_chars(u, &s) )
     return PL_warning("lowercase/2: instantiation fault");
   copy = malloc(strlen(s)+1);
+  if ( !copy )
+    return PL_resource_error("memory");
 
   for( q=copy; *s; q++, s++)
     *q = (isupper(*s) ? tolower(*s) : *s);
@@ -4644,7 +4772,7 @@ subsequent modifications.
 Get the next key-value pair from a cursor.
 \end{description}
 
-\subsection{Debugging and profiling foreign code (valgrind)}
+\subsection{Debugging and profiling foreign code (valgrind, asan)}
 \label{sec:foreign-debug-and-profile}
 
 \index{valgrind}\index{profiling,foreign code}%
@@ -4667,6 +4795,27 @@ using \program{bash} as login shell:
 % VALGRIND=yes valgrind --tool=callgrind pl <args>
 <prolog interaction>
 % kcachegrind callgrind.out.<pid>
+\end{code}
+
+\index{asan}\index{profiling,foreign code}%
+
+Instead of \program{valgrind}, you can use
+\href{https://github.com/google/sanitizers/wiki/AddressSanitizer}{AddressSanitizer}
+or \program{asan}. Here is a short example for building with
+\jargon{asan} enabled and then running the resulting binary. When you
+exit \program{swipl}, a message is printed and any leaks are printed.
+During execution, other messages may be printed out, such as freeing
+an address twice or using freed or unallocated memory.
+
+\begin{code}
+% cd build.sanitize
+% cmake -G Ninja -DCMAKE_BUILD_TYPE=Sanitize ..
+% ninja
+% ASAN_OPTIONS=detect_leaks=1 build.sanitize/src/swipl
+<prolog interaction>
+% halt
+Running LSAN memory leak check (reclaim_memory=1)
+No leaks detected
 \end{code}
 
 \subsection{Name Conflicts in C modules}

--- a/src/SWI-Prolog.h
+++ b/src/SWI-Prolog.h
@@ -715,7 +715,7 @@ PL_EXPORT(int)		PL_syntax_error(const char *msg, IOSTREAM *in);
 typedef struct PL_blob_t
 { uintptr_t		magic;		/* PL_BLOB_MAGIC */
   uintptr_t		flags;		/* PL_BLOB_* */
-  char *		name;		/* name of the type */
+  const char *		name;		/* name of the type */
   int			(*release)(atom_t a);
   int			(*compare)(atom_t a, atom_t b);
   int			(*write)(IOSTREAM *s, atom_t a, int flags);

--- a/src/test/lwrcase.c
+++ b/src/test/lwrcase.c
@@ -33,9 +33,10 @@
 */
 
 #include <SWI-Prolog.h>
+#include <string.h>
 #include <ctype.h>
 
-foreign_t
+static foreign_t
 pl_lowercase(term_t u, term_t l)
 { char *copy;
   char *s, *q;
@@ -44,6 +45,8 @@ pl_lowercase(term_t u, term_t l)
   if ( !PL_get_atom_chars(u, &s) )
     return PL_warning("lowercase/2: instantiation fault");
   copy = malloc(strlen(s)+1);
+  if ( !copy )
+    return PL_resource_error("memory");
 
   for( q=copy; *s; q++, s++)
     *q = (isupper(*s) ? tolower(*s) : *s);


### PR DESCRIPTION
I used \program{...} in some changes because \ctype{...} seemed wrong and I couldn't figure out how to add another command to pl.sty (e.g., \cfuncname{...}) that also expanded the HTML.

Also, there's a good chance I got some things wrong in what I wrote, even though so of it is copy-and-paste from what Jan had written to me in an email.