### PR TITLE
Update pl-inline.h: end of data for murmur_key (please check carefully)

### DIFF
--- a/src/pl-inline.h
+++ b/src/pl-inline.h
@@ -762,7 +762,7 @@ murmur_key(const void *ptr, size_t n)
 
     for(size_t i=0; i<KEY_INDEX_MAX-2; i++)
       data[i] = in[i];
-    data[KEY_INDEX_MAX-2] = in[n/sizeof(word)-1];
+    data[KEY_INDEX_MAX-2] = in[n/sizeof(word)-2];
     data[KEY_INDEX_MAX-1] = n;
 
     k = MurmurHashAligned2(data, sizeof(word)*4, MURMUR_SEED);

--- a/src/pl-inline.h
+++ b/src/pl-inline.h
@@ -762,7 +762,9 @@ murmur_key(const void *ptr, size_t n)
 
     for(size_t i=0; i<KEY_INDEX_MAX-2; i++)
       data[i] = in[i];
-    data[KEY_INDEX_MAX-2] = in[n/sizeof(word)-2];
+
+    /* the extra n%... silences a -Warray-bounds warning */
+    data[KEY_INDEX_MAX-2] = in[n/sizeof(word) - n%sizeof(word) - 1];
     data[KEY_INDEX_MAX-1] = n;
 
     k = MurmurHashAligned2(data, sizeof(word)*4, MURMUR_SEED);


### PR DESCRIPTION
With 

````
CC="gcc-14 -std=gnu99 -fsanitize=address,undefined,bounds-strict -fno-omit-frame-pointer" CXX="g++ -std=gnu++17" CFLAGS="-g -O2 " CXXFLAGS="-g -O2  -fpic" cmake -DCMAKE_CXX_STANDARD=17 -S ..
````

I get a warning:

````
In function ‘murmur_key’,
    inlined from ‘indexKeyFromClause’ at /home/matthias/swipl-devel/src/pl-index.c:1455:12,
    inlined from ‘deleteActiveClauseFromIndex’ at /home/matthias/swipl-devel/src/pl-index.c:1475:14,
    inlined from ‘deleteActiveClauseFromIndexes’ at /home/matthias/swipl-devel/src/pl-index.c:1540:4:
/home/matthias/swipl-devel/src/pl-inline.h:765:31: warning: array subscript ‘word {aka long unsigned int}[3]’ is partly outside array bounds of ‘word[4]’ {aka ‘long unsigned int[4]’} [-Warray-bounds=]
  765 |     data[KEY_INDEX_MAX-2] = in[n/sizeof(word)-1]; // was n/sizeof(word)-1
      |                             ~~^~~~~~~~~~~~~~~~~~
/home/matthias/swipl-devel/src/pl-index.c: In function ‘deleteActiveClauseFromIndexes’:
/home/matthias/swipl-devel/src/pl-index.c:1441:10: note: at offset [25, 32] into object ‘key’ of size 32
 1441 |   { word key[MAX_MULTI_INDEX];                  /* TBD: special case for 1 arg */
      |          ^~~
````

Changing from -1 to -2 fixes the problem (and all tests in ctest pass). Needless to say, I have no idea what I am doing here :-P