### PR TITLE
Wrap elementary functions to correct issues with rounding mode support in various libm's

### DIFF
--- a/src/Tests/rational/test_ieee754.pl
+++ b/src/Tests/rational/test_ieee754.pl
@@ -538,7 +538,10 @@ test(ieee_rndto) :-
     assertion(test_roundto(-2.0** 1r3)),
     assertion(test_roundto( 2.0** 1r3)),
     assertion(test_roundto(pi)),
-    assertion(test_roundto(e)).
+    assertion(test_roundto(e)),
+    assertion(test_roundto(sin(pi/2))),
+    assertion(test_roundto(atan2(1,-1))),
+    assertion(test_roundto(cosh(-0.5))).
 
 test(bounded) :-
     assertion(bounded_number(0,10,1)),
@@ -605,7 +608,11 @@ roundto(Exp,r(Rc,Rp,Rn,Rz)) :-                  % for non-precise Exp
 %
 %   Round is a term r(Nearest, Positive, Negative, Zero)
 
+check_round(_Exp, r(R,R,R,R)) :- 
+	float(R), float_class(R,infinite),
+	!.
 check_round(Exp, r(Rc,Rp,Rn,Rz)) :-
+	abs(Rp-Rc+Rn-Rz) < 1e-15,  % all values should be almost equal so sum~=0
     Rn =< Rc, Rc =< Rp,
     (   Rc < 0
     ->  Rz >= Rc, expect_less_then(Exp, n=Rn, z=Rz)


### PR DESCRIPTION
Various platform libm's produce incorrect results when used with IEEE float rounding modes other than 'to_nearest'. This PR wraps these functions with additional code to ensure rounding mode correctness. See comment in 'pl-arith.c' for further details. A few additional test cases are included to detect incorrect rounding, but these are by no means exhaustive. Also see <https://swi-prolog.discourse.group/t/rounding-transcendentals-broken-on-macos-intel/5166> for lengthy discussion preceding this PR.

Note that this fix does not address any precision issues in the various libraries. A proven implementation, such as 'crlibm', is required to address this issue.