### PR TITLE
Minor fix in pl-segstack.c

### DIFF
--- a/src/pl-segstack.c
+++ b/src/pl-segstack.c
@@ -70,7 +70,7 @@ next_chunk_size(segstack *stack)
 void *
 pushSegStack_(segstack *stack, void *data)
 { if ( stack->top + stack->unit_size <= stack->max )
-  { void *ptr = stack->top;
+  { char *ptr = stack->top;
 
     if ( data )
       memcpy(ptr, data, stack->unit_size);


### PR DESCRIPTION
below, we have ptr + number, which raises a warning on pointer arithmetic if ptr is void*. Since stack->top is char* anyway, this seems harmless (though uint8_t could be used instead of char)