### PR TITLE
PORT: Suppress uninit warning in msys2

### DIFF
--- a/src/pl-thread.c
+++ b/src/pl-thread.c
@@ -3261,7 +3261,7 @@ PRED_IMPL("sig_pending", 1, sig_pending, META)
   if ( LD->thread.sig_head )
   { struct siglist sl = {0};
     thread_sig *sg;
-    int rc;
+    int rc = FALSE;
 
     sl.list = A1;
 


### PR DESCRIPTION
I think rc can safely be initialized to FALSE