### PR TITLE
Registry path now has the missing WOW6432Node

### DIFF
--- a/cmake/Pack.cmake
+++ b/cmake/Pack.cmake
@@ -109,7 +109,7 @@ if(WIN32)
     ")
     set(CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS "
     DeleteRegKey HKLM 'Software\\\\SWI\\\\Prolog'
-    DeleteRegKey HKLM 'Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Uninstall\\\\Swipl'
+    DeleteRegKey HKLM 'Software\\\\WOW6432Node\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Uninstall\\\\Swipl'
     ")
   endif()
 endif()


### PR DESCRIPTION
After testing with daily build (swipl-w64-2022-09-10.exe) Swi-prolog is still in the Add/Remove App list after clicking Remove, so this addition to registry path could  work. I am not testing this commit locally (it is not even possible I think??), I am using the daily builds for testing.