### PR TITLE
ENHANCED: Handle C++ functions in doc files'

### DIFF
--- a/man/pl.sty
+++ b/man/pl.sty
@@ -78,6 +78,9 @@
 	\mbox{{\reffont #1(}{\rm #2}{\tt )}}}
 \newcommand{\cfuncref}[2]{%		% function(Args...)
 	\mbox{{\reffont #1(}{\it #2}{\tt )}}}
+% \cxxfuncref is for function references that don't start with PL_, S, pr Pl*::*
+\newcommand{\cxxfuncref}[2]{%		% function(Args...)
+	\mbox{{\reffont #1(}{\it #2}{\tt )}}}
 \newcommand{\prologflag}[1]{%
 	\mbox{\reffont #1}}
 


### PR DESCRIPTION
\cxxfuncref currently is the same as \cfuncref. It was useful for debugging `doc2tex.pl`; and it's possible that the definition will change in future.

This change depends on https://github.com/SWI-Prolog/packages-ltx2htm/pull/5