### PR TITLE
ENHANCED: indicate DCG rules in xref_defined/3

### DIFF
--- a/library/prolog_xref.pl
+++ b/library/prolog_xref.pl
@@ -612,6 +612,7 @@ xref_called(Source, Called, By, Cond, Line) :-
 %     * foreign(Location)
 %     * constraint(Location)
 %     * imported(From)
+%     * dcg
 
 xref_defined(Source, Called, How) :-
     nonvar(Source),


### PR DESCRIPTION
Add a new predicate `xref_grammar_rule/2`, allowing consumers of `library(prolog_xref)` to find out if a predicate is a DCG grammar rule.

Determining whether a predicate is a DCG non-terminal is important, for example, when adding a that predicate to the module's export list (if it's a non-terminal we want to add `foo//N-2` rather then `foo/N` to the export list).