### PR TITLE
Add support for conditional breakpoints

### DIFF
--- a/library/prolog_breakpoints.pl
+++ b/library/prolog_breakpoints.pl
@@ -38,7 +38,7 @@
 :- module(prolog_breakpoints,
           [ set_breakpoint/4,           % +File, +Line, +CharPos, -Id
             set_breakpoint/5,           % +Owner, +File, +Line, +CharPos, -Id
-            set_breakpoint/6,           % +Owner, +File, +Line, +CharPos, +Cond, -Id
+            set_breakpoint/6,           % +Owner, +File, +Line, +CharPos, :Cond, -Id
             delete_breakpoint/1,        % +Id
             breakpoint_property/2       % ?Id, ?Property
           ]).
@@ -350,5 +350,5 @@ prolog:break_hook(Clause, PC, Frame, _Choice, _Goal, true, Action) :-
                        ->  Action = trace
                        ;   Action = continue
                        ),
-                       prolog:erase(Ref)).
+                       erase(Ref)).
 

--- a/library/prolog_breakpoints.pl
+++ b/library/prolog_breakpoints.pl
@@ -342,11 +342,10 @@ breakpoint_name(Id) -->
 
 
 :- thread_local break_context_frame/1.
-:- multifile prolog:break_hook/6.
+:- multifile prolog:break_hook/7.
 
-prolog:break_hook(Clause, PC, Frame, _Choice, _Goal, Action) :-
+prolog:break_hook(Clause, PC, Frame, _Choice, _Goal, true, Action) :-
     known_breakpoint(Clause, PC, _, Cond, _Id),
-    current_prolog_flag(debug, true),
     setup_call_cleanup(asserta(break_context_frame(Frame), Ref),
                        (   Cond
                        ->  Action = trace

--- a/library/prolog_breakpoints.pl
+++ b/library/prolog_breakpoints.pl
@@ -39,6 +39,7 @@
           [ set_breakpoint/4,           % +File, +Line, +CharPos, -Id
             set_breakpoint/5,           % +Owner, +File, +Line, +CharPos, -Id
             set_breakpoint/6,           % +Owner, +File, +Line, +CharPos, :Cond, -Id
+            set_breakpoint_condition/2, % +Id, :Cond
             delete_breakpoint/1,        % +Id
             breakpoint_property/2       % ?Id, ?Property
           ]).
@@ -340,7 +341,33 @@ breakpoint_name(Id) -->
     ).
 
 
+                 /**********************************************
+                 *            Conditional Breakpoints          *
+                 **********************************************/
+
+
+%!  set_breakpoint_condition(+Id, :Cond) is det.
+%
+%   Set the condition goal of the breakpoint with given Id to Cond.
+%
+%   @error existence_error(breakpoint, Id).
+
+set_breakpoint_condition(Id, Cond) :-
+    retract(known_breakpoint(ClauseRef, PC, Location, _OldCond, Id)),
+    !,
+    asserta(known_breakpoint(ClauseRef, PC, Location, Cond, Id)).
+set_breakpoint_condition(Id, _Cond) :-
+    existence_error(breakpoint, Id).
+
+
+%!  break_context_frame(-Frame) is semidet.
+%
+%   When called from the condition goal of a conditional breakpoint,
+%   this predicate unifies Frame with an identifier of the frame in
+%   which the pending breakpoint was triggered.
+
 :- thread_local break_context_frame/1.
+
 :- multifile prolog:break_hook/7.
 
 prolog:break_hook(Clause, PC, Frame, _Choice, _Goal, true, Action) :-

--- a/library/prolog_breakpoints.pl
+++ b/library/prolog_breakpoints.pl
@@ -38,6 +38,7 @@
 :- module(prolog_breakpoints,
           [ set_breakpoint/4,           % +File, +Line, +CharPos, -Id
             set_breakpoint/5,           % +Owner, +File, +Line, +CharPos, -Id
+            set_breakpoint/6,           % +Owner, +File, +Line, +CharPos, +Cond, -Id
             delete_breakpoint/1,        % +Id
             breakpoint_property/2       % ?Id, ?Property
           ]).
@@ -61,9 +62,11 @@ Note that the hook must fail  after   creating  its side-effects to give
 other hooks the opportunity to react.
 */
 
+:- meta_predicate set_breakpoint(+, +, +, +, 0, -).
+
 %!  set_breakpoint(+File, +Line, +Char, -Id) is det.
-%!  set_breakpoint(+File, +Line, +Char, :Cond, -Id) is det.
 %!  set_breakpoint(+Owner, +File, +Line, +Char, -Id) is det.
+%!  set_breakpoint(+Owner, +File, +Line, +Char, :Cond, -Id) is det.
 %
 %   Put a breakpoint at the indicated source-location. File is a current
 %   sourcefile (as reported by source_file/1). Line  is the 1-based line
@@ -71,7 +74,7 @@ other hooks the opportunity to react.
 %
 %   Cond is a goal that will be invoked whenever the newly set
 %   breakpoint is triggered. If goal fails, the breakpoint is skipped
-%   and execution commences normaly.  In the context of Cond,
+%   and execution commences normally.  In the context of Cond,
 %   break_context_frame/1 is made available for obtaining the
 %   execution frame identifier in which the breakpoint was triggered.
 %
@@ -94,11 +97,7 @@ set_breakpoint(File, Line, Char, Id) :-
     set_breakpoint(File, File, Line, Char, Id).
 
 set_breakpoint(Owner, File, Line, Char, Id) :-
-    integer(Char),
-    !,
     set_breakpoint(Owner, File, Line, Char, true, Id).
-set_breakpoint(File, Line, Char, Cond, Id) :-
-    set_breakpoint(File, File, Line, Char, Cond, Id).
 
 set_breakpoint(Owner, File, Line, Char, Cond, Id) :-
     debug(break, 'break_at(~q, ~d, ~d).', [File, Line, Char]),

--- a/man/hack.doc
+++ b/man/hack.doc
@@ -287,16 +287,18 @@ with the library \pllib{prolog_breakpoints}. Setting a breakpoint
 replaces a virtual machine instruction with the \const{D_BREAK}
 instruction.  If the virtual machine executes a \const{D_BREAK}, it
 performs a callback to decide on the action to perform.  This section
-describes this callback, called prolog:break_hook/6.
+describes this callback, called prolog:break_hook/7.
 
 \begin{description}
-    \predicate[hook,semidet]{prolog:break_hook}{6}{+Clause, +PC, +FR,
-						   +BFR, +Expression, -Action}
+    \predicate[hook,semidet]{prolog:break_hook}{7}{+Clause, +PC, +FR,
+						   +BFR, +Expression, +Debug, -Action}
 \emph{Experimental}
 This hook is called if the virtual machine executes a \const{D_BREAK},
 set using set_breakpoint/4. \arg{Clause} and \arg{PC} identify the
 breakpoint. \arg{FR} and \arg{BFR} provide the environment frame and
-current choicepoint.  \arg{Expression} identifies the action that is
+current choicepoint. \arg{Debug} is \const{true} if the system was in
+debug mode when the breakpoint was reached, otherwise \arg{Debug} is
+\const{false}. \arg{Expression} identifies the action that is
 interrupted, and is one of the following:
 
     \begin{description}
@@ -334,7 +336,7 @@ interrupted, and is one of the following:
     both the unification start and end instructions.}
     \end{description}
 
-If prolog:break_hook/6 succeeds, it must unify \arg{Action} with a value
+If prolog:break_hook/7 succeeds, it must unify \arg{Action} with a value
 that describes how execution must continue. Possible values for
 \arg{Action} are:
 

--- a/man/textdebugger.md
+++ b/man/textdebugger.md
@@ -627,11 +627,12 @@ true.
 X = rock1 ;
 X = rock2.
 
-[debug]  ?- test_noun2(foo, rock).
-   Call: (11) noun(foo, rock) ? goals
-     [11] noun(foo, rock)
-     [10] test_noun2(foo, rock)
-   Call: (11) noun(foo, rock) ? abort
+[debug]  ?- test_noun2(rock2, rock).
+   Call: (11) noun(rock2, rock) ? creep
+   Call: (12) is_a(rock2, rock) ? creep
+   Exit: (12) is_a(rock2, rock) ? creep
+   Exit: (11) noun(rock2, rock) ? creep
+   Exit: (10) test_noun2(rock2, rock) ? creep
 [trace]  ?-
 ~~~
 

--- a/man/textdebugger.md
+++ b/man/textdebugger.md
@@ -602,6 +602,38 @@ breakpoints discussed thus far, except that whenever the breakpoint is
 triggered, the given goal is invoked and trace mode is only turned on
 in case it succeeds.
 
+To enable tracing just when ``noun/2`` is called from ``test_noun2/2``
+with ``rock2`` as the first argument, `set_breakpoint/4` can be used
+like this:
+
+~~~
+?- [user].
+|:
+|: should_break :-
+|:     prolog_breakpoints:break_context_frame(Frame),
+|:     prolog_frame_attribute(Frame, argument(1), Arg),
+|:     Arg == rock2.
+|:
+|: ^Dtrue.
+
+?- set_breakpoint('/...path.../Example.pl', 8, 24, user:should_break, ID).
+ID = 1.
+
+?- debug.
+true.
+
+[debug]  ?- test_noun2(X, rock).
+X = rock1 ;
+X = rock2.
+
+[debug]  ?- test_noun2(foo, rock).
+   Call: (11) noun(foo, rock) ? goals
+     [11] noun(foo, rock)
+     [10] test_noun2(foo, rock)
+   Call: (11) noun(foo, rock) ? abort
+[trace]  ?-
+~~~
+
 ## Command Line Debugger Summary {#trace-summary}
 
 In summary, there are really two distinct "tracing" features: trace

--- a/man/textdebugger.md
+++ b/man/textdebugger.md
@@ -596,15 +596,16 @@ calling nodebug/0 since shutting off debug mode automatically turns off
 trace mode.
 
 In addition, SWI-Prolog supports attaching an arbitrary goal to each
-breakpoint via `set_breakpoint/6`, which yields *Conditional
+breakpoint via `set_breakpoint_condition/2`, which yields *Conditional
 Breakpoints*. A conditional breakpoint is the same as the regular
 breakpoints discussed thus far, except that whenever the breakpoint is
 triggered, the given goal is invoked and trace mode is only turned on
-in case it succeeds.
+in case it succeeds. It is also possible to specify a condition for a
+breakpoint when creating the breakpoint with `set_breakpoint/6`.
 
 To enable tracing just when ``noun/2`` is called from ``test_noun2/2``
-with ``rock2`` as the first argument, `set_breakpoint/4` can be used
-like this:
+with ``rock2`` as the first argument, `set_breakpoint_condition/2` can
+be used like this:
 
 ~~~
 ?- [user].
@@ -616,9 +617,11 @@ like this:
 |:
 |: ^Dtrue.
 
-?- Path = '/...path.../Example.pl', set_breakpoint(Path, Path, 8, 24, user:should_break, ID).
-Path = '/...path.../Example.pl',
+?- set_breakpoint('/tmp/e.pl', 8, 24, ID).
 ID = 1.
+
+?- set_breakpoint_condition(1, user:should_break).
+true.
 
 ?- debug.
 true.
@@ -633,6 +636,27 @@ X = rock2.
    Exit: (12) is_a(rock2, rock) ? creep
    Exit: (11) noun(rock2, rock) ? creep
    Exit: (10) test_noun2(rock2, rock) ? creep
+true.
+
+[trace]  ?- notrace.
+true.
+
+[debug]  ?- set_breakpoint_condition(1, true).
+true.
+
+[debug]  ?- test_noun2(X, rock).
+   Call: (11) noun(_23686, rock) ? creep
+   Call: (12) is_a(_23686, rock) ? creep
+   Exit: (12) is_a(rock1, rock) ? creep
+   Exit: (11) noun(rock1, rock) ? creep
+   Exit: (10) test_noun2(rock1, rock) ? creep
+X = rock1 ;
+   Redo: (12) is_a(_23686, rock) ? creep
+   Exit: (12) is_a(rock2, rock) ? creep
+   Exit: (11) noun(rock2, rock) ? creep
+   Exit: (10) test_noun2(rock2, rock) ? creep
+X = rock2.
+
 [trace]  ?-
 ~~~
 

--- a/man/textdebugger.md
+++ b/man/textdebugger.md
@@ -596,7 +596,7 @@ calling nodebug/0 since shutting off debug mode automatically turns off
 trace mode.
 
 In addition, SWI-Prolog supports attaching an arbitrary goal to each
-breakpoint via `set_breakpoint/5`, which yields *Conditional
+breakpoint via `set_breakpoint/6`, which yields *Conditional
 Breakpoints*. A conditional breakpoint is the same as the regular
 breakpoints discussed thus far, except that whenever the breakpoint is
 triggered, the given goal is invoked and trace mode is only turned on
@@ -616,7 +616,8 @@ like this:
 |:
 |: ^Dtrue.
 
-?- set_breakpoint('/...path.../Example.pl', 8, 24, user:should_break, ID).
+?- Path = '/...path.../Example.pl', set_breakpoint(Path, Path, 8, 24, user:should_break, ID).
+Path = '/...path.../Example.pl',
 ID = 1.
 
 ?- debug.

--- a/man/textdebugger.md
+++ b/man/textdebugger.md
@@ -595,6 +595,13 @@ the system in debug mode. All debugging modes can be shut off at once by
 calling nodebug/0 since shutting off debug mode automatically turns off
 trace mode.
 
+In addition, SWI-Prolog supports attaching an arbitrary goal to each
+breakpoint via `set_breakpoint/5`, which yields *Conditional
+Breakpoints*. A conditional breakpoint is the same as the regular
+breakpoints discussed thus far, except that whenever the breakpoint is
+triggered, the given goal is invoked and trace mode is only turned on
+in case it succeeds.
+
 ## Command Line Debugger Summary {#trace-summary}
 
 In summary, there are really two distinct "tracing" features: trace

--- a/man/textdebugger.md
+++ b/man/textdebugger.md
@@ -600,27 +600,17 @@ breakpoint via `set_breakpoint_condition/2`, which yields *Conditional
 Breakpoints*. A conditional breakpoint is the same as the regular
 breakpoints discussed thus far, except that whenever the breakpoint is
 triggered, the given goal is invoked and trace mode is only turned on
-in case it succeeds. It is also possible to specify a condition for a
-breakpoint when creating the breakpoint with `set_breakpoint/6`.
+in case it succeeds.
 
 To enable tracing just when ``noun/2`` is called from ``test_noun2/2``
 with ``rock2`` as the first argument, `set_breakpoint_condition/2` can
 be used like this:
 
 ~~~
-?- [user].
-|:
-|: should_break :-
-|:     prolog_breakpoints:break_context_frame(Frame),
-|:     prolog_frame_attribute(Frame, argument(1), Arg),
-|:     Arg == rock2.
-|:
-|: ^Dtrue.
-
-?- set_breakpoint('/tmp/e.pl', 8, 24, ID).
+?- set_breakpoint('/...path.../Example.pl', 8, 24, ID).
 ID = 1.
 
-?- set_breakpoint_condition(1, user:should_break).
+?- set_breakpoint_condition(1, "X == rock2").
 true.
 
 ?- debug.
@@ -637,25 +627,6 @@ X = rock2.
    Exit: (11) noun(rock2, rock) ? creep
    Exit: (10) test_noun2(rock2, rock) ? creep
 true.
-
-[trace]  ?- notrace.
-true.
-
-[debug]  ?- set_breakpoint_condition(1, true).
-true.
-
-[debug]  ?- test_noun2(X, rock).
-   Call: (11) noun(_23686, rock) ? creep
-   Call: (12) is_a(_23686, rock) ? creep
-   Exit: (12) is_a(rock1, rock) ? creep
-   Exit: (11) noun(rock1, rock) ? creep
-   Exit: (10) test_noun2(rock1, rock) ? creep
-X = rock1 ;
-   Redo: (12) is_a(_23686, rock) ? creep
-   Exit: (12) is_a(rock2, rock) ? creep
-   Exit: (11) noun(rock2, rock) ? creep
-   Exit: (10) test_noun2(rock2, rock) ? creep
-X = rock2.
 
 [trace]  ?-
 ~~~

--- a/src/pl-global.h
+++ b/src/pl-global.h
@@ -322,7 +322,7 @@ struct PL_global_data
     Procedure	print_message2;
     Procedure	foreign_registered2;	/* $foreign_registered/2 */
     Procedure	prolog_trace_interception4;
-    Procedure	prolog_break_hook6;	/* prolog:break_hook/6 */
+    Procedure	prolog_break_hook7;	/* prolog:break_hook/7 */
     Procedure	portray;		/* portray/1 */
     Procedure   dcall1;			/* $call/1 */
     Procedure   call1;			/* call/1 */

--- a/src/pl-vmi.c
+++ b/src/pl-vmi.c
@@ -268,7 +268,7 @@ END_VMH
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 D_BREAK implements break-points in the  code.   A  break-point is set by
-replacing  an  instruction  by  a   D_BREAK  instruction.  The  orininal
+replacing  an  instruction  by  a   D_BREAK  instruction.  The  original
 instruction is saved in a table. replacedBreak() fetches it.
 
 We simply switch to trace-mode, which will   trap the tracer on the next


### PR DESCRIPTION
This PR implements (and documents) a new API for creating *conditional breakpoints*, which are breakpoints that invoke an arbitrary user-provided condition goal to decide whether turn on trace mode.