### PR TITLE
Fix bug in mpz_rootrem optimization

### DIFF
--- a/src/libbf/bf_gmp.c
+++ b/src/libbf/bf_gmp.c
@@ -658,8 +658,8 @@ mpz_rootrem(mpz_t rop, mpz_t rem, const mpz_t OP, unsigned long int n)
   
   if ( mpz_sizeinbase(OP, 2) < n )  // if n > bit size, answer is +/- 1
   { op_sgn = mpz_sgn(OP);
+    mpz_add_si(rem, OP, -op_sgn);
     mpz_set_si(rop, op_sgn);
-    mpz_sub_ui(rem, OP, op_sgn);
     return;
   }
 


### PR DESCRIPTION
Tripped over case when rop same as OP in degenerate case. Also replace mpz_sub_ui with mpz_add_si since  argument op_sign is signed.