### PR TITLE
Update GNU Emacs support

### DIFF
--- a/boot/init.pl
+++ b/boot/init.pl
@@ -1061,6 +1061,8 @@ user:file_search_path(swi, Home) :-
     current_prolog_flag(home, Home).
 user:file_search_path(swi, Home) :-
     current_prolog_flag(shared_home, Home).
+user:file_search_path(libswi, Dir) :-
+    current_prolog_flag(libswipl_dir, Dir).
 user:file_search_path(library, app_config(lib)).
 user:file_search_path(library, swi(library)).
 user:file_search_path(library, swi(library/clp)).

--- a/cmake/Params.cmake
+++ b/cmake/Params.cmake
@@ -44,3 +44,5 @@ elseif(APPLE)
 else()
   set(SO_PATH LD_LIBRARY_PATH)
 endif()
+
+set(SO_DIR ${CMAKE_INSTALL_PREFIX}/${LIBSWIPL_DIR})

--- a/man/overview.doc
+++ b/man/overview.doc
@@ -697,22 +697,42 @@ we can start adding new themes.
 
 \index{GNU-Emacs}\index{Emacs}
 
-Unfortunately the default Prolog mode of GNU~Emacs is not very good.
-There are several alternatives though:
+SWI-Prolog provides tight integration with GNU~Emacs through the
+\const{sweep} package.  This package embeds SWI-Prolog as a dynamic
+Emacs module, allowing for Prolog queries to be executed directly from
+Emacs Lisp.  The accompanying Emacs package \const{sweeprolog.el},
+available for installation with the standard Emacs package manager
+\const{package.el}, builds on top of this embedding to provide a fully
+integrated development environment for SWI-Prolog in GNU~Emacs.
+
+GNU~Emacs ships with by default with a Prolog mode called
+\const{prolog.el}.  Compared to \const{sweeprolog.el}, this mode
+suffers from some problems that arise due to the lack of a proper
+Prolog parser.  The original \const{prolog.el} by Masanobu Umeda has
+been included in GNU Emacs since 1989, in 2006 Stefan Monnier added
+explicit support for SWI-Prolog to \const{prolog.el}.  In 2011, most
+of the original implementation has been replaced with a new Prolog
+mode written by initially for the XEmacs port by Stefan Bruda.
+Bruda's mode was adapted to GNU~Emacs by Stefan Monnier, who has been
+maintaining it along with other GNU~Emacs contributor since.  Users of
+this mode may find useful configuration suggestions at
+\url{https://www.metalevel.at/pceprolog/}.
+
+Other Emacs package that can be useful for working with SWI-Prolog are:
 
 \begin{shortlist}
-    \item \url{https://bruda.ca/emacs/prolog_mode_for_emacs}\\
-          Prolog mode for Emacs and XEmacs maintained by Stefan Bruda.
-    \item \url{https://www.metalevel.at/pceprolog/}\\
-          Recommended configuration options for editing Prolog code with Emacs.
     \item \url{https://www.metalevel.at/ediprolog/}\\
           Interact with SWI-Prolog directly in Emacs buffers.
     \item \url{https://www.metalevel.at/etrace/}\\
           Trace Prolog code with Emacs.
     \item \url{https://emacs-lsp.github.io/dap-mode/page/configuration/#swi-prolog}\\
-          Debug Adapter Protocol (DAP) for SWI-Prolog with Emacs using
+          Debug Adapter Protocol (DAP) support for SWI-Prolog in Emacs via
           \exam{dap-mode} and the \const{debug_adapter} pack from
           \url{https://github.com/eshelyaron/debug_adapter}
+    \item \url{https://emacs-lsp.github.io/lsp-mode/page/lsp-prolog/}\\
+          Language Server Protocol (LSP) support for SWI-Prolog in Emacs via
+          \exam{lsp-mode} and the \const{lsp_server} pack from
+          \url{https://github.com/jamesnvc/lsp_server}
 \end{shortlist}
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -567,6 +567,12 @@ if(INSTALL_TESTS)
 install_tests()
 endif()
 
+if(SWIPL_INSTALL_IN_LIB)
+  set(LIBSWIPL_DIR ${CMAKE_INSTALL_PREFIX}/lib)
+else()
+  set(LIBSWIPL_DIR ${SWIPL_INSTALL_ARCH_LIB})
+endif()
+
 # Populate parms.h, making the compilation environment known to Prolog
 include(Params)
 configure_file(parms.h.cmake parms.h)
@@ -595,12 +601,6 @@ configure_package_config_file(
 ################
 # Installation
 ################
-
-if(SWIPL_INSTALL_IN_LIB)
-  set(LIBSWIPL_DIR ${CMAKE_INSTALL_PREFIX}/lib)
-else()
-  set(LIBSWIPL_DIR ${SWIPL_INSTALL_ARCH_LIB})
-endif()
 
 # Make sure tmp directory exists
 #

--- a/src/SWI-Prolog.h
+++ b/src/SWI-Prolog.h
@@ -1345,6 +1345,11 @@ PL_EXPORT(void)		PL_prof_exit(void *node);
 		 *	      DEBUG		*
 		 *******************************/
 
+PL_EXPORT_DATA(int)     plugin_is_GPL_compatible;
+#ifndef EMACS_MODULE_H
+PL_EXPORT(int)          emacs_module_init(void*);
+#endif
+
 PL_EXPORT(int)		PL_prolog_debug(const char *topic);
 PL_EXPORT(int)		PL_prolog_nodebug(const char *topic);
 

--- a/src/os/pl-prologflag.c
+++ b/src/os/pl-prologflag.c
@@ -1469,6 +1469,9 @@ initPrologFlags(void)
 #ifdef PLSHAREDHOME
   setPrologFlag("shared_home", FT_ATOM|FF_READONLY, PLSHAREDHOME);
 #endif
+#ifdef SO_DIR
+  setPrologFlag("libswipl_dir", FT_ATOM|FF_READONLY, SO_DIR);
+#endif
   if ( GD->paths.executable )
     setPrologFlag("executable", FT_ATOM|FF_READONLY, GD->paths.executable);
 #if defined(HAVE_GETPID) || defined(EMULATE_GETPID)

--- a/src/parms.h.cmake
+++ b/src/parms.h.cmake
@@ -9,6 +9,7 @@
 #cmakedefine SO_PATH      "@SO_PATH@"
 #cmakedefine C_LIBDIR     "@SWIPL_RELATIVE_LIBDIR@"
 #cmakedefine C_LIBPLSO    "@C_LIBPLSO@"
+#cmakedefine SO_DIR       "@SO_DIR@"
 #define C_LIBS            ""
 #define C_PLLIB           "-lswipl"
 #define C_LDFLAGS         ""

--- a/src/pl-init.c
+++ b/src/pl-init.c
@@ -433,6 +433,14 @@ on_error_style(const char *s)
 }
 
 
+int plugin_is_GPL_compatible;
+
+int
+emacs_module_init(void*a) {
+  (void)a;
+  return 0;
+}
+
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 When detected to run under a  GNU-Emacs   shell  or using M-x run-prolog
 from GNU-Emacs, don't pretend we  can   manipulate  the TTY settings. On


### PR DESCRIPTION
This PR does the following:
1. Add a new Prolog flag `libswipl_dir` which holds the absolute path of the directory in which `libswipl` will be installed according to the effective `cmake` flags.
2. Update the manual section about GNU Emacs interfaces.
3. Make it possible to load `libswipl` itself as a dynamic Emacs module that does nothing except for making its other symbols visible to other dynamic Emacs modules.

Note: I accidentally pushed these changes to the `master` branch directly (my apologies), so I reverted them to allow for a proper review. This PR simply reverts that revert.