### PR TITLE
chore: add `_free` and `_malloc` to exports

### DIFF
--- a/src/wasm/exports.json
+++ b/src/wasm/exports.json
@@ -208,5 +208,8 @@
     "_WASM_set_yield_result",
     "_WASM_variable_id",
     "_js_unify_obj",
-    "_js_get_obj"
+    "_js_get_obj",
+
+    "_free",
+    "_malloc"
 ]


### PR DESCRIPTION
Confirmed to resolve the `_free` error from https://github.com/SWI-Prolog/npm-swipl-wasm/pull/127 thanks to the input in https://github.com/emscripten-core/emscripten/issues/19267.