### PR TITLE
FIXED: eliminated a spurious choice-point in sub_atom/5

### DIFF
--- a/src/pl-prims.c
+++ b/src/pl-prims.c
@@ -4899,8 +4899,10 @@ again:
 		   PL_unify_integer(len,    ls) &&
 		   PL_unify_integer(after,  la-ls-state->n1));
 
-	  state->n1++;
-	  goto next;
+	  if ( ++(state->n1) + ls > la )
+            goto exit_succeed;
+          else
+            goto next;
 	}
       }
       goto exit_fail;


### PR DESCRIPTION
This PR eliminates a spurious choice-point that was left by `sub_atom/5` in mode `(+Atom, -Before, ?Len, -After, +Sub)` upon finding a match at the end of `Atom`. 

The change is an addition of an end-of-input check in the underlying C function sub_text when it succeeds with a matched sub-atom/string.

Before:
```
?- sub_atom('abracadabra', X, 4, Z, 'abra').
X = 0,
Z = 7 ;
X = 7,
Z = 0 ;
false.
```

After:
```
?- sub_atom('abracadabra', X, 4, Z, 'abra').
X = 0,
Z = 7 ;
X = 7,
Z = 0.  % No open choice-point
```

Reported in https://swi-prolog.discourse.group/t/careful-with-sub-atom-5-and-feature-request-last-sub-atom-5/5422

