### PR TITLE
Added markup processing for C++ and non-PL function references

### DIFF
--- a/man/doc2tex.pl
+++ b/man/doc2tex.pl
@@ -76,6 +76,9 @@ doc2tex(InFile, OutFile) :-
         emit(Result, Out),
         close(Out)).
 
+doc2tex([]) -->
+    "{END_OF_FILE}", !, % Useful for finding markup that caused a crash
+    remainder(_).
 doc2tex(Result) -->
     tr(One),
     !,
@@ -95,22 +98,33 @@ add_result(One, [One|Tail], Tail).
 		 *            RECOGNISERS	*
 		 *******************************/
 
+tr(\cfuncref(FName, Args)) -->
+    pl_c_func_prefix(Prefix),
+    c_identifier(Name), "(", string_without(")", Chars), ")",
+    !,
+    {  atom_concat(Prefix, Name, FName),
+       string_chars(Args, Chars)
+    }.
+tr(\cfuncref(FName, Args)) -->
+    pl_cxx_func_prefix(Prefix),
+    cxx_identifier(Name), "(", string_without(")", Chars), ")",
+    !,
+    {  atom_concat(Prefix, Name, FName),
+       string_chars(Args, Chars)
+    }.
+tr(\cfuncref(FName, Args)) --> % This might become a different cmd
+    cxx_identifier(FName), "(", string_without(")", Chars), ")",
+    !,
+    {  string_chars(Args0, Chars),
+       (   Args0 = "{{}}" % TODO: remove when Args is properly processed
+       ->  Args = "\\Scurl"
+       ;   Args = Args0
+       )
+    }.
 tr(Object) -->
     unquoted_atom(Name),
     !,
     tr_name(Name, Object).
-tr(\cfuncref(FName, Args)) -->
-    "PL_", c_identifier(Name), "(", string_without(")", Chars), ")",
-    !,
-    {  atom_concat('PL_', Name, FName),
-       string_chars(Args, Chars)
-    }.
-tr(\cfuncref(FName, Args)) -->
-    "S", c_identifier(Name), "(", string_without(")", Chars), ")",
-    !,
-    {  atom_concat('S', Name, FName),
-       string_chars(Args, Chars)
-    }.
 tr([\begin(code),Code,\end(code),'\n\n',\noindent,'\n']) -->
     "\\begin{code}", string(CodeChars), "\\end{code}",
     !,
@@ -176,6 +190,12 @@ tr(\bnfmeta(Name)) -->
 tr(C) -->
     [C].
 
+pl_c_func_prefix('PL_') --> "PL_", !.
+pl_c_func_prefix('S')   --> "S", !.
+pl_c_func_prefix('Plx') --> "Plx", !. % SWI-cpp2-plx.h
+pl_c_func_prefix('Pl')  --> "Pl".  % SWI-cpp2.h
+
+pl_cxx_func_prefix('Pl') --> "Pl", !. % SWI-cpp2.h
 
 tr_name(Module, [\index(Index),\qpredref(Module,Name,write(Arity))]) -->
     ":", unquoted_atom(Name), "/", arity(Arity), !,
@@ -343,6 +363,26 @@ c_id_cont([H|T]) -->
 	[H], { code_type(H, csym) }, !,
 	c_id_cont(T).
 c_id_cont([]) --> "".
+
+%!  cxx_identifier(-Identifier)//
+% This covers thing such as Class::method
+
+cxx_identifier(Name) -->
+    [C0], { code_type(C0, csymf) }, !,
+    cxx_id_cont(CL),
+    { atom_codes(Name, [C0|CL]) }.
+
+cxx_id_cont([0':,0':|T]) -->
+    "::", !, % For C++ "::"
+    cxx_id_cont(T).
+cxx_id_cont([0'~|T]) --> % '
+    "~", !, % For C++ destructor
+    cxx_id_cont(T).
+cxx_id_cont([H|T]) -->
+    [H], { code_type(H, csym) }, !,
+    cxx_id_cont(T).
+cxx_id_cont([]) --> "".
+
 
 %!  arity(-Spec)
 


### PR DESCRIPTION
This PR makes the documentation for the C++ API look nicer.
It has two kludges:
- A check for `{END_OF_FILE}` ... I used when trying to track down a markup bug that caused a crash in `latex2html.pl`.
- Special handling of `{{}}` in an arguments list, which caused `packages/swipy/janus.doc` to not be processed properly. The proper solution for this is to recursively process the args, but that appears to require changing other parts of the processing pipeline.