### PR TITLE
FIXED: Issue#1025: stream encoding wchar_t not returned as stream property

### DIFF
--- a/src/os/pl-file.c
+++ b/src/os/pl-file.c
@@ -3673,7 +3673,7 @@ PL_atom_to_encoding(atom_t a)
 
 atom_t
 PL_encoding_to_atom(IOENC enc)
-{ if ( (int)enc > 0 && (int)enc < ENC_WCHAR )
+{ if ( (int)enc > 0 && (int)enc <= ENC_WCHAR )
     return encoding_names[enc].name;
   return NULL_ATOM;
 }


### PR DESCRIPTION
Fixes #1025 , array bounds check was wrong.

Tested with:
```prolog
?- with_output_to(string(S), stream_property(current_output, encoding(E))).
S = "",
E = wchar_t.
```