### PR TITLE
PORT: add_package_path/1 also under Windows

### DIFF
--- a/boot/build_home.pl
+++ b/boot/build_home.pl
@@ -196,10 +196,7 @@ add_package(_Pkg, PkgBinDir) :-
 %   probably cheaper to add it anyway.
 
 add_package_path(PkgBinDir) :-
-    (   current_prolog_flag(windows, true)
-    ->  true
-    ;   assertz(user:file_search_path(foreign, PkgBinDir))
-    ).
+    assertz(user:file_search_path(foreign, PkgBinDir)).
 
 :- if(\+ current_prolog_flag(emscripten, true)).
 % disabled as we do not (yet) have packages and opendir() is broken


### PR DESCRIPTION
This minor change allows for a GNU-style directory structure also under Windows. Mostly needed for the generation of SSL certificates at the end of the normal build process under MSYS2.