### PR TITLE
ENHANCEMENT: profiler - improve port count accuracy

### DIFF
--- a/src/pl-prof.c
+++ b/src/pl-prof.c
@@ -89,7 +89,7 @@ typedef struct call_node
   void *            handle;		/* handle to procedure-id */
   PL_prof_type_t   *type;
   uintptr_t	    calls;		/* Calls from the parent */
-  uintptr_t	    redos;		/* redos while here */
+  uintptr_t	    fails;		/* fails back to choicepoint */
   uintptr_t	    exits;		/* exits to the parent */
   uintptr_t	    recur;		/* recursive calls */
   uintptr_t	    ticks;		/* time-statistics */
@@ -513,7 +513,7 @@ PRED_IMPL("$prof_node", 8, prof_node, 0)
 
   return ( unify_node_id(A2, n) &&
 	   PL_unify_integer(A3, n->calls) &&
-	   PL_unify_integer(A4, n->redos) &&
+	   PL_unify_integer(A4, n->exits + n->fails - n->calls) &&
 	   PL_unify_integer(A5, n->exits) &&
 	   PL_unify_integer(A6, n->recur) &&
 	   PL_unify_integer(A7, n->ticks) &&
@@ -583,13 +583,13 @@ add_parent_ref(node_sum *sum,
 { prof_ref *r;
 
   sum->calls += self->calls;
-  sum->redos += self->redos;
+  sum->redos += self->exits + self->fails - self->calls;
   sum->exits += self->exits;
 
   for(r=sum->callers; r; r=r->next)
   { if ( r->handle == handle && r->cycle == cycle )
     { r->calls += self->calls;
-      r->redos += self->redos;
+      r->redos += self->exits + self->fails - self->calls;
       r->exits += self->exits;
       r->ticks += self->ticks;
       r->sibling_ticks += self->sibling_ticks;
@@ -600,7 +600,7 @@ add_parent_ref(node_sum *sum,
 
   r = allocHeapOrHalt(sizeof(*r));
   r->calls = self->calls;
-  r->redos = self->redos;
+  r->redos = self->exits + self->fails - self->calls;
   r->exits = self->exits;
   r->ticks = self->ticks;
   r->sibling_ticks = self->sibling_ticks;
@@ -641,7 +641,7 @@ add_sibling_ref(node_sum *sum, call_node *sibling, int cycle)
   for(r=sum->callees; r; r=r->next)
   { if ( r->handle == sibling->handle && r->cycle == cycle )
     { r->calls += sibling->calls;
-      r->redos += sibling->redos;
+      r->redos += sibling->exits + sibling->fails - sibling->calls;
       r->exits += sibling->exits;
       r->ticks += sibling->ticks;
       r->sibling_ticks += sibling->sibling_ticks;
@@ -652,7 +652,7 @@ add_sibling_ref(node_sum *sum, call_node *sibling, int cycle)
 
   r = allocHeapOrHalt(sizeof(*r));
   r->calls = sibling->calls;
-  r->redos = sibling->redos;
+  r->redos = sibling->exits + sibling->fails - sibling->calls;
   r->exits = sibling->exits;
   r->ticks = sibling->ticks;
   r->sibling_ticks = sibling->sibling_ticks;
@@ -1159,6 +1159,16 @@ profResumeParent(DECL_LD struct call_node *node)
   LD->profile.current = node;
 }
 
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+profExit(call_node from_node)
+
+Exit to the parent of from_node. Note that all nodes from the current
+node back to and including from_node are deemed to have exited. This 
+catches all normal exits (from_node == current) and last calls (from_node
+is an ancestor of current).
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 void
 profExit(DECL_LD struct call_node *node)
@@ -1169,31 +1179,47 @@ profExit(DECL_LD struct call_node *node)
 }
 
 
+/* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+profFail(call_node cp_node)
+
+Fail to choicepoint node. All nodes in the branch from the current node 
+back to a common ancestor with cp_node are deemed to have failed. Note 
+that if the current node is the choicepoint node, nothing fails as this 
+is internal to the predicate (doesn't pass through Fail port).
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+static
+int lookback(call_node *from_node, call_node *to_node)
+{ struct call_node *node = from_node;
+  while (node)
+    if (node == to_node)
+      return TRUE;
+    else 
+      node = node->parent;
+  return FALSE;
+}
+ 
 void
-profRedo(DECL_LD struct call_node *node)
-{ if ( node && node->magic != PROFNODE_MAGIC )
-    return;
-
-  if ( node )
-  { if ( LD->profile.current )
-    { struct call_node *n;
-
-      DEBUG(MSG_PROF_CALLTREE,
-	    Sdprintf("Redo: on %s; current is %s\n",
-		     node_name(node), node_name(LD->profile.current) ));
-
-      for(n=node; n && n != LD->profile.current; n = n->parent)
-      { DEBUG(MSG_PROF_CALLTREE,
-	      Sdprintf("Redo: %s\n", node_name(n)));
-	n->redos++;
-      }
-    } else
-    { DEBUG(MSG_PROF_CALLTREE,
-	    Sdprintf("Redo: %s\n", node_name(node)));
-      node->redos++;
-    }
+profFailToCP(struct call_node *current, struct call_node *cp_node)
+{ if (current && (!lookback(cp_node, current)))
+  { DEBUG(MSG_PROF_CALLTREE,
+	    Sdprintf("Fail: %s\n", node_name(current)));
+    if (current->magic == PROFNODE_MAGIC)
+      current->fails++;
+    profFailToCP(current->parent, cp_node);
   }
-  LD->profile.current = node;
+}
+
+void
+profFail(DECL_LD struct call_node *cp_node)
+{ LD->profile.accounting = TRUE;
+  
+  profFailToCP(LD->profile.current, cp_node);
+  LD->profile.current = cp_node;
+  
+  LD->profile.accounting = FALSE;
 }
 
 

--- a/src/pl-prof.h
+++ b/src/pl-prof.h
@@ -47,7 +47,7 @@ typedef enum
 #define	profCall(def)			LDFUNC(profCall, def)
 #define	profResumeParent(node)		LDFUNC(profResumeParent, node)
 #define	profExit(node)			LDFUNC(profExit, node)
-#define	profRedo(node)			LDFUNC(profRedo, node)
+#define	profFail(node)			LDFUNC(profRedo, node)
 #endif /*USE_LD_MACROS*/
 
 #define LDFUNC_DECLARATIONS
@@ -58,7 +58,7 @@ bool		resetProfiler(void);
 struct call_node* profCall(Definition def);
 void		profResumeParent(struct call_node *node);
 void		profExit(struct call_node *node);
-void		profRedo(struct call_node *node);
+void		profFail(struct call_node *node);
 void		profSetHandle(struct call_node *node, void *handle);
 
 #undef LDFUNC_DECLARATIONS

--- a/src/pl-vmi.c
+++ b/src/pl-vmi.c
@@ -6829,6 +6829,8 @@ next_choice:
     }
   }
 
+  Profile(profFail(ch->prof_node));
+
   switch(ch->type)
   { case CHP_JUMP:
       DEBUG(MSG_BACKTRACK,
@@ -6885,7 +6887,6 @@ next_choice:
 	    THROW_EXCEPTION;
 	}
 #endif
-	Profile(profRedo(ch->prof_node));
       }
       NEXT_INSTRUCTION;
     case CHP_CLAUSE:			/* try next clause */
@@ -6947,7 +6948,6 @@ next_choice:
 	    THROW_EXCEPTION;
 	}
 #endif
-	Profile(profRedo(ch->prof_node));
       }
 
       if ( chp.cref )
@@ -6975,7 +6975,6 @@ next_choice:
 		     loffset(FR),
 		     predicateName(DEF)));
       DiscardMark(ch->mark);
-      Profile(profRedo(ch->prof_node));
       QF = QueryFromQid(QID);
       set(QF, PL_Q_DETERMINISTIC);
       QF->foreign_frame = PL_open_foreign_frame();


### PR DESCRIPTION
Intent is that port counts should reflect events on standard box model ports. This means no internal failures/backtracking, e.g., head unifications, inline "predicates" etc., are visible to the profiler.

External interface/display not affected so existing code is not affected by this change. Review of profiling doc probably required moving forward.