### PR TITLE
Find pthread_setname_np/2 or /3

### DIFF
--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -303,7 +303,6 @@ include(TestRecursiveMutex)
 
 if(HAVE_PTHREAD_SETNAME_NP)
 function(check_pthread_setname_np)
-  set(CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS} -Werror)
   check_c_source_compiles(
       "#define _GNU_SOURCE
        #include <pthread.h>\nint main()


### PR DESCRIPTION
The code is meant to find pthread_setname_np/2 or /3. Unclear what -Werror does here.