### PR TITLE
DOC: use modern update of submodules directly via git pull

### DIFF
--- a/CMAKE.md
+++ b/CMAKE.md
@@ -54,8 +54,7 @@ as follows:
 In most cases the following should  update   an  installed system to the
 latest version:
 
-    git pull
-    git submodule update --init
+    git pull --recurse-submodule
     cd build
     cmake ..
     ninja

--- a/CMAKE.md
+++ b/CMAKE.md
@@ -54,12 +54,15 @@ as follows:
 In most cases the following should  update   an  installed system to the
 latest version:
 
-    git pull --recurse-submodule
+    git pull
+    git submodule update --init
     cd build
     cmake ..
     ninja
     ctest -j 8
     ninja install
+
+The first two steps can be jointly done via `git pull --recurse-submodule=on-demand`.
 
 If the build fails, one could try to remove the entire `build` directory
 and re-create it as  above.  Note  that   the  build  process  makes  no


### PR DESCRIPTION
- Address comment in previous PR #1280 from @kamahen . Basically update the doc to update submodules via `git pull` directly, as it is more modern