### PR TITLE
handle `preRun` as a function rather than an array

### DIFF
--- a/src/wasm/pre.js
+++ b/src/wasm/pre.js
@@ -126,5 +126,11 @@ function bind_std_streams()
 }
 
 if ( Module.on_output )
-{ Module.preRun.push(bind_std_streams);
+{ if (typeof Module.preRun === 'function') {
+    Module.preRun = [ Module.preRun ]
+  } else if (!Array.isArray(Module.preRun)) {
+    Module.preRun = []
+  }
+  
+  Module.preRun.push(bind_std_streams);
 }


### PR DESCRIPTION
Resolves the issue observed in https://github.com/SWI-Prolog/swipl-devel/pull/1088#issuecomment-1399651681