### PR TITLE
PORT: suppress uninit warnings in Rtools42/gcc10.3

### DIFF
--- a/src/pl-arith.c
+++ b/src/pl-arith.c
@@ -2234,7 +2234,9 @@ get_int_exponent(Number n, unsigned long *expp)
   exp = (long)i;
 #if SIZEOF_LONG < 8
   if ( (int64_t)exp != i )
+  { *expp = (unsigned long)0 ; // suppress an uninitialized warning in ar_pow
     return int_too_big();
+  }
 #endif
 
   if ( exp >= 0 )
@@ -2242,7 +2244,9 @@ get_int_exponent(Number n, unsigned long *expp)
   else if ( -exp != exp )
     *expp = (unsigned long)-exp;
   else
-   return int_too_big();
+  { *expp = (unsigned long)0 ; // suppress an uninitialized warning in ar_pow
+    return int_too_big();
+  }
 
   return TRUE;
 }


### PR DESCRIPTION
C:/Users/matth/swipl-devel/src/pl-arith.c: In function 'ar_pow':
C:/Users/matth/swipl-devel/src/pl-arith.c:2388:10: warning: 'exp' may be used uninitialized in this function [-Wmaybe-uninitialized]
 2388 |     if ( mul64(op1_bits, exp, &r_bits) )
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
