### PR TITLE
FIXED: Addresses #1160, residual constraints in tuples_in/2 from clp(…

### DIFF
--- a/library/clp/clpfd.pl
+++ b/library/clp/clpfd.pl
@@ -4131,7 +4131,8 @@ relation_tuple(Relation, Tuple) :-
 tuple_domain([], _).
 tuple_domain([T|Ts], Relation0) :-
         maplist(list_first_rest, Relation0, Firsts, Relation1),
-        (   var(T) ->
+        (   Firsts = [Unique] -> T = Unique
+        ;   var(T) ->
             (   Firsts = [Unique] -> T = Unique
             ;   list_to_domain(Firsts, FDom),
                 fd_get(T, TDom, TPs),

--- a/man/overview.doc
+++ b/man/overview.doc
@@ -2174,6 +2174,11 @@ following \verb$~$ (tilde) sequences are replaced:
 \end{tabular}
 \end{center}
 
+    \prologflagitem{toplevel_residue_vars}{bool}{rw}
+When \const{true} (default \const{false}), print residual variables as
+detected by call_residue_vars/2 that do not appear in the bindings
+returned by the goal.
+
     \prologflagitem{toplevel_var_size}{int}{rw}
 Maximum size counted in literals of a term returned as a binding for a
 variable in a top-level query that is saved for re-use using the


### PR DESCRIPTION
…fd).

Patch by @triska for Scryer Prolog.