### PR TITLE
updates to foreign.doc, builtins.doc, extensions.doc

### DIFF
--- a/man/builtin.doc
+++ b/man/builtin.doc
@@ -7556,26 +7556,12 @@ atom_insert(Str, Val, At, NewStr) :-
 \end{code}
 
 If the \arg{NewString} should be a string, use
-atomics_to-string/2 instead of atomic_list_concat/2:
+atomics_to_string/2 instead of atomic_list_concat/2:
 \begin{code}
 string_insert(Str, Val, At, NewStr) :-
     sub_string(Str, 0, At, A1, S1),
     sub_string(Str, At, A1, _, S2),
     atomics_to_string([S1,Val,S2], NewStr).
-\end{code}
-
-The suffix of a string can be removed by:
-\begin{code}
-remove_suffix(Atom, Suffix, FirstPart) :-
-    sub_atom(Atom, Before, _, 0, Suffix),
-    sub_atom(Atom, 0, Before, _, FirstPart).
-\end{code}
-
-However, other predicates can be more convenient, for example
-atom_concat/3, which also allow different instantiation patterns:
-\begin{code}
-remove_suffix(Atom, Suffix, FirstPart) :-
-    atom_concat(FirstPart, Suffix, Atom).
 \end{code}
 
 On backtracking, matches are delivered in order left-to-right (i.e.
@@ -11181,6 +11167,12 @@ This performs as halt/1 above except that:
     \item Termination cannot be cancelled with cancel_halt/1.
     \item abort() is called instead of exit(Status).
     \end{itemize}
+
+In addition to an integer status name we also allow passing a
+\jargon{signal name}.  This is similar to \const{abort}, blocking halt
+cancellation and set the termination code to 128+signum.  For example,
+using \exam{halt(term)} the system exits with status 143 (= 128+15) on
+Linux.
 
     \predicate{prolog}{0}{}
 This goal starts the default interactive top level. Queries are read

--- a/man/builtin.doc
+++ b/man/builtin.doc
@@ -7534,6 +7534,50 @@ After = 3,
 SubAtom = xyz.
 \end{code}
 
+The following example splits a string of the form
+<name>=<value> into the name part (an atom) and the value (a string).
+
+\begin{code}
+name_value(String, Name, Value) :-
+    sub_atom(String, Before, _, After, "="),
+    !,
+    sub_atom(String, 0, Before, _, Name),
+    sub_atom(String, _, After, 0, Value).
+\end{code}
+
+This example defines a predicate that inserts a value at a position.
+Note that sub_string/5 is used here instead of sub_atom/5, to avoid
+the overhead of creating atoms compared to creating strinngs.
+\begin{code}
+atom_insert(Str, Val, At, NewStr) :-
+    sub_string(Str, 0, At, A1, S1),
+    sub_string(Str, At, A1, _, S2),
+    atomic_list_concat([S1,Val,S2], NewStr).
+\end{code}
+
+If the \arg{NewString} should be a string, use
+atomics_to-string/2 instead of atomic_list_concat/2:
+\begin{code}
+string_insert(Str, Val, At, NewStr) :-
+    sub_string(Str, 0, At, A1, S1),
+    sub_string(Str, At, A1, _, S2),
+    atomics_to_string([S1,Val,S2], NewStr).
+\end{code}
+
+The suffix of a string can be removed by:
+\begin{code}
+remove_suffix(Atom, Suffix, FirstPart) :-
+    sub_atom(Atom, Before, _, 0, Suffix),
+    sub_atom(Atom, 0, Before, _, FirstPart).
+\end{code}
+
+However, other predicates can be more convenient, for example
+atom_concat/3, which also allow different instantiation patterns:
+\begin{code}
+remove_suffix(Atom, Suffix, FirstPart) :-
+    atom_concat(FirstPart, Suffix, Atom).
+\end{code}
+
 On backtracking, matches are delivered in order left-to-right (i.e.
 \arg{Before} increases monotonically):
 
@@ -11137,12 +11181,6 @@ This performs as halt/1 above except that:
     \item Termination cannot be cancelled with cancel_halt/1.
     \item abort() is called instead of exit(Status).
     \end{itemize}
-
-In addition to an integer status name we also allow passing a
-\jargon{signal name}.  This is similar to \const{abort}, blocking halt
-cancellation and set the termination code to 128+signum.  For example,
-using \exam{halt(term)} the system exits with status 143 (= 128+15) on
-Linux.
 
     \predicate{prolog}{0}{}
 This goal starts the default interactive top level. Queries are read

--- a/man/extensions.doc
+++ b/man/extensions.doc
@@ -428,16 +428,10 @@ undefined.  See also read_string/5.
 This predicate is functionally equivalent to sub_atom/5, but operates on
 strings. Note that this implies the string \emph{input} arguments can be
 either strings or atoms.  If \arg{SubString} is unbound (output) it is
-unified with a string. The following example splits a string of the form
-<name>=<value> into the name part (an atom) and the value (a string).
+unified with a string.
 
-\begin{code}
-name_value(String, Name, Value) :-
-    sub_string(String, Before, _, After, "="),
-    !,
-    sub_atom(String, 0, Before, _, Name),
-    sub_string(String, _, After, 0, Value).
-\end{code}
+For examples of using this predicate, see sub_atom/5.
+
 
     \predicate{atomics_to_string}{2}{+List, -String}
 \arg{List} is a list of strings, atoms, or number types. Succeeds

--- a/man/foreign.doc
+++ b/man/foreign.doc
@@ -1917,19 +1917,26 @@ argument is bound, the code below may fail before reaching the end of
 the word list, but even if the unification succeeds, this code avoids a
 duplicate (garbage) list and a deep unification.
 
+Note that PL_unify_list() is not used with \arg{env} but with
+\exam{env_ref}, which has a reference to \arg{env}. The only thing
+that is allowed to be done with and argument to a foreign predicate
+(such as \arg{env}) is unification; for anything that might over-write
+the term, you must use a reference created by PL_copy_term_ref().
+
 \begin{code}
 foreign_t
 pl_get_environ(term_t env)
-{ term_t item = PL_new_term_ref();
+{ term_t env_ref = PL_copy_term_ref(env);
+  term_t item = PL_new_term_ref();
   extern char **environ;
 
   for(const char **e = environ; *e; e++)
-  { if ( !PL_unify_list(env, item, env) ||
+  { if ( !PL_unify_list(env_ref, item, env_ref) ||
          !PL_unify_atom_chars(item, *e) )
       PL_fail;
   }
 
-  return PL_unify_nil(env);
+  return PL_unify_nil(env_ref);
 }
 \end{code}
 

--- a/man/foreign.doc
+++ b/man/foreign.doc
@@ -1375,9 +1375,9 @@ atoms, each on a line:
 foreign_t
 pl_write_atoms(term_t l)
 { term_t head = PL_new_term_ref();   /* the elements */
-  term_t list = PL_copy_term_ref(l); /* copy (we modify list) */
+  term_t tail = PL_copy_term_ref(l); /* copy (we modify tail) */
 
-  while( PL_get_list(list, head, list) )
+  while( PL_get_list(tail, head, tail) )
   { char *s;
 
     if ( PL_get_atom_chars(head, &s) )
@@ -1386,7 +1386,7 @@ pl_write_atoms(term_t l)
       PL_fail;
   }
 
-  return PL_get_nil(list);            /* test end for [] */
+  return PL_get_nil(tail);            /* test end for [] */
 }
 \end{code}
 
@@ -2551,7 +2551,7 @@ Write the content of the blob \arg{a} to the stream \arg{s}
 respecting the \arg{flags}.  The \arg{flags} are a bitwise
 \emph{or} of zero or more of the \const{PL_WRT_*} flags defined in
 \file{SWI-Prolog.h}. This prototype is available if the
-undocumented \file{SWI-Stream.h} is included \emph{before}
+\file{SWI-Stream.h} is included \emph{before}
 \file{SWI-Prolog.h}. This function can retrieve the data of the blob
 using PL_blob_data().
 
@@ -2571,15 +2571,30 @@ Write the blob to stream \arg{s}, in an opaque form that's known only
 to the blob. If this is not possible, the "save" function should call
 PL_message() and return \const{FALSE}. If a "save" function is not
 provided (that is, the field is \const{NULL}), the default
-implementation writes the blob as if it is a string of characters
-(this could cause problems if a saved state is created on a big-endian
+implementation writes the blob as if it is a string of bytes (this
+could cause problems if a saved state is created on a big-endian
 machine and used on a little-endian machine).
+
+If the "save" function encounters an error, it should call
+PL_raise_exception() or one of the interface functions (e.g.,
+resource_error() or PL_representation_error() and return
+\const{FALSE}. Alternatively, it can call Sseterr() on the stream and
+return \const{FALSE}.  If no error has been set
+\exam{representation_error(culprit)} is used, where \arg{culprit} is
+the result of the blob's "write" function.\footnote{Details are
+subject to change; see
+\href{https://github.com/SWI-Prolog/swipl-devel/issues/1118}{bug
+1118}.}
 
     \cfunction{atom_t}{load}{IOSTREAM *s}
 
 Read the blob from its saved form. If this cannot be done (e.g., a
 stream read failure or a corrupted external form), the "load" function
-should call PL_fatal_error() and return const{FALSE}.
+should call PL_fatal_error() and return const{FALSE}.\footnote{Details
+are subject to change; see the "save" function.}  If a "load" function
+is not provided (that is, the field is \const{NULL}, the default
+implementation assumes that the blob was written by the default
+"save".
 
 \begin{description}
     \cfunction{int}{PL_unregister_blob_type}{PL_blob_t *type}

--- a/man/foreign.doc
+++ b/man/foreign.doc
@@ -1383,10 +1383,13 @@ pl_write_atoms(term_t l)
     if ( PL_get_atom_chars(head, &s) )
       Sprintf("%s\n", s);
     else
+    { (void)PL_release_stream(s);
       PL_fail;
+    }
   }
 
-  return PL_get_nil(tail);            /* test end for [] */
+  return PL_release_stream(s) &&
+    PL_get_nil(tail);            /* test end for [] */
 }
 \end{code}
 

--- a/man/streams.doc
+++ b/man/streams.doc
@@ -276,11 +276,11 @@ freed by the caller when done. Example:
 \end{code}
 
 The \arg{mode} is \const{"r"} or \const{"w"}. The mode \arg{"rF"} calls
-\exam{PL_free(*buffer)} at when closed.
+\exam{PL_free(buffer)} when closed.
 
 \textbf{Note:} Its is \emph{not} allowed to access streams created with
 this call from multiple threads. This is ok for all usage inside Prolog
-itself. This call is intented to use write and other output predicates
+itself. This call is intended to use Sfprintf() and other output functions
 to create strings.
 
     \cfunction{void}{Sfree}{void *ptr}

--- a/src/Tests/core/test_text.pl
+++ b/src/Tests/core/test_text.pl
@@ -53,7 +53,8 @@ test_text :-
 		    number_codes,
 		    number_chars,
 		    sub_atom,
-		    atomic_list_concat
+		    atomic_list_concat,
+                    substring
 		  ]).
 
 :- begin_tests(char_code).
@@ -251,3 +252,73 @@ test(error, error(domain_error(non_empty_atom, ''))) :-
 	atomic_list_concat(_L, '', text).
 
 :- end_tests(atomic_list_concat).
+
+% Tests for the examples given in builtins.doc for sub_atom/5.
+
+:- begin_tests(substring).
+
+test(sub_atom) :-
+    sub_atom(aaxyzbbb, 2, 3, After, SubAtom),
+    assertion(After == 3),
+    assertion(SubAtom == xyz).
+test(sub_atom) :-
+    sub_atom(aaxyzbbb, Before, Length, 3, xyz),
+    assertion(Before == 2),
+    assertion(Length == 3).
+
+test(name_value) :-
+    name_value("foo=bar", Name, Value),
+    assertion(Name == foo),
+    assertion(Value == bar).
+
+test(string_insert, S == abcdeFOOfgh) :-
+    atom_insert("abcdefgh", "FOO", 5, S).
+test(string_insert, S == "abcdeFOOfgh") :-
+    string_insert("abcdefgh", "FOO", 5, S).
+
+test(prefix) :-
+    has_prefix(abcde, abc).
+test(prefix, Rest == de) :-
+    remove_prefix(abcde, abc, Rest).
+
+test(suffix) :-
+    has_suffix("foo.pl", ".pl").
+test(suffix, Rest == foo) :-
+    remove_suffix("foo.pl", ".pl", Rest).
+test(suffix, Rest == foo) :-
+    remove_suffix2("foo.pl", '.pl', Rest).
+
+name_value(String, Name, Value) :-
+    sub_atom(String, Before, _, After, "="),
+    !,
+    sub_atom(String, 0, Before, _, Name),
+    sub_atom(String, _, After, 0, Value).
+
+atom_insert(Str, Val, At, NewStr) :-
+    sub_string(Str, 0, At, A1, S1),
+    sub_string(Str, At, A1, _, S2),
+    atomic_list_concat([S1,Val,S2], NewStr).
+
+string_insert(Str, Val, At, NewStr) :-
+    sub_string(Str, 0, At, A1, S1),
+    sub_string(Str, At, A1, _, S2),
+    atomics_to_string([S1,Val,S2], NewStr).
+
+has_prefix(Atom, Prefix) :-
+    sub_atom(Atom, 0, _, _, Prefix).
+
+has_suffix(Atom, Suffix) :-
+    sub_atom(Atom, _, _, 0, Suffix).
+
+remove_prefix(Atom, Prefix, SecondPart) :-
+    sub_atom(Atom, 0, Len, After, Prefix),
+    sub_atom(Atom, Len, After, 0, SecondPart).
+
+remove_suffix(Atom, Suffix, FirstPart) :-
+    sub_atom(Atom, Before, _, 0, Suffix),
+    sub_atom(Atom, 0, Before, _, FirstPart).
+
+remove_suffix2(Atom, Suffix, FirstPart) :-
+    atom_concat(FirstPart, Suffix, Atom).
+
+:- end_tests(substring).


### PR DESCRIPTION
DOC: move sub_string/5 examples to sub_atom/5 and add a few more examples
Fix example code for pl_get_environ/1