### PR TITLE
prolog_pack: only check for git dir if git(false) is not in options

### DIFF
--- a/library/prolog_pack.pl
+++ b/library/prolog_pack.pl
@@ -893,7 +893,8 @@ pack_unpack_from_local(Source0, PackTopDir, Name, PackDir, Options) :-
             link_file(RelPath, PackDir, symbolic),
             assertion(same_file(Source, PackDir))
         )
-    ;   is_git_directory(Source)
+    ;   \+ option(git(false), Options),
+        is_git_directory(Source)
     ->  remove_existing_pack(PackDir, Options),
         run_process(path(git), [clone, Source, PackDir], [])
     ;   prepare_pack_dir(PackDir, Options),


### PR DESCRIPTION
Per #1305, currently trying to install a pack from a local dir will fail if git is not present, even if git would not be required to run the install.

This PR modifies the behavior of `pack_unpack_from_local/5` to check the options for an explicitly set `git(false)`, in which case the check for a git directory is skipped.