### PR TITLE
FIXED: build order for dependencies in packs

### DIFF
--- a/library/prolog_pack.pl
+++ b/library/prolog_pack.pl
@@ -1415,8 +1415,9 @@ build_plan(Plan, Ordered, Options) :-
     (   ToBuild == []
     ->  Ordered = []
     ;   order_builds(ToBuild, Ordered),
-        confirm(build_plan(Ordered), yes, Options),
-        maplist(exec_plan_rebuild_step(Options), Ordered)
+        reverse(Ordered, Reversed),
+        confirm(build_plan(Ordered), yes, Reversed),
+        maplist(exec_plan_rebuild_step(Options), Reversed)
     ).
 
 needs_rebuild_from_info(Options, Info) :-


### PR DESCRIPTION
I think the order is in the wrong way. Say, pack a depends on pack b, and both have post-installation scripts. Then, pack b's script should be run before pack a's script. This does not seem to be the case here. If I reverse the order, it is running fine.

There's probably a better way to fix this (e.g., in build_order).