### PR TITLE
ENHANCED: fallback to the default allocation functions in the GMP hooks

### DIFF
--- a/src/pl-gmp.c
+++ b/src/pl-gmp.c
@@ -92,7 +92,7 @@ mp_alloc(size_t bytes)
 { GET_LD
   mp_mem_header *mem;
 
-  if ( LD->gmp.persistent )
+  if ( LD == NULL || LD->gmp.context == NULL || LD->gmp.persistent )
     return malloc(bytes);
 
   if ( TOO_BIG_GMP(bytes) ||
@@ -126,7 +126,7 @@ mp_realloc(void *ptr, size_t oldsize, size_t newsize)
 { GET_LD
   mp_mem_header *oldmem, *newmem;
 
-  if ( LD->gmp.persistent )
+  if ( LD == NULL || LD->gmp.context == NULL || LD->gmp.persistent )
     return realloc(ptr, newsize);
 
   oldmem = ((mp_mem_header*)ptr)-1;
@@ -163,7 +163,7 @@ mp_free(void *ptr, size_t size)
 { GET_LD
   mp_mem_header *mem;
 
-  if ( LD->gmp.persistent )
+  if ( LD == NULL || LD->gmp.context == NULL || LD->gmp.persistent )
   { free(ptr);
     return;
   }


### PR DESCRIPTION
This PR makes the GMP memory hooks detect that they are invoked out of the context of Prolog and fall back to the default allocation functions.
