### PR TITLE
ADD: License to CBG Chords example

### DIFF
--- a/src/wasm/cbg.html
+++ b/src/wasm/cbg.html
@@ -6,6 +6,32 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootswatch/4.1.3/sketchy/bootstrap.min.css"/>
 
     <title>CBG Chords</title>
+    <!--
+    BSD 2-Clause License
+
+    Copyright (c) 2022, Paul Brown
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+      list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+    -->
   </head>
   <body>
     <div class="container mt-4">
@@ -85,8 +111,10 @@
         </div>
       </div>
       <hr/>
+
       <footer class="footer mt-5 bt">
-	<a rel="license" href="http://creativecommons.org/licenses/by-nc/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc/4.0/88x31.png" /></a><br /><span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/InteractiveResource" property="dct:title" rel="dct:type">CBG Chords</span> by <span xmlns:cc="http://creativecommons.org/ns#" property="cc:attributionName">Paul Brown</span> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc/4.0/">Creative Commons Attribution-NonCommercial 4.0 International License</a>.<br />Based on a work at: <a xmlns:dct="http://purl.org/dc/terms/" href="https://pbrown.me/cbg.html" rel="dct:source">https://pbrown.me/cbg.html</a>.  See also: <a href="https://pbrown.me/blog/tau_prolog_chords/">blog post</a> with initial announcement and details.
+	<span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/InteractiveResource" property="dct:title" rel="dct:type">CBG Chords</span> by <span xmlns:cc="http://creativecommons.org/ns#" property="cc:attributionName">Paul Brown</span> is licensed under a BSD 2-Clause license, (full text in source).<br />
+  Based on a work at: <a xmlns:dct="http://purl.org/dc/terms/" href="https://pbrown.me/cbg.html" rel="dct:source"> https://pbrown.me/cbg.html </a>.  See also: <a href="https://pbrown.me/blog/tau_prolog_chords/">blog post</a> with initial announcement and details.
       </footer>
     </div>
 

--- a/src/wasm/cbg.html
+++ b/src/wasm/cbg.html
@@ -8,7 +8,7 @@
     <title>CBG Chords</title>
   </head>
   <body>
-    <div class="container">
+    <div class="container mt-4">
       <h1>CBG Chords</h1>
       <p class="lead">
         When it comes to Cigar Box Guitars, there are no rules. So you can tune
@@ -20,13 +20,9 @@
 
       <h3>About</h3>
       <p>
-	This page is a port of a page written by Paul Brown for
-	Tau-Prolog to <a href="https://swi-prolog.discourse.group/t/swi-prolog-in-the-browser-using-wasm/">SWI-Prolog for WASM</a>.  See his
-	<a href="https://pbrown.me/blog/tau_prolog_chords/">blog</a> for an
-	announcement and details.
+	This is a port of an web app initially written for Tau-Prolog to <a href="https://swi-prolog.discourse.group/t/swi-prolog-in-the-browser-using-wasm/">SWI-Prolog for WASM</a>.
       </p>
 
-      <p><small><a href="/4string.html">Looking for the 4-string generator? Click here.</a></small></p>
       <div>
         <hr/>
         <h2 class="text-center">Tuning</h2>
@@ -57,7 +53,7 @@
           <button type="button" id="tuning" class="btn btn-primary">Set Tuning</button>
         </form>
       </div>
-      <div>
+      <div class="mb-3">
         <hr/>
         <h2 class="text-center">Chords</h2>
         <form>
@@ -88,6 +84,10 @@
         <div id="chords">
         </div>
       </div>
+      <hr/>
+      <footer class="footer mt-5 bt">
+	<a rel="license" href="http://creativecommons.org/licenses/by-nc/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc/4.0/88x31.png" /></a><br /><span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/InteractiveResource" property="dct:title" rel="dct:type">CBG Chords</span> by <span xmlns:cc="http://creativecommons.org/ns#" property="cc:attributionName">Paul Brown</span> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc/4.0/">Creative Commons Attribution-NonCommercial 4.0 International License</a>.<br />Based on a work at: <a xmlns:dct="http://purl.org/dc/terms/" href="https://pbrown.me/cbg.html" rel="dct:source">https://pbrown.me/cbg.html</a>.  See also: <a href="https://pbrown.me/blog/tau_prolog_chords/">blog post</a> with initial announcement and details.
+      </footer>
     </div>
 
     <script type="text/prolog" id="code.pl">


### PR DESCRIPTION
I've added in a CC license because this feels a bit like a publication. It's permissive minus commercial (so no-one starts selling it in an app store or something): https://creativecommons.org/licenses/by-nc/4.0/
If that's a problem for SWI, let me know and I'll allow the commercial.

I put the license in the footer, which also contains links so I moved the attribution and the links from the "About" section there too. 

Now it looks like this:
 
![image](https://user-images.githubusercontent.com/10325887/190637190-01876313-f44c-42f3-878c-02e21f39667d.png)
