### PR TITLE
PORT: MSYS2, add $MINGW_PREFIX/bin to dll search path

### DIFF
--- a/boot/build_home.pl
+++ b/boot/build_home.pl
@@ -208,6 +208,15 @@ add_package_path(PkgBinDir) :-
           add_package(Pkg, PkgBinDir)).
 :- endif.
 
+% Add %MINGW_PREFIX%/bin to dll search path under MSYS2
+:- if(current_prolog_flag(windows, true)).
+:- (   getenv('MINGW_PREFIX', Prefix)
+   ->  format(atom(Bin), '~w/bin', [Prefix]),
+       win_add_dll_directory(Bin, _)
+   ;   true
+   ).
+:- endif.
+
 %!  set_version_info
 %
 %   Indicate we are running from the   build directory rather than using


### PR DESCRIPTION
If swipl is invoked from the bash under MSYS2, /mingw64/bin is not on the dll search path, so that the dlls such as zlib1.dll are not found. Here I check if $MINGW_PREFIX is defined, and if it is $MINGW_PREFIX/bin is added to the dll search path.