### PR TITLE
fix: fix fid arg position in this.query call in `__call_yieldable`

### DIFF
--- a/src/wasm/prolog.js
+++ b/src/wasm/prolog.js
@@ -983,7 +983,7 @@ class Prolog
     const term = this.new_term_ref();
     if ( !this.chars_to_term(goal, term) )
       throw new Error('Query has a syntax error: ' + query);
-    const q = this.query(module, flags, pred_call1, term, fid);
+    const q = this.query(module, flags, pred_call1, term, undefined, fid);
     return q.next_yieldable();
   }
 


### PR DESCRIPTION
Fixes a bug where this test https://github.com/SWI-Prolog/npm-swipl-wasm/pull/583/files results in the error

```
  1) SWI-Prolog WebAssembly on Node.js
       [node] should query SWI-Prolog Input:
     TypeError: this.map.call is not a function
      at Query.next (dist/swipl/swipl.js:8:170777)
      at next (dist/swipl/swipl.js:8:171145)
      at rc.resume (dist/swipl/swipl.js:8:172012)
      at Context.<anonymous> (tests/node.js:114:25)
```