### PR TITLE
Port: ifdefs for Rtools44 

### DIFF
--- a/src/pl-alloc.c
+++ b/src/pl-alloc.c
@@ -55,7 +55,7 @@
 /* Provides error checking for the weak declarations below */
 #include <gperftools/malloc_extension_c.h>
 #endif
-#ifdef HAVE_SYS_MMAN_H
+#if defined(HAVE_SYS_MMAN_H) && defined(HAVE_MMAP) && defined(HAVE_SYSCONF)
 #define MMAP_STACK 1
 #include <sys/mman.h>
 #include <unistd.h>


### PR DESCRIPTION
(from CRAN): The upcoming version of Rtools44 has sys/mman.h, which however doesn't have all the Unix functionality of the same header file (e.g. it misses mmap, sysconf). It is from the mman-win32 project.