### PR TITLE
cmake: Fix C99 compatibility issues in GCC built-in detection

### DIFF
--- a/cmake/GCCBuiltins.cmake
+++ b/cmake/GCCBuiltins.cmake
@@ -22,7 +22,7 @@ check_c_source_compiles(
     "volatile int i=0; int main() { return 0; }"
     HAVE_VOLATILE)
 check_c_source_compiles(
-    "static inline foo() { return 0; } int main() { return foo(); }"
+    "static inline int foo() { return 0; } int main() { return foo(); }"
     HAVE_INLINE)
 check_c_source_compiles(
     "int main() { void *p = &&lbl; goto *p; lbl: return 0; }"
@@ -45,7 +45,7 @@ check_visibility()
 # Builtin functions that lead to conflicts
 
 check_c_source_compiles(
-    "int main() { char *s = alloca(10); return s!=0; }"
+    "#include <alloca.h>\nint main() { char *s = alloca(10); return s!=0; }"
     HAVE_ALLOCA)
 check_c_source_compiles(
     "#include <math.h>\nint main() { double x; return signbit(x); }"


### PR DESCRIPTION
Future compilers may not support implicit ints or implicit function declarations, so avoid them, by using an explicit int type and including <alloca.h> for the alloca function.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
