### PR TITLE
feat: add pcre to wasm pacakges

### DIFF
--- a/cmake/PackageSelection.cmake
+++ b/cmake/PackageSelection.cmake
@@ -112,7 +112,7 @@ set(SWIPL_PACKAGE_LIST_X
     xpce)
 
 set(SWIPL_PACKAGE_LIST_WASM
-    clpqr plunit chr clib http semweb)
+    clpqr plunit chr clib http semweb pcre)
 
 # swipl_package_component(pkg var)
 #


### PR DESCRIPTION
Closes #1166 

**EDIT** Converted to draft as some regex tests with this config are failing when I expect them to work - looking at the build log; the error seems to be `#21 148.0 -- Could NOT find PCRE (missing: PCRE_LIBRARY PCRE_INCLUDE_DIR) `

The full build log is [here](https://pastebin.com/CE6n47f2). It was built using the dockerfile in npm-swipl-wasm