### PR TITLE
SWI-Stream.h and SWi-Prolog.h can be in any order (issues 1120, 1133)

### DIFF
--- a/man/foreign.doc
+++ b/man/foreign.doc
@@ -2593,8 +2593,8 @@ Write the content of the blob \arg{a} to the stream \arg{s}
 respecting the \arg{flags}.  The \arg{flags} are a bitwise
 \emph{or} of zero or more of the \const{PL_WRT_*} flags defined in
 \file{SWI-Prolog.h}. This prototype is available if the
-\file{SWI-Stream.h} is included \emph{before}
-\file{SWI-Prolog.h}. This function can retrieve the data of the blob
+\file{SWI-Stream.h} is included.
+This function can retrieve the data of the blob
 using PL_blob_data().
 
 If this function is not provided, write/1 emits the content

--- a/src/os/SWI-Stream.h
+++ b/src/os/SWI-Stream.h
@@ -34,6 +34,10 @@
     POSSIBILITY OF SUCH DAMAGE.
 */
 
+#ifndef _SWI_NOT_INCLUDE_SWI_PROLOG_H
+#include <SWI-Prolog.h>
+#endif
+
 #ifndef _SWI_STREAM_H
 #define _SWI_STREAM_H
 

--- a/src/os/pl-stream.c
+++ b/src/os/pl-stream.c
@@ -35,6 +35,8 @@
     POSSIBILITY OF SUCH DAMAGE.
 */
 
+#define _SWI_NOT_INCLUDE_SWI_PROLOG_H
+
 #ifdef __WINDOWS__
 #include "windows/uxnt.h"
 #include "config/wincfg.h"

--- a/src/pl-fli.c
+++ b/src/pl-fli.c
@@ -784,7 +784,7 @@ saveUCSAtom(atom_t atom, IOSTREAM *fd)
   const pl_wchar_t *s = (const pl_wchar_t*)a->name;
   size_t len = a->length/sizeof(pl_wchar_t);
 
-  PL_qlf_PutStringW(s, len, fd);
+  PL_PutStringW(s, len, fd);
 
   return TRUE;
 }
@@ -797,7 +797,7 @@ loadUCSAtom(IOSTREAM *fd)
   size_t len;
   atom_t a;
 
-  w = PL_qlf_GetStringUTF8(fd, &len, buf, sizeof(buf)/sizeof(pl_wchar_t));
+  w = PL_GetStringUTF8(fd, &len, buf, sizeof(buf)/sizeof(pl_wchar_t));
   a = lookupUCSAtom(w, len);
 
   if ( w != buf )

--- a/src/pl-wic.h
+++ b/src/pl-wic.h
@@ -48,9 +48,12 @@ bool		loadWicFromStream(const char *rcpath, IOSTREAM *fd);
 bool		compileFileList(IOSTREAM *out, int argc, char **argv);
 void		qlfCleanup(void);
 
-void		PL_qlf_PutStringW(const pl_wchar_t *w, size_t len,
-				  IOSTREAM *fd);
-pl_wchar_t*	PL_qlf_GetStringUTF8(IOSTREAM *fd, size_t *length,
-				     pl_wchar_t *buf, size_t bufsize);
+/* PL_PutStringW() and PL_GetStringUTF() are not public but might
+   become public in future. */
+
+void		PL_PutStringW(const pl_wchar_t *w, size_t len,
+			      IOSTREAM *fd);
+pl_wchar_t*	PL_GetStringUTF8(IOSTREAM *fd, size_t *length,
+				 pl_wchar_t *buf, size_t bufsize);
 
 #endif /*_PL_WIC_H*/


### PR DESCRIPTION
Start work on making putAtom() in pl-wic.c public. 
Fix a couple of names that were mistakenly made part PL_qlf_*().

This is a bit of a hack, but a proper fix looks like quite a bit of work for very little benefit.

https://github.com/SWI-Prolog/swipl-devel/issues/1133
https://github.com/SWI-Prolog/swipl-devel/issues/1120