### PR TITLE
Fix some print formats

### DIFF
--- a/man/streams.doc
+++ b/man/streams.doc
@@ -550,6 +550,11 @@ Emit a 0-terminated string.
 This function returns the number of characters written. Note that due to
 multibyte encodings the number of bytes written can be more.
 
+    \cfunction{int}{SfprintfX}{IOSTREAM *s, const char *fm, ...}
+Same as Sfprintf() but doesn't have the format-checking attribute.
+This is intended for formats that include extended format specifiers
+such as \exam{"%Ws"}.
+
     \cfunction{int}{Sprintf}{const char *fm, ...}
 Similar to Sfprintf(), printing to \arg{Soutput}
 
@@ -565,6 +570,11 @@ number of bytes written. Currently \arg{buf} uses
 \const{ENC_ISO_LATIN_1} encoding. Future versions will probably change
 to \const{ENC_UTF8}.
 
+    \cfunction{int}{SsnprintfX}{char *buf, size_t size, const char *fm, ...}
+Same as Ssnprintf() but doesn't have the format-checking attribute.
+This is intended for formats that include extended format specifiers
+such as \exam{"%Ws"}.
+
     \cfunction{int}{Svsprintf}{char *buf, const char *fm, va_list args}
 Variadic argument list version of Ssprintf(). Deprecated. Use
 Svsnprintf() instead.
@@ -575,6 +585,11 @@ Variadic argument list version of Ssnprintf().
     \cfunction{int}{Sdprintf}{const char *fm, ...}
 Print to \arg{Serror}.  This function should be used for printing debug
 output from foreign code.
+
+    \cfunction{int}{SdprintfX}{const char *fm, ...}
+Same as Sdprintf() but doesn't have the format-checking attribute.
+This is intended for formats that include extended format specifiers
+such as \exam{"%Ws"}.
 
     \cfunction{int}{Svdprintf}{const char *fm, va_list args}
 Variadic argument list version of Sdprintf().

--- a/src/os/SWI-Stream.h
+++ b/src/os/SWI-Stream.h
@@ -387,6 +387,7 @@ PL_EXPORT_DATA(IOSTREAM)	S__iob[3];		/* Libs standard streams */
   _Pragma ("GCC diagnostic push") \
   _Pragma ("GCC diagnostic ignored \"-Wformat\"") \
   _Pragma ("GCC diagnostic ignored \"-Wformat-extra-args\"")
+#define WPRINT_POP _Pragma ("GCC diagnostic pop")
 #else
 #define WPRINTF12
 #define WPRINTF23
@@ -442,15 +443,18 @@ PL_EXPORT(size_t)	Spending(IOSTREAM *s);
 PL_EXPORT(int)		Sfputs(const char *q, IOSTREAM *s);
 PL_EXPORT(int)		Sputs(const char *q);
 PL_EXPORT(int)		Sfprintf(IOSTREAM *s, const char *fm, ...) WPRINTF23;
+PL_EXPORT(int)		SfprintfX(IOSTREAM *s, const char *fm, ...);
 PL_EXPORT(int)		Sprintf(const char *fm, ...) WPRINTF12;
 PL_EXPORT(int)		Svprintf(const char *fm, va_list args);
 PL_EXPORT(int)		Svfprintf(IOSTREAM *s, const char *fm, va_list args);
 PL_EXPORT(int)		Ssprintf(char *buf, const char *fm, ...) WPRINTF23;
 PL_EXPORT(int)		Ssnprintf(char *buf, size_t size, const char *fm, ...) WPRINTF34;
+PL_EXPORT(int)		SsnprintfX(char *buf, size_t size, const char *fm, ...);
 PL_EXPORT(int)		Svsprintf(char *buf, const char *fm, va_list args);
 PL_EXPORT(int)		Svsnprintf(char *buf, size_t size, const char *fm, va_list args);
 PL_EXPORT(int)		Svdprintf(const char *fm, va_list args);
 PL_EXPORT(int)		Sdprintf(const char *fm, ...) WPRINTF12;
+PL_EXPORT(int)		SdprintfX(const char *fm, ...);
 PL_EXPORT(int)		Slock(IOSTREAM *s);
 PL_EXPORT(int)		StryLock(IOSTREAM *s);
 PL_EXPORT(int)		Sunlock(IOSTREAM *s);

--- a/src/os/SWI-Stream.h
+++ b/src/os/SWI-Stream.h
@@ -379,14 +379,21 @@ PL_EXPORT_DATA(IOSTREAM)	S__iob[3];		/* Libs standard streams */
 		 *******************************/
 
 #if defined(CHECK_FORMAT)
-/* Note that SWI-Prolog's "%Ws" etc confuses the compiler's format checker */
 #define WPRINTF12  __attribute__ ((format (printf, 1, 2)))
 #define WPRINTF23  __attribute__ ((format (printf, 2, 3)))
 #define WPRINTF34  __attribute__ ((format (printf, 3, 4)))
+/* SWI-Prolog's "%Ws" etc confuses the compiler's format checker */
+#define WPRINT_PUSH \
+  _Pragma ("GCC diagnostic push") \
+  _Pragma ("GCC diagnostic ignored \"-Wformat\"") \
+  _Pragma ("GCC diagnostic ignored \"-Wformat-extra-args\"")
+#define WPRINT_POP _Pragma ("GCC diagnostic pop")
 #else
 #define WPRINTF12
 #define WPRINTF23
 #define WPRINTF34
+#define WPRINT_PUSH
+#define WPRINT_POP
 #endif
 
 PL_EXPORT(void)		SinitStreams(void);

--- a/src/os/SWI-Stream.h
+++ b/src/os/SWI-Stream.h
@@ -378,6 +378,17 @@ PL_EXPORT_DATA(IOSTREAM)	S__iob[3];		/* Libs standard streams */
 		 *	    PROTOTYPES		*
 		 *******************************/
 
+#if defined(CHECK_FORMAT)
+/* Note that SWI-Prolog's "%Ws" etc confuses the compiler's format checker */
+#define WPRINTF12  __attribute__ ((format (printf, 1, 2)))
+#define WPRINTF23  __attribute__ ((format (printf, 2, 3)))
+#define WPRINTF34  __attribute__ ((format (printf, 3, 4)))
+#else
+#define WPRINTF12
+#define WPRINTF23
+#define WPRINTF34
+#endif
+
 PL_EXPORT(void)		SinitStreams(void);
 PL_EXPORT(void)		Scleanup(void);
 PL_EXPORT(void)		Sreset(void);
@@ -424,16 +435,16 @@ PL_EXPORT(ssize_t)	Sread_pending(IOSTREAM *s,
 PL_EXPORT(size_t)	Spending(IOSTREAM *s);
 PL_EXPORT(int)		Sfputs(const char *q, IOSTREAM *s);
 PL_EXPORT(int)		Sputs(const char *q);
-PL_EXPORT(int)		Sfprintf(IOSTREAM *s, const char *fm, ...);
-PL_EXPORT(int)		Sprintf(const char *fm, ...);
+PL_EXPORT(int)		Sfprintf(IOSTREAM *s, const char *fm, ...) WPRINTF23;
+PL_EXPORT(int)		Sprintf(const char *fm, ...) WPRINTF12;
 PL_EXPORT(int)		Svprintf(const char *fm, va_list args);
 PL_EXPORT(int)		Svfprintf(IOSTREAM *s, const char *fm, va_list args);
-PL_EXPORT(int)		Ssprintf(char *buf, const char *fm, ...);
-PL_EXPORT(int)		Ssnprintf(char *buf, size_t size, const char *fm, ...);
+PL_EXPORT(int)		Ssprintf(char *buf, const char *fm, ...) WPRINTF23;
+PL_EXPORT(int)		Ssnprintf(char *buf, size_t size, const char *fm, ...) WPRINTF34;
 PL_EXPORT(int)		Svsprintf(char *buf, const char *fm, va_list args);
 PL_EXPORT(int)		Svsnprintf(char *buf, size_t size, const char *fm, va_list args);
 PL_EXPORT(int)		Svdprintf(const char *fm, va_list args);
-PL_EXPORT(int)		Sdprintf(const char *fm, ...);
+PL_EXPORT(int)		Sdprintf(const char *fm, ...) WPRINTF12;
 PL_EXPORT(int)		Slock(IOSTREAM *s);
 PL_EXPORT(int)		StryLock(IOSTREAM *s);
 PL_EXPORT(int)		Sunlock(IOSTREAM *s);

--- a/src/os/pl-cstack.c
+++ b/src/os/pl-cstack.c
@@ -437,17 +437,17 @@ print_trace(btrace *bt, int me)
 #endif
 	       ) &&
 	       addr2line(info.dli_fname, offset, buf, sizeof(buf)) )
-	    Sdprintf("  [%d] %s [%p]\n", i, buf, addr);
+	    Sdprintf("  [%zd] %s [%p]\n", i, buf, addr);
 	  else if ( info.dli_sname )
-	    Sdprintf("  [%d] %s(%s+%p) [%p]\n",
+	    Sdprintf("  [%zd] %s(%s+%lu) [%p]\n",
 		     i, info.dli_fname, info.dli_sname,
 		     (uintptr_t)addr-(uintptr_t)info.dli_saddr,
 		     addr);
 	  else
-	    Sdprintf("  [%d] %s(+%p) [%p]\n",
+	    Sdprintf("  [%zd] %s(+%p) [%p]\n",
 		     i, info.dli_fname, (void*)offset, addr);
 	} else
-	{ Sdprintf("  [%d] ??? [%p]\n", i, addr);
+	{ Sdprintf("  [%zd] ??? [%p]\n", i, addr);
 	}
       }
     }

--- a/src/os/pl-cstack.c
+++ b/src/os/pl-cstack.c
@@ -439,7 +439,7 @@ print_trace(btrace *bt, int me)
 	       addr2line(info.dli_fname, offset, buf, sizeof(buf)) )
 	    Sdprintf("  [%zd] %s [%p]\n", i, buf, addr);
 	  else if ( info.dli_sname )
-	    Sdprintf("  [%zd] %s(%s+%lu) [%p]\n",
+	    Sdprintf("  [%zd] %s(%s+0x%tx) [%p]\n",
 		     i, info.dli_fname, info.dli_sname,
 		     (uintptr_t)addr-(uintptr_t)info.dli_saddr,
 		     addr);
@@ -940,9 +940,11 @@ sigCrashHandler(int sig)
   if ( PL_get_thread_alias(tid, &alias) )
     name = PL_atom_wchars(alias, NULL);
 
+  WPRINT_PUSH
   Sdprintf("\nSWI-Prolog [thread %d (%Ws) at %s]: "
 	   "received fatal signal %d (%s)\n",
 	   PL_thread_self(), name, tbuf, sig, signal_name(sig));
+  WPRINT_POP
   print_c_backtrace("crash");
   Sdprintf("Prolog stack:\n");
   PL_backtrace(25, PL_BT_SAFE);

--- a/src/os/pl-cstack.c
+++ b/src/os/pl-cstack.c
@@ -441,7 +441,7 @@ print_trace(btrace *bt, int me)
 	  else if ( info.dli_sname )
 	    Sdprintf("  [%zd] %s(%s+0x%tx) [%p]\n",
 		     i, info.dli_fname, info.dli_sname,
-		     (uintptr_t)addr-(uintptr_t)info.dli_saddr,
+		     (char*)addr-(char*)info.dli_saddr,
 		     addr);
 	  else
 	    Sdprintf("  [%zd] %s(+%p) [%p]\n",
@@ -940,11 +940,9 @@ sigCrashHandler(int sig)
   if ( PL_get_thread_alias(tid, &alias) )
     name = PL_atom_wchars(alias, NULL);
 
-  WPRINT_PUSH
-  Sdprintf("\nSWI-Prolog [thread %d (%Ws) at %s]: "
-	   "received fatal signal %d (%s)\n",
-	   PL_thread_self(), name, tbuf, sig, signal_name(sig));
-  WPRINT_POP
+  SdprintfX("\nSWI-Prolog [thread %d (%Ws) at %s]: "
+	    "received fatal signal %d (%s)\n",
+	    PL_thread_self(), name, tbuf, sig, signal_name(sig));
   print_c_backtrace("crash");
   Sdprintf("Prolog stack:\n");
   PL_backtrace(25, PL_BT_SAFE);

--- a/src/os/pl-stream.c
+++ b/src/os/pl-stream.c
@@ -2172,6 +2172,21 @@ Sfprintf(IOSTREAM *s, const char *fm, ...)
   return rval;
 }
 
+/* SfprintfX() is identical to Sfprintf() but its definition in
+   SWI-Stream.h doesn't have the "check format" attribute. */
+
+int
+SfprintfX(IOSTREAM *s, const char *fm, ...)
+{ va_list args;
+  int rval;
+
+  va_start(args, fm);
+  rval = Svfprintf(s, fm, args);
+  va_end(args);
+
+  return rval;
+}
+
 
 int
 Sprintf(const char *fm, ...)
@@ -2594,6 +2609,22 @@ Ssnprintf(char *buf, size_t size, const char *fm, ...)
 }
 
 
+/* SsnprintfX() is identical to Ssnprintf() but its definition in
+   SWI-Stream.h doesn't have the "check format" attribute. */
+
+int
+SsnprintfX(char *buf, size_t size, const char *fm, ...)
+{ va_list args;
+  int rval;
+
+  va_start(args, fm);
+  rval = Svsnprintf(buf, size, fm, args);
+  va_end(args);
+
+  return rval;
+}
+
+
 int
 Svsprintf(char *buf, const char *fm, va_list args)
 { IOSTREAM s;
@@ -2656,6 +2687,21 @@ Svdprintf(const char *fm, va_list args)
 
 int
 Sdprintf(const char *fm, ...)
+{ va_list args;
+  int rval;
+
+  va_start(args, fm);
+  rval = Svdprintf(fm, args);
+  va_end(args);
+
+  return rval;
+}
+
+/* SdprintfX() is identical to Sdprintf() but its definition in
+   SWI-Stream.h doesn't have the "check format" attribute. */
+
+int
+SdprintfX(const char *fm, ...)
 { va_list args;
   int rval;
 

--- a/src/pl-assert.c
+++ b/src/pl-assert.c
@@ -92,9 +92,11 @@ __assert_fail(const char *assertion,
     if ( PL_get_thread_alias(tid, &alias) )
       name = PL_atom_wchars(alias, NULL);
 
+    WPRINT_PUSH
     Sdprintf("[Thread %d (%Ws) at %s] %s:%d: %s: Assertion failed: %s\n",
 	     PL_thread_self(), name, tbuf,
 	     file, line, function, assertion);
+    WPRINT_POP
   }
 #else
   Sdprintf("[At %s] %s:%d: %s: Assertion failed: %s\n",

--- a/src/pl-assert.c
+++ b/src/pl-assert.c
@@ -92,11 +92,9 @@ __assert_fail(const char *assertion,
     if ( PL_get_thread_alias(tid, &alias) )
       name = PL_atom_wchars(alias, NULL);
 
-    WPRINT_PUSH
-    Sdprintf("[Thread %d (%Ws) at %s] %s:%d: %s: Assertion failed: %s\n",
-	     PL_thread_self(), name, tbuf,
-	     file, line, function, assertion);
-    WPRINT_POP
+    SdprintfX("[Thread %d (%Ws) at %s] %s:%d: %s: Assertion failed: %s\n",
+	      PL_thread_self(), name, tbuf,
+	      file, line, function, assertion);
   }
 #else
   Sdprintf("[At %s] %s:%d: %s: Assertion failed: %s\n",

--- a/src/pl-atom.c
+++ b/src/pl-atom.c
@@ -1247,7 +1247,9 @@ unregister_atom(volatile Atom p)
     char *enc;
     char *buf = NULL;
 
+    WPRINT_PUSH
     strcpy(fmt, "OOPS: PL_unregister_atom('%Ls'): -1 references\n");
+    WPRINT_POP
     enc = strchr(fmt, '%')+1;
 
     Sdprintf(fmt, dbgAtomName(p, enc, &buf));

--- a/src/pl-atom.c
+++ b/src/pl-atom.c
@@ -1247,9 +1247,7 @@ unregister_atom(volatile Atom p)
     char *enc;
     char *buf = NULL;
 
-    WPRINT_PUSH
     strcpy(fmt, "OOPS: PL_unregister_atom('%Ls'): -1 references\n");
-    WPRINT_POP
     enc = strchr(fmt, '%')+1;
 
     Sdprintf(fmt, dbgAtomName(p, enc, &buf));

--- a/src/pl-comp.c
+++ b/src/pl-comp.c
@@ -4786,7 +4786,7 @@ argKey(Code PC, int skip, word *key)
 	goto again;
 #endif
       default:
-	Sdprintf("Unexpected VM code %ld at %p\n", c, PC);
+	Sdprintf("Unexpected VM code %" PRIuPTR " at %p\n", c, PC);
 	Sdprintf("\topcode=%s\n", codeTable[c].name);
 	assert(0);
 	fail;
@@ -7081,7 +7081,7 @@ vm_list(Code start, Code end)
   { code op = fetchop(PC);
     const code_info *ci = &codeTable[op];
 
-    Sdprintf("%-3ld %s\n", PC-start, ci->name);
+    Sdprintf("%-3zd %s\n", (size_t)(PC-start), ci->name);
     if ( !end )
     { switch(op)
       { case I_EXIT:

--- a/src/pl-comp.c
+++ b/src/pl-comp.c
@@ -4786,7 +4786,7 @@ argKey(Code PC, int skip, word *key)
 	goto again;
 #endif
       default:
-	Sdprintf("Unexpected VM code %d at %p\n", c, PC);
+	Sdprintf("Unexpected VM code %ld at %p\n", c, PC);
 	Sdprintf("\topcode=%s\n", codeTable[c].name);
 	assert(0);
 	fail;
@@ -7081,7 +7081,7 @@ vm_list(Code start, Code end)
   { code op = fetchop(PC);
     const code_info *ci = &codeTable[op];
 
-    Sdprintf("%-3d %s\n", PC-start, ci->name);
+    Sdprintf("%-3ld %s\n", PC-start, ci->name);
     if ( !end )
     { switch(op)
       { case I_EXIT:

--- a/src/pl-dde.c
+++ b/src/pl-dde.c
@@ -179,9 +179,7 @@ get_hsz(DWORD ddeInst, term_t data, HSZ *rval)
 
     assert(s[len] == 0);			/* Must be 0-terminated */
 
-    WPRINT_PUSH
-    DEBUG(2, Sdprintf("Get HSZ for %Ws ...\n", s));
-    WPRINT_POP
+    DEBUG(2, SdprintfX("Get HSZ for %Ws ...\n", s));
     if ( (h=DdeCreateStringHandleW(ddeInst, s, CP_WINUNICODE)) )
     { DEBUG(2, Sdprintf("\tHSZ = %p\n", h));
       *rval = h;

--- a/src/pl-dde.c
+++ b/src/pl-dde.c
@@ -179,7 +179,9 @@ get_hsz(DWORD ddeInst, term_t data, HSZ *rval)
 
     assert(s[len] == 0);			/* Must be 0-terminated */
 
+    WPRINT_PUSH
     DEBUG(2, Sdprintf("Get HSZ for %Ws ...\n", s));
+    WPRINT_POP
     if ( (h=DdeCreateStringHandleW(ddeInst, s, CP_WINUNICODE)) )
     { DEBUG(2, Sdprintf("\tHSZ = %p\n", h));
       *rval = h;

--- a/src/pl-ext.c
+++ b/src/pl-ext.c
@@ -222,7 +222,7 @@ static unsigned int
 predicate_signature(const Definition def)
 { char str[256];
 
-  Ssprintf(str, "%s/%d/%d",
+  Ssprintf(str, "%s/%d/0x%" PRIx64,
 	   stringAtom(def->functor->name),
 	   (int)def->functor->arity,
 	   def->flags);

--- a/src/pl-fli.c
+++ b/src/pl-fli.c
@@ -4455,10 +4455,8 @@ PL_clear_foreign_exception(LocalFrame fr)
   if ( PL_get_thread_alias(tid, &alias) )
     name = PL_atom_wchars(alias, NULL);
 
-  WPRINT_PUSH
-  Sdprintf("Thread %d (%Ws): foreign predicate %s did not clear exception:\n\t",
-	   tid, name, predicateName(fr->predicate));
-  WPRINT_POP
+  SdprintfX("Thread %d (%Ws): foreign predicate %s did not clear exception:\n\t",
+	    tid, name, predicateName(fr->predicate));
 #if O_DEBUG
   print_backtrace_named("exception");
 #endif

--- a/src/pl-fli.c
+++ b/src/pl-fli.c
@@ -4455,8 +4455,10 @@ PL_clear_foreign_exception(LocalFrame fr)
   if ( PL_get_thread_alias(tid, &alias) )
     name = PL_atom_wchars(alias, NULL);
 
-  Sdprintf("Thread %d (%Ws): foreign predicate %s did not clear exception: \n\t",
+  WPRINT_PUSH
+  Sdprintf("Thread %d (%Ws): foreign predicate %s did not clear exception:\n\t",
 	   tid, name, predicateName(fr->predicate));
+  WPRINT_POP
 #if O_DEBUG
   print_backtrace_named("exception");
 #endif

--- a/src/pl-init.c
+++ b/src/pl-init.c
@@ -1714,10 +1714,8 @@ vsysError(const char *fm, va_list args)
   if ( PL_get_thread_alias(tid, &alias) )
     name = PL_atom_wchars(alias, NULL);
 
-  WPRINT_PUSH
-  Sfprintf(Serror, "[PROLOG SYSTEM ERROR:  Thread %d (%Ws) at %s\n\t",
-	   tid, name, tbuf);
-  WPRINT_POP
+  SfprintfX(Serror, "[PROLOG SYSTEM ERROR:  Thread %d (%Ws) at %s\n\t",
+	    tid, name, tbuf);
 }
 #else
   Sfprintf(Serror, "[PROLOG SYSTEM ERROR: at %s\n\t", tbuf);

--- a/src/pl-init.c
+++ b/src/pl-init.c
@@ -1714,8 +1714,10 @@ vsysError(const char *fm, va_list args)
   if ( PL_get_thread_alias(tid, &alias) )
     name = PL_atom_wchars(alias, NULL);
 
+  WPRINT_PUSH
   Sfprintf(Serror, "[PROLOG SYSTEM ERROR:  Thread %d (%Ws) at %s\n\t",
 	   tid, name, tbuf);
+  WPRINT_POP
 }
 #else
   Sfprintf(Serror, "[PROLOG SYSTEM ERROR: at %s\n\t", tbuf);

--- a/src/pl-nt.c
+++ b/src/pl-nt.c
@@ -735,11 +735,8 @@ PRED_IMPL("win_add_dll_directory", 2, win_add_dll_directory, 0)
 
       /* AddDllDirectoryW() cannot handle "\\?\" */
       if ( (cookie = (*f_AddDllDirectoryW)(dirw + _xos_win_prefix_length(dirw))) )
-      {
-        WPRINT_PUSH
-        DEBUG(MSG_WIN_API,
-	      Sdprintf("AddDllDirectory(%Ws) ok\n", dirw));
-        WPRINT_POP
+      { DEBUG(MSG_WIN_API,
+	      SdprintfX("AddDllDirectory(%Ws) ok\n", dirw));
 
 	return PL_unify_int64(A2, (int64_t)(uintptr_t)cookie);
       }
@@ -813,9 +810,7 @@ PL_dlopen(const char *file, int flags)	/* file is in UTF-8, POSIX path */
     *w = 0;
   }
 
-  WPRINT_PUSH
-  DEBUG(MSG_WIN_API, Sdprintf("dlopen(%Ws)\n", wfile));
-  WPRINT_POP
+  DEBUG(MSG_WIN_API, SdprintfX("dlopen(%Ws)\n", wfile));
 
   if ( is_windows_abs_path(wfile) )
     llflags |= load_library_search_flags();

--- a/src/pl-nt.c
+++ b/src/pl-nt.c
@@ -735,8 +735,11 @@ PRED_IMPL("win_add_dll_directory", 2, win_add_dll_directory, 0)
 
       /* AddDllDirectoryW() cannot handle "\\?\" */
       if ( (cookie = (*f_AddDllDirectoryW)(dirw + _xos_win_prefix_length(dirw))) )
-      { DEBUG(MSG_WIN_API,
+      {
+        WPRINT_PUSH
+        DEBUG(MSG_WIN_API,
 	      Sdprintf("AddDllDirectory(%Ws) ok\n", dirw));
+        WPRINT_POP
 
 	return PL_unify_int64(A2, (int64_t)(uintptr_t)cookie);
       }
@@ -810,7 +813,9 @@ PL_dlopen(const char *file, int flags)	/* file is in UTF-8, POSIX path */
     *w = 0;
   }
 
+  WPRINT_PUSH
   DEBUG(MSG_WIN_API, Sdprintf("dlopen(%Ws)\n", wfile));
+  WPRINT_POP
 
   if ( is_windows_abs_path(wfile) )
     llflags |= load_library_search_flags();

--- a/src/pl-proc.c
+++ b/src/pl-proc.c
@@ -672,7 +672,7 @@ get_head_functor(DECL_LD term_t head, functor_t *fdef, int how)
     } else
     { char buf[100];
 
-      Ssprintf(buf, "limit is %d, request = %d", MAXARITY, fd->arity);
+      Ssprintf(buf, "limit is %d, request = %zd", MAXARITY, fd->arity);
 
       return PL_error(NULL, 0, buf,
 		      ERR_REPRESENTATION, ATOM_max_procedure_arity);

--- a/src/pl-setup.c
+++ b/src/pl-setup.c
@@ -487,9 +487,11 @@ dispatch_signal(int sig, int sync)
 
 	  if ( PL_get_thread_alias(tid, &alias) )
 	    name = PL_atom_wchars(alias, NULL);
+          WPRINT_PUSH
 	  Sdprintf("Got signal %d in thread %d (%Ws) %s\n",
 		   sig, tid, name,
 		   sync ? " (sync)" : " (async)");
+          WPRINT_POP
 	});
 #else
   DEBUG(MSG_SIGNAL,

--- a/src/pl-setup.c
+++ b/src/pl-setup.c
@@ -487,11 +487,9 @@ dispatch_signal(int sig, int sync)
 
 	  if ( PL_get_thread_alias(tid, &alias) )
 	    name = PL_atom_wchars(alias, NULL);
-          WPRINT_PUSH
-	  Sdprintf("Got signal %d in thread %d (%Ws) %s\n",
-		   sig, tid, name,
-		   sync ? " (sync)" : " (async)");
-          WPRINT_POP
+	  SdprintfX("Got signal %d in thread %d (%Ws) %s\n",
+		    sig, tid, name,
+		    sync ? " (sync)" : " (async)");
 	});
 #else
   DEBUG(MSG_SIGNAL,

--- a/src/pl-srcfile.c
+++ b/src/pl-srcfile.c
@@ -369,7 +369,7 @@ releaseSourceFile(SourceFile sf)
 		 sf->references-1));
 
   if ( sf->references <= 0 )
-  { Sdprintf("Oops: %d references for sourc file %s\n", PL_atom_chars(sf->name));
+  { Sdprintf("Oops: %d references for source file %s\n", sf->references, PL_atom_chars(sf->name));
     sf->references = 0x4000000;
   }
   if ( ATOMIC_DEC(&sf->references) == 0 )

--- a/src/pl-thread.c
+++ b/src/pl-thread.c
@@ -432,9 +432,7 @@ PRED_IMPL("mutex_statistics", 0, mutex_statistics, 0)
     if ( cm->count == 0 )
       continue;
 
-    WPRINT_PUSH
-    Sfprintf(s, "%-56Us %8ld", cm->name, cm->count); /* %Us: UTF-8 string */
-    WPRINT_POP
+    SfprintfX(s, "%-56Us %8ld", cm->name, cm->count); /* %Us: UTF-8 string */
 
 #ifdef O_CONTENTION_STATISTICS
     Sfprintf(s, " %8d", cm->collisions);

--- a/src/pl-thread.c
+++ b/src/pl-thread.c
@@ -2614,7 +2614,7 @@ PRED_IMPL("thread_join", 2, thread_join, 0)
     { case EINTR:
 	return FALSE;
       case ESRCH:
-	Sdprintf("Join %s: ESRCH from %d\n",
+	Sdprintf("Join %s: ESRCH from %ld\n",
 		 threadName(info->pl_tid), info->tid);
 	return PL_error("thread_join", 2, NULL,
 			ERR_EXISTENCE, ATOM_thread, thread);

--- a/src/pl-thread.c
+++ b/src/pl-thread.c
@@ -432,7 +432,10 @@ PRED_IMPL("mutex_statistics", 0, mutex_statistics, 0)
     if ( cm->count == 0 )
       continue;
 
-    Sfprintf(s, "%-56Us %8d", cm->name, cm->count); /* %Us: UTF-8 string */
+    WPRINT_PUSH
+    Sfprintf(s, "%-56Us %8ld", cm->name, cm->count); /* %Us: UTF-8 string */
+    WPRINT_POP
+
 #ifdef O_CONTENTION_STATISTICS
     Sfprintf(s, " %8d", cm->collisions);
 #endif

--- a/src/pl-trace.c
+++ b/src/pl-trace.c
@@ -1252,7 +1252,7 @@ _PL_backtrace(IOSTREAM *out, int depth, int flags)
       if ( frame->predicate == def )
       { if ( ++same_proc >= 10 )
 	{ if ( same_proc == 10 )
-	    Sfprintf(out, "    ...\n    ...\n", Sdout);
+	    Sfprintf(out, "    ...\n    ...\n");
 	  rctx = ctx;
 	  continue;
 	}

--- a/src/pl-util.c
+++ b/src/pl-util.c
@@ -152,7 +152,7 @@ predicateName(Definition def)
   strcpy(e, atom_summary(def->functor->name, 50));
   e += strlen(e);
   *e++ = '/';
-  Ssprintf(e, "%d", def->functor->arity);
+  Ssprintf(e, "%zd", def->functor->arity);
 
   return buffer_string(tmp, BUF_STACK);
 }
@@ -171,7 +171,7 @@ functorName(functor_t f)
   strcpy(e, atom_summary(fd->name, 50));
   e += strlen(e);
   *e++ = '/';
-  Ssprintf(e, "%d", fd->arity);
+  Ssprintf(e, "%zd", fd->arity);
 
   return buffer_string(tmp, BUF_STACK);
 }
@@ -196,7 +196,7 @@ keyName(word key)
 	  get_number(key, &n);
 	  switch(n.type)
 	  { case V_INTEGER:
-	      Ssprintf(tmp, "%lld", n.value.i);
+	      Ssprintf(tmp, "%" PRIi64, n.value.i);
 	      break;
 	    case V_FLOAT:
 	      Ssprintf(tmp, "%f", n.value.f);
@@ -244,9 +244,9 @@ generationName(gen_t gen)
   { int tid    = (gen-GEN_TRANSACTION_BASE)/GEN_TRANSACTION_SIZE;
     int64_t g2 = (gen-GEN_TRANSACTION_BASE)%GEN_TRANSACTION_SIZE;
 
-    Ssprintf(tmp, "%d@%lld", tid, (int64_t)g2);
+    Ssprintf(tmp, "%d@%" PRIi64, tid, (int64_t)g2);
   } else
-  { Ssprintf(tmp, "%lld", (int64_t)gen);
+  { Ssprintf(tmp, "%" PRIi64, (int64_t)gen);
   }
 
   return buffer_string(tmp, BUF_STACK);

--- a/src/pl-vmi.c
+++ b/src/pl-vmi.c
@@ -3622,7 +3622,7 @@ VMI(S_INCR_DYNAMIC, 0, 0, ())
       { size_t i;
 
 	if ( DEF->tabling->abstract != 0 )
-	  Sdprintf("% WARNING: Only abstract(0) is supported\n");
+	  Sdprintf("%% WARNING: Only abstract(0) is supported\n");
 	for(i=0; i<DEF->functor->arity; i++)
 	  setVar(ap[i]);
       } else

--- a/src/pl-write.c
+++ b/src/pl-write.c
@@ -124,7 +124,7 @@ var_name_ptr(DECL_LD Word p, char *name)
   else
     iref = ((Word)p - (Word)gBase)*2;
 
-  Ssprintf(name, "_%lld", (int64_t)iref);
+  Ssprintf(name, "_%" PRIi64, (int64_t)iref);
 
   return name;
 }

--- a/src/wasm/pl-wasm.c
+++ b/src/wasm/pl-wasm.c
@@ -167,9 +167,7 @@ write_jsobj_ref(IOSTREAM *out, atom_t aref, int flags)
 
   PL_STRINGS_MARK();
   s = PL_atom_wchars(cname, NULL);
-  WPRINT_PUSH
-  Sfprintf(out, "<js_%Ws>(%d)", s, ref->id);
-  WPRING_POP
+  SfprintfX(out, "<js_%Ws>(%d)", s, ref->id);
   PL_STRINGS_RELEASE();
 
   return TRUE;

--- a/src/wasm/pl-wasm.c
+++ b/src/wasm/pl-wasm.c
@@ -167,7 +167,9 @@ write_jsobj_ref(IOSTREAM *out, atom_t aref, int flags)
 
   PL_STRINGS_MARK();
   s = PL_atom_wchars(cname, NULL);
+  WPRINT_PUSH
   Sfprintf(out, "<js_%Ws>(%d)", s, ref->id);
+  WPRING_POP
   PL_STRINGS_RELEASE();
 
   return TRUE;


### PR DESCRIPTION
I'm not sure of the change to pl-trace.c
Some of the changes might not be portable to other platforms - e.g., can they be automatically checked on Windows or on a 32-bit system?