### PR TITLE
FIXED: user_or_explicit autoload mode not working

### DIFF
--- a/boot/autoload.pl
+++ b/boot/autoload.pl
@@ -607,11 +607,9 @@ autoload_in(Module, How) :-
 
 autoload_in(true,             _,        _).
 autoload_in(explicit,         explicit, _).
-autoload_in(explicit_or_user, explicit, _).
-autoload_in(user,             explicit, user).
-autoload_in(explicit_or_user, explicit, _).
 autoload_in(user,             _,        user).
-autoload_in(explicit_or_user, general,  user).
+autoload_in(user_or_explicit, explicit, _).
+autoload_in(user_or_explicit, _,        user).
 
 
 %!  do_autoload(+File, :PI, +LoadModule) is det.


### PR DESCRIPTION
Currently setting `autoload` to `user_or_explicit` is actually equivalent to `false`:
```
1 ?- set_prolog_flag(autoload, user_or_explicit).
% Disabled autoloading (loaded 17 files)
true.

2 ?- member(X,[1,2,3]).
Correct to: "lists:member(X,[1,2,3])"? no
ERROR: Unknown procedure: member/2
```
This is because autoload is looking for `explicit_or_user`, instead of `user_or_explicit`.