### PR TITLE
Replace MINGW_ROOT by WIN32

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -370,7 +370,7 @@ endif()
 add_executable(swipl${PGO_SUFFIX} ${SWIPL_SRC})
 target_link_libraries(swipl${PGO_SUFFIX} ${SWIPL_LIBRARIES} libswipl${PGO_SUFFIX})
 target_c_stack(swipl${PGO_SUFFIX} 4000000)
-if(MINGW_ROOT)
+if(WIN32)
   target_link_options(swipl${PGO_SUFFIX} PRIVATE -municode)
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -370,7 +370,7 @@ endif()
 add_executable(swipl${PGO_SUFFIX} ${SWIPL_SRC})
 target_link_libraries(swipl${PGO_SUFFIX} ${SWIPL_LIBRARIES} libswipl${PGO_SUFFIX})
 target_c_stack(swipl${PGO_SUFFIX} 4000000)
-if(WIN32)
+if(MINGW)
   target_link_options(swipl${PGO_SUFFIX} PRIVATE -municode)
 endif()
 


### PR DESCRIPTION
I think -municode needs to be defined on all Windows systems that are currently supported (= several flavors of MinGW). MINGW_ROOT was not defined on my system, so I would like to change this to WIN32 to save a cmake command line switch.