### PR TITLE
CLEANUP: Silence UBSAN message

### DIFF
--- a/src/pl-thread.c
+++ b/src/pl-thread.c
@@ -7645,7 +7645,8 @@ localiseDefinition(Definition def)
 
   *local = *def;
   local->impl.any.args = allocHeapOrHalt(bytes);
-  memcpy(local->impl.any.args, def->impl.any.args, bytes);
+  if ( bytes )
+    memcpy(local->impl.any.args, def->impl.any.args, bytes);
   clear(local, P_THREAD_LOCAL|P_DIRTYREG);	/* remains P_DYNAMIC */
   local->impl.clauses.first_clause = NULL;
   local->impl.clauses.clause_indexes = NULL;


### PR DESCRIPTION
Silences the following warning:

/.../swipl-devel/src/pl-thread.c:7649:5: runtime error: null pointer passed as argument 1, which is declared to never be null
/.../swipl-devel/src/pl-thread.c:7649:5: runtime error: null pointer passed as argument 2, which is declared to never be null

In the call that raises the error, arg1 and arg2 from a memcpy(arg1, arg2, bytes) are NULL, but bytes is also 0.