### PR TITLE
Fixes for arithmetic function ar_pow() - float**rat case

### DIFF
--- a/src/Tests/rational/test_ieee754.pl
+++ b/src/Tests/rational/test_ieee754.pl
@@ -528,6 +528,18 @@ test(ieee_rmode) :-
     assertion(test_rounding(pi)),
     assertion(test_rounding(e)).
 
+% rational exponent power tests (3)
+test(float_to_rat) :-
+    assertion(test_value(8.0 is 4.0**3r2)),
+    assertion(1.5NaN is -4.0**3r2),  % neg. base, even Q
+    assertion(test_value(2.0 is 8.0**1r3)),
+    assertion(test_value(-2.0 is -8.0**1r3)),
+    assertion(test_value(4.0 is 8.0**2r3)),
+    assertion(test_value(4.0 is -8.0**2r3)),
+    assertion(test_value(0.5 is 8.0** -1r3)),
+    assertion(test_value(-0.5 is -8.0** -1r3)),
+    assertion(2**1r2 =:= sqrt(2)).
+
 test(ieee_rndto) :-
     assertion(test_roundto(-1.0/(3))),
     assertion(test_roundto(float(1r3))),
@@ -535,8 +547,21 @@ test(ieee_rndto) :-
     assertion(test_roundto(sqrt(2))),
     assertion(test_roundto(exp(log(2)))),
     assertion(test_roundto(2**0.5)),
-    assertion(test_roundto(-2.0** 1r3)),
-    assertion(test_roundto( 2.0** 1r3)),
+    assertion(test_roundto(-2.0002** 2)),
+    assertion(test_roundto( 2.0002** 2)),
+    assertion(test_roundto( 2.0002** 1r2)),
+    assertion(test_roundto(-2.0002** 1r3)),
+    assertion(test_roundto( 2.0002** 1r3)),
+    assertion(test_roundto(-2.0002** 2r3)),
+    assertion(test_roundto( 2.0002** 2r3)),
+    assertion(test_roundto( 0.0002 ** 1r3)),
+    assertion(test_roundto(-0.0002 ** 1r3)),
+    assertion(test_roundto( 0.0002 ** 2r3)),
+    assertion(test_roundto(-0.0002 ** 2r3)),        
+    assertion(test_roundto( 0.0002 ** -1r3)),
+    assertion(test_roundto(-2.0002 ** -1r3)),
+    assertion(test_roundto( 0.0002 ** -2r3)),
+    assertion(test_roundto(-2.0002 ** -2r3)),
     assertion(test_roundto(pi)),
     assertion(test_roundto(e)),
     assertion(test_roundto(sin(pi/2))),
@@ -581,6 +606,10 @@ float_parts(F,Ip,Fp) :-
     Ip is float_integer_part(F),
     Fp is float_fractional_part(F).
 
+test_value(R is Exp) :-
+	Rp is roundtoward(Exp,to_positive),
+    Rn is roundtoward(Exp,to_negative),
+    Rn =< R,R =< Rp.
 
 test_rounding(Exp) :-
     rounding(Exp, Rounded),
@@ -612,7 +641,7 @@ check_round(_Exp, r(R,R,R,R)) :-
 	float(R), float_class(R,infinite),
 	!.
 check_round(Exp, r(Rc,Rp,Rn,Rz)) :-
-	abs(Rp-Rc+Rn-Rz) < 1e-15,  % all values should be almost equal so sum~=0
+    abs((Rp-Rc+Rn-Rz)/Rc) < 4e-15,
     Rn =< Rc, Rc =< Rp,
     (   Rc < 0
     ->  Rz >= Rc, expect_less_then(Exp, n=Rn, z=Rz)

--- a/src/Tests/rational/test_rational.pl
+++ b/src/Tests/rational/test_rational.pl
@@ -117,18 +117,6 @@ test(conversion) :-
     assertion((R1 is float(5r3), R2 is (5)/(3), check_error(R1,R2))),
     assertion(rationalize((1)/(2)) =:= 1r2).
 
-% rational exponent power tests (3)
-test(float_to_rat) :-
-    assertion(8.0 is 4.0**3r2),
-    assertion(1.5NaN is -4.0**3r2),  % neg. base, even Q
-    assertion(2.0 is 8.0**1r3),
-    assertion(-2.0 is -8.0**1r3),
-    assertion(4.0 is 8.0**2r3),
-    assertion(4.0 is -8.0**2r3),
-    assertion(0.5 is 8.0** -1r3),
-    assertion(-0.5 is -8.0** -1r3),
-    assertion(2**1r2 =:= sqrt(2)).
-
 test(int_to_rat) :-
     assertion(div0err(0** -1)),  % additional test for negative integer exp.
     assertion(div0err(0** -1r2)),

--- a/src/pl-arith.c
+++ b/src/pl-arith.c
@@ -2228,37 +2228,6 @@ get_int_exponent(Number n, unsigned long *expp)
   return TRUE;
 }
 
-/* cond_minus_pow() handles rounding mode issues calculating pow with
-   negative base float have to reverse to_positive and to_negative.
-*/
-
-static double
-cond_minus_pow(double base, double exp)
-{ double res;
-
-  if ( base < 0 )
-  { switch( fegetround() )
-    { case FE_UPWARD:
-	fesetround(FE_DOWNWARD);
-        res = -pow(-base,exp);
-	fesetround(FE_UPWARD);
-	break;
-      case FE_DOWNWARD:
-	fesetround(FE_UPWARD);
-        res = -pow(-base,exp);
-	fesetround(FE_DOWNWARD);
-	break;
-      default:
-	res = -pow(-base,exp);
-    }
-  } else
-  { res = pow(base,exp);
-  }
-
-  return res;
-}
-
-
 static int
 ar_smallint(Number n, int *i)
 { switch(n->type)
@@ -2542,17 +2511,61 @@ ar_pow(Number n1, Number n2, Number r)
         if ( n1->value.f < 0  && !( r_den & 1 ))
 	{ r->value.f = const_nan;	/* negative base, even denominator */
 	} else
-        {
-	doreal_mpq:
-	  mpq_init(r->value.mpq);
-	  mpq_set_ui(r->value.mpq,1,mpz_get_ui(mpq_denref(n2->value.mpq)));
-	  double dexp = mpq_get_d(r->value.mpq);  /* float(1/n2.den) */
-	  mpq_clear(r->value.mpq);
-	  r->value.f = pow(cond_minus_pow(n1->value.f, dexp),
-			   mpz_get_ui(mpq_numref(n2->value.mpq)));
-	  if ( exp_sign == -1 )
-	    r->value.f = 1.0/r->value.f;
+doreal_mpq:{  // float n1 ^ rat n2*exp_sign, permit -ve float
+      /*  Difficult to keep rounding modes straight as 1)the pow function
+       * switches between monotonic increasing and decreasing depending on 
+       * value of n1 and n2, and 2) it's a two step function ( promoteToFloatNumber()
+       * and pow() ) with independent rounding.
+       */
+      int roundMode = fegetround();  // original roundMode
+      int roundMode1, roundMode2;
+      int neg_res = (n1->value.f < 0.0) && 
+                    (mpz_get_ui(mpq_numref(n2->value.mpq)) & 1 );  // result negative 
+      if ( neg_res )                 // pow monotonic increasing or decreasing
+      { switch (roundMode)           // decreasing
+        { case FE_UPWARD:
+            roundMode1 = FE_DOWNWARD;
+            break;
+          case FE_DOWNWARD:
+            roundMode1 = FE_UPWARD;
+            break;
+          default: 
+            roundMode1 = roundMode;
+        };
+      } else                         // increasing
+        roundMode1 = roundMode;
+
+      n1->value.f = fabs(n1->value.f);  // positive n1 for pow function
+      if ( n1->value.f < 1.0 )       // pow monotonic increasing or decreasing
+      { switch (roundMode1)          // decreasing
+        { case FE_UPWARD:
+            roundMode2 = FE_DOWNWARD;
+            break;
+          case FE_DOWNWARD:
+            roundMode2 = FE_UPWARD;
+            break;
+          default: 
+            roundMode2 = roundMode1;
         }
+      } else                         // increasing
+        roundMode2 = roundMode1;
+
+      fesetround(roundMode2);
+      if ( exp_sign == -1 )                        // restore exp sign
+        mpq_neg(n2->value.mpq, n2->value.mpq);
+      if ( !promoteToFloatNumber(n2) )             // using roundMode as set
+        return FALSE;                              // failed to promote to float?
+
+      if (roundMode1 != roundMode2)
+        fesetround(roundMode1);
+      r->value.f = pow(n1->value.f, n2->value.f);  // single call using roundMode1
+
+      if ( neg_res )                               // restore result sign
+        r->value.f = -r->value.f;
+
+      if ( roundMode1 != roundMode )
+        fesetround(roundMode);                     // restore original roundMode
+        }  /* doreal_mpq */
 
         r->type = V_FLOAT;
         return check_float(r);

--- a/src/pl-gmp.c
+++ b/src/pl-gmp.c
@@ -1545,9 +1545,9 @@ mpz_fdiv(mpz_t num, mpz_t den)
     }
 
     if ( swapped )
-      res = (l/s) * pow(2.0, le-se);
+      res = ldexp(l/s, le-se);
     else
-      res = (s/l) * pow(2.0, se-le);
+      res = ldexp(s/l, se-le);
 
     if ( negative )
       fesetround(r_mode);


### PR DESCRIPTION
Recent change for correctly rounded elementary function exposed weaknesses in ar_pow() when raising a float to a rational number. This PR largely replaces the previous code in pl_arith.c.

Additional test cases have been added to test the changes and some have been moved from test_rational.pl to test_ieee754.pl  to put all the tests in one place.

Also replaced the pow() calls (non-corrected) in pl_gmp.c (function fpz_fdiv) with calls to ldexp() which seem to be intended for the required functionality. Note that this function is commonly used when promoting rationals to floats, but running ctest does not detect any issues.

I believe these changes are fairly localized and the risk of applying them should be minimal.

 