### PR TITLE
CLEANUP: avoid UBSAN error in mkvmi.c

### DIFF
--- a/src/mkvmi.c
+++ b/src/mkvmi.c
@@ -205,7 +205,8 @@ load_vmis(const char *file)
 	  exit(1);
 	} else
 	{ e4--;				/* backspace over ) */
-	  e5 -= is_vmh;
+	  if ( e5 )
+	    e5 -= is_vmh;
 	}
 
 	vmi_list[vmi_count].name  = my_strndup(s1, e1-s1);


### PR DESCRIPTION
The error is raised because we have e5 -= 0 for e5 == NULL

else-branch of if ( !e4 || (is_vmh && !e5) )
<=> e4 && !(is_vmh && !e5)
<=> e4 && (!is_vmh || e5)

Consequence is e4-- (which is fine) and e5 -= is_vmh which is either a noop* for is_vmh == 0 or fine for is_vmh != 0 && e5 != NULL.

*The noop case raises the error if e5 == NULL.