### PR TITLE
Do not check for non-null Sinput

### DIFF
--- a/src/os/pl-os.c
+++ b/src/os/pl-os.c
@@ -2162,7 +2162,9 @@ Sread_terminal(void *handle, char *buf, size_t size)
 
   if ( Soutput )
   { if ( LD->prompt.next &&
+#ifndef __WINDOWS__
 	 Sinput &&
+#endif
 	 false(Sinput, SIO_RAW) &&
 	 true(Sinput, SIO_ISATTY) )
       PL_write_prompt(TRUE);


### PR DESCRIPTION
Suppresses this warning under MinGW/MSYS2:

C:/msys64/home/Matthias/swipl-devel/src/os/pl-os.c: In function 'Sread_terminal':
C:/msys64/home/Matthias/swipl-devel/src/os/pl-os.c:2164:26: warning: the comparison will always evaluate as 'true' for the address of 'S__iob' will never be NULL [-Waddress]
 2164 |   { if ( LD->prompt.next &&
      |                          ^~
In file included from C:/msys64/home/Matthias/swipl-devel/src/pl-builtin.h:67,
                 from C:/msys64/home/Matthias/swipl-devel/src/pl-incl.h:145,
                 from C:/msys64/home/Matthias/swipl-devel/src/os/pl-os.c:67:
C:/msys64/home/Matthias/swipl-devel/src/os/SWI-Stream.h:284:33: note: 'S__iob' declared here
  284 | PL_EXPORT_DATA(IOSTREAM)        S__iob[3];              /* Libs standard streams */
      |                                 ^~~~~~