### PR TITLE
Rational arithmetic version of `rationalize/1` arithmetic function

### DIFF
--- a/src/libbf/bf_gmp.h
+++ b/src/libbf/bf_gmp.h
@@ -388,23 +388,39 @@ mpz_mul_2exp(mpz_t r, const mpz_t n1, mp_bitcnt_t n2)
 }
 
 static inline void
-mpz_addmul_ui(mpz_t r, const mpz_t n1, unsigned long n2)
-{ mpz_t add;
+mpz_addmul(mpz_t r, const mpz_t n1, const mpz_t n2)
+{ mpz_t tmp; mpz_init_set(tmp,r);
+  mpz_t acc; mpz_init(acc);
+  
+  bf_mul(acc, n1, n2, BF_PREC_INF, BF_RNDN);
+  bf_add(r, tmp, acc, BF_PREC_INF, BF_RNDN);
 
-  mpz_init(add);
-  bf_mul_ui(add, n1, n2, BF_PREC_INF, BF_RNDN);
-  bf_add(r, n1, add, BF_PREC_INF, BF_RNDN);
-  mpz_clear(add);
+  mpz_clear(tmp);
+  mpz_clear(acc);
+}
+
+static inline void
+mpz_addmul_ui(mpz_t r, const mpz_t n1, unsigned long n2)
+{ mpz_t tmp; mpz_init_set(tmp,r);
+  mpz_t acc; mpz_init(acc);
+  
+  bf_mul_ui(acc, n1, n2, BF_PREC_INF, BF_RNDN);
+  bf_add(r, tmp, acc, BF_PREC_INF, BF_RNDN);
+
+  mpz_clear(tmp);
+  mpz_clear(acc);
 }
 
 static inline void
 mpz_submul_ui(mpz_t r, const mpz_t n1, unsigned long n2)
-{ mpz_t sub;
+{ mpz_t tmp; mpz_init_set(tmp,r);
+  mpz_t acc; mpz_init(acc);
+  
+  bf_mul_ui(acc, n1, n2, BF_PREC_INF, BF_RNDN);
+  bf_sub(r, tmp, acc, BF_PREC_INF, BF_RNDN);
 
-  mpz_init(sub);
-  bf_mul_ui(sub, n1, n2, BF_PREC_INF, BF_RNDN);
-  bf_sub(r, n1, sub, BF_PREC_INF, BF_RNDN);
-  mpz_clear(sub);
+  mpz_clear(tmp);
+  mpz_clear(acc);
 }
 
 static inline void
@@ -694,6 +710,26 @@ mpq_cnumref(const mpq_t q)
 static inline const MP_INT*
 mpq_cdenref(const mpq_t q)
 { return &q[1];
+}
+
+static inline void
+mpq_get_num(mpz_t n, const mpq_t r)
+{ bf_set(n, &r[0]);
+}
+
+static inline void
+mpq_get_den(mpz_t d, const mpq_t r)
+{ bf_set(d, &r[1]);
+}
+
+static inline void
+mpq_set_num(mpq_t r, const mpz_t n)
+{ bf_set(&r[0], n);
+}
+
+static inline void
+mpq_set_den(mpq_t r, const mpz_t d)
+{ bf_set(&r[1], d);
 }
 
 static inline int

--- a/src/pl-gmp.c
+++ b/src/pl-gmp.c
@@ -1884,12 +1884,15 @@ mpq_set_double(mpq_t r, double f)	/* float -> nice rational */
   mpz_t d; mpz_init(d);
   mpz_t u; mpz_init(u);
   
+  fpattern fp = { .d = f};  // required due to C compiler optimization "bug"
+  fpattern rp;  
   for(;;)
   { mpz_fdiv_qr(d,u,v,w);
     mpz_addmul(p,d,m);
     mpz_addmul(q,d,n);
-    if ((mpz_fdiv(p,q) == f) || (mpz_sgn(u) == 0)) {  // terminating conditions
-      mpq_set_num(r,p); mpq_set_den(r,q);             // final answer, p & q are co-prime
+    rp.d = mpz_fdiv(p,q);
+    if ((rp.i == fp.i) || (mpz_sgn(u) == 0)) {  // terminating conditions
+      mpq_set_num(r,p); mpq_set_den(r,q);       // final answer, p & q are co-prime
       break;
     } else {
       mpz_set(v,w);  mpz_set(w,u);        


### PR DESCRIPTION
IMO the current test and doc for `rational` &and `rationalize` are deficient in that they depend on a mathematically incorrect interpretation of `=:=`. Hopefully it's just my problem or that someone else can make sense of it.