### PR TITLE
FIXED: prolog_deps:src_file/2 SSU error

### DIFF
--- a/library/prolog_deps.pl
+++ b/library/prolog_deps.pl
@@ -266,8 +266,8 @@ missing_autoload(_Src, _, Head, _) :-
 src_file(@(Ref), File) =>
     get(?(@(Ref), file), absolute_path, File).
 :- endif.
-src_file(File, File) =>
-    true.
+src_file(File0, File) =>
+    File = File0.
 
 %!  directives(+File, +FileAndHeads, -Directives, +Options) is det.
 %


### PR DESCRIPTION
This fixes an error in `file_autoload_directives/3` introduced in 8019b12f47130799caa611791b5f5bf4fc51ba51
