### PR TITLE
for windows, open_url/1 cut

### DIFF
--- a/library/www_browser.pl
+++ b/library/www_browser.pl
@@ -94,7 +94,8 @@ open_url(URL) :-
     run_command(Command, [URL], Mode).
 :- if(current_predicate(win_shell/2)).
 open_url(URL) :-                        % Windows shell
-    win_shell(open, URL).
+    win_shell(open, URL),
+    !.
 :- endif.
 open_url(URL) :-                        % Unix `open document'
     open_command(Open),


### PR DESCRIPTION
www_open_url leaves a choice point that is useless in Windows