### PR TITLE
FIXED: bf_set_si for -INT_MIN

### DIFF
--- a/src/libbf/libbf.c
+++ b/src/libbf/libbf.c
@@ -262,7 +262,10 @@ int bf_set_si(bf_t *r, int64_t a)
 {
     int ret;
 
-    if (a < 0) {
+    if (a == UINT64_MIN) { /* avoid undef. beh. for -INT_MIN */
+	ret = bf_set_ui(r, ((uint64_t) -(INT64_MIN + 1)) + 1U);
+	r->sign = 1;        
+    } else if (a < 0) {
 	ret = bf_set_ui(r, -a);
 	r->sign = 1;
     } else {


### PR DESCRIPTION
avoid undefined behavior raised by UBSAN