### PR TITLE
ENHANCED: library(prolog_colour): handle arithmetic functions

### DIFF
--- a/library/prolog_colour.pl
+++ b/library/prolog_colour.pl
@@ -1617,17 +1617,12 @@ colourise_expression(Arg, TB, parentheses_term_position(PO,PC,Pos)) :-
     !,
     colour_item(parentheses, TB, PO-PC),
     colourise_expression(Arg, TB, Pos).
-colourise_expression(Var, TB, Pos) :-                     % variable
-    var(Var), Pos = _-_,
-    !,
-    (   singleton(Var, TB)
-    ->  colour_item(singleton, TB, Pos)
-    ;   colour_item(var, TB, Pos)
-    ).
 colourise_expression(Compound, TB, Pos) :-
     compound(Compound), Pos = term_position(_F,_T,FF,FT,_ArgPos),
     !,
-    (   current_arithmetic_function(Compound)
+    (   dict_field_extraction(Compound)
+    ->  colourise_term_arg(Compound, TB, Pos)
+    ;   current_arithmetic_function(Compound)
     ->  colour_item(function, TB, FF-FT)
     ;   colour_item(no_function, TB, FF-FT)
     ),
@@ -1639,20 +1634,16 @@ colourise_expression(Atom, TB, Pos) :-
     ->  colour_item(function, TB, Pos)
     ;   colour_item(no_function, TB, Pos)
     ).
-colourise_expression(Integer, TB, Pos) :-
-    integer(Integer),
+colourise_expression(NumOrVar, TB, Pos) :-
+    Pos = _-_,
     !,
-    colour_item(int, TB, Pos).
-colourise_expression(Rational, TB, Pos) :-
-    rational(Rational),
-    !,
-    colour_item(rational(Rational), TB, Pos).
-colourise_expression(Float, TB, Pos) :-
-    float(Float),
-    !,
-    colour_item(float, TB, Pos).
+    colourise_term_arg(NumOrVar, TB, Pos).
 colourise_expression(_Arg, TB, Pos) :-
     colour_item(type_error(evaluable), TB, Pos).
+
+dict_field_extraction(Term) :-
+    functor(Term, '.', 2),
+    Term \= [_|_].
 
 
 colourise_expression_args(Term, TB,

--- a/library/prolog_colour.pl
+++ b/library/prolog_colour.pl
@@ -1651,8 +1651,9 @@ colourise_expression(Float, TB, Pos) :-
     float(Float),
     !,
     colour_item(float, TB, Pos).
-colourise_expression(_Arg, _TB, _Pos) :-
-    true.
+colourise_expression(_Arg, TB, Pos) :-
+    colour_item(type_error(evaluable), TB, Pos).
+
 
 colourise_expression_args(Term, TB,
                           term_position(_,_,_,_,ArgPos)) :-

--- a/library/prolog_colour.pl
+++ b/library/prolog_colour.pl
@@ -1357,8 +1357,7 @@ colour_option_values([V0|TV], [T0|TT], TB, [P0|TP]) :-
         ;   T0 = list(_),
             member(E, V0),
             var(E)
-        ;   functor(V0, '.', 2),
-            V0 \= [_|_]
+        ;   dict_field_extraction(V0)
         )
     ->  colourise_term_arg(V0, TB, P0)
     ;   callable(V0),

--- a/src/Tests/library/test_prolog_colour.pl
+++ b/src/Tests/library/test_prolog_colour.pl
@@ -1,0 +1,77 @@
+/*  Part of SWI-Prolog
+
+    Author:        Eshel Yaron
+    E-mail:        eshel@swi-prolog.org
+    WWW:           www.swi-prolog.org
+    Copyright (c)  2023, SWI-Prolog Solutions b.v.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in
+       the documentation and/or other materials provided with the
+       distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+
+:- module(test_prolog_colour,
+          [ test_prolog_colour/0
+          ]).
+
+:- use_module(library(debug), [assertion/1]).
+:- use_module(library(plunit)).
+
+/** <module> Test set for library(prolog_colour)
+
+*/
+
+test_prolog_colour :-
+        run_tests([ prolog_colour
+                  ]).
+
+:- begin_tests(prolog_colour).
+:- use_module(library(prolog_colour)).
+
+:- dynamic range_class/3.
+
+assert_range_class(Class, Beg, Len) :-
+    asserta(range_class(Beg, Len, Class)).
+
+test(function) :-
+    retractall(range_class(_, _, _)),
+    prolog_colourise_query("cos(pi) =:= - sin(pi/2) * _{foo:1}.foo / bar",
+                           user,
+                           assert_range_class),
+    !,
+    assertion(range_class(0,  3, function)),
+    assertion(range_class(4,  2, function)),
+    assertion(range_class(12, 1, function)),
+    assertion(range_class(14, 3, function)),
+    assertion(range_class(18, 2, function)),
+    assertion(range_class(20, 1, function)),
+    assertion(range_class(24, 1, function)),
+    assertion(range_class(26, 8, dict)),
+    assertion(range_class(34, 1, functor)),
+    assertion(range_class(35, 3, atom)),
+    assertion(range_class(39, 1, function)),
+    assertion(range_class(41, 3, no_function)).
+
+:- end_tests(prolog_colour).


### PR DESCRIPTION
This PR teaches `library(prolog_colour)` to recognize arithmetic expressions when they appear as an argument of the general purpose arithmetic predicates from https://www.swi-prolog.org/pldoc/man?section=arithpreds.
It checks the used arithmetic functions with `current_arithmetic_function/1` and classifies them accordingly.

Here's a screenshot from Sweep leveraging this addition:
<img width="302" alt="Screenshot 2023-01-19 at 20 26 43" src="https://user-images.githubusercontent.com/83165320/213530491-fa1231ec-dd9d-48ad-a779-1de66fe88def.png">
