### PR TITLE
modify cmake ilink to install symlink in CMAKE_INSTALL_PREFIX

### DIFF
--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -33,7 +33,7 @@ FUNCTION(ILINK from to)
   get_filename_component(LNTNAME ${from} NAME)
   file(RELATIVE_PATH LNLNK ${LNTDIR} ${from})
   install(CODE "EXECUTE_PROCESS(COMMAND ln -sf ${LNLNK} ./${LNTNAME}
-				WORKING_DIRECTORY \$ENV{DESTDIR}${LNTDIR})")
+				WORKING_DIRECTORY \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}${LNTDIR})")
 ENDFUNCTION(ILINK)
 
 # Some autoconf utilities

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -735,10 +735,10 @@ else(WIN32)
 if(SWIPL_INSTALL_AS_LINK)
 # Create symbolic link from public installation dir to executables
 install(DIRECTORY DESTINATION bin)
-ilink(${CMAKE_INSTALL_PREFIX}/${SWIPL_INSTALL_ARCH_EXE}/swipl
-      ${CMAKE_INSTALL_PREFIX}/bin/swipl)
-ilink(${CMAKE_INSTALL_PREFIX}/${SWIPL_INSTALL_ARCH_EXE}/swipl-ld
-      ${CMAKE_INSTALL_PREFIX}/bin/swipl-ld)
+ilink(/${SWIPL_INSTALL_ARCH_EXE}/swipl
+      /bin/swipl)
+ilink(/${SWIPL_INSTALL_ARCH_EXE}/swipl-ld
+      /bin/swipl-ld)
 endif()
 
 endif(WIN32)


### PR DESCRIPTION
The `ilink` utility function in the cmake build was installing symlinks under `CMAKE_INSTALL_PREFIX` as it was known at configure time. This PR changes `ilink` to use `CMAKE_INSTALL_PREFIX` at install time, and modifies the calls to `ilink` accordingly.

`ilink` now takes two absolute paths without the `CMAKE_INSTALL_PREFIX`, and prepends `CMAKE_INSTALL_PREFIX` at install time.

This is a 3 part PR, since two submodules (swipl-win and jpl) also have to be changed to this new `ilink` contract. They need to be merged first, and then this PR can be updated to also include a submodule update.