### PR TITLE
Append newly installed pack to file_search_path(pack, ...)

### DIFF
--- a/boot/packs.pl
+++ b/boot/packs.pl
@@ -183,7 +183,7 @@ attach_packs(_, _).
 register_packs_from(Dir) :-
     (   user:file_search_path(pack, Dir)
     ->  true
-    ;   asserta(user:file_search_path(pack, Dir))
+    ;   assertz(user:file_search_path(pack, Dir))
     ).
 
 attach_packages([], _, _).


### PR DESCRIPTION
To reproduce the problem:
$ rm -rf .local/share/swi-prolog/pack/
$ swipl
$ pack_install(date_time)
$ pack_install(environ) -> installed in the wrong folder ("tap")
$ file_search_path(pack, Dir). -> illustrates the problem

The patch appends the new directory to the path list.