### PR TITLE
chore: use `stringToNewUTF8` instead of `allocateUTF8`

### DIFF
--- a/src/wasm/prolog.js
+++ b/src/wasm/prolog.js
@@ -499,8 +499,8 @@ class Prolog
 	throw(`Prolog.predicate: illegal specification: ${name}`);
     }
 
-    const c_name   = allocateUTF8(name);
-    const c_module = allocateUTF8(module||"user");
+    const c_name   = stringToNewUTF8(name);
+    const c_module = stringToNewUTF8(module||"user");
 
     const pred = this.bindings.PL_predicate(c_name, arity, c_module);
 


### PR DESCRIPTION
See https://github.com/emscripten-core/emscripten/blob/b1fbec18442635058b362d36bc613ed9cecd5f17/ChangeLog.md?plain=1#L61.

I have tested this on 3.1.37 of emscripten. It does fix the build error encountered in https://github.com/SWI-Prolog/npm-swipl-wasm/actions/runs/4843424186/jobs/8631031803?pr=127 but we are also getting a `_free` is undefined error which we may wish to also resolve before merging this change.