### PR TITLE
Correct documentation for disjunctive opt_type

### DIFF
--- a/library/main.pl
+++ b/library/main.pl
@@ -169,7 +169,7 @@ interrupt(_Sig) :-
 %         as http(true), ``--no-http`` as http(false), ``--http=3000``
 %         and ``--http 3000`` as http(3000).  With an optional boolean
 %         an option is considered boolean if it is the last or the next
-%         argument does not start with hyphen (``-``).
+%         argument starts with a hyphen (``-``).
 %       - boolean(Default)
 %       - boolean
 %         Boolean options are special.  They do not take a value except


### PR DESCRIPTION
It seems from reading the source (and indeed, what one would expect), that the argument is considered a boolean if the next argument *does* start with a hyphen.