### PR TITLE
Avoiding ReferenceError while running WebAssembly version in Nodejs

### DIFF
--- a/src/wasm/prolog.js
+++ b/src/wasm/prolog.js
@@ -1172,23 +1172,25 @@ function release_registered_object(id)
   delete prolog.object[id];
 }
 
+if (typeof window !== 'undefined')
+{
+  window.js_add_script = function(text, opts)
+  { opts = opts||{};
+    let node;
 
-window.js_add_script = function(text, opts)
-{ opts = opts||{};
-  let node;
-
-  if ( opts.id )
-  { if ( (node = document.getElementById(opts.id)) )
-    { node.textContent = text;
+    if ( opts.id )
+    { if ( (node = document.getElementById(opts.id)) )
+      { node.textContent = text;
+      } else
+      { node = document.createElement("script");
+        node.id = opts.id;
+        node.textContent = text;
+        document.body.appendChild(node);
+      }
     } else
     { node = document.createElement("script");
-      node.id = opts.id;
       node.textContent = text;
       document.body.appendChild(node);
     }
-  } else
-  { node = document.createElement("script");
-    node.textContent = text;
-    document.body.appendChild(node);
   }
 }


### PR DESCRIPTION
This PR avoids error when running WebAssembly version in Node as there is no `window` object available.