### PR TITLE
fix: Use `globalThis` to reference html collections

### DIFF
--- a/src/wasm/prolog.js
+++ b/src/wasm/prolog.js
@@ -1691,14 +1691,14 @@ function release_registered_object(id)
 }
 
 
-if ( BigInt.prototype.toJSON === undefined )
-{ BigInt.prototype.toJSON = function ()
+if ( globalThis.BigInt.prototype.toJSON === undefined )
+{ globalThis.BigInt.prototype.toJSON = function ()
   { return this.toString();
   }
 }
 
-if ( HTMLCollection && HTMLCollection.prototype && !HTMLCollection.prototype.toList )
-{ HTMLCollection.prototype.toList = function()
+if ( globalThis.HTMLCollection && globalThis.HTMLCollection.prototype && !globalThis.HTMLCollection.prototype.toList )
+{ globalThis.HTMLCollection.prototype.toList = function()
   { const ar = [];
 
     for(let i=0; i<this.length; i++)


### PR DESCRIPTION
Otherwise this causes errors in `node`

```
  1) SWI-Prolog WebAssembly on Node.js
       [node] should conform to certain typing:
     ReferenceError: HTMLCollection is not defined
      at /home/jesse/Documents/github/npm-swipl-wasm/dist/swipl/swipl.js:9:184617
      at module.exports (dist/swipl-node.js:8:10)
      at Context.<anonymous> (tests/node.js:14:27)
      at process.processImmediate (node:internal/timers:471:21)
```