### PR TITLE
Add predefined function del/1 on dict with some minimal tests

### DIFF
--- a/boot/dicts.pl
+++ b/boot/dicts.pl
@@ -63,6 +63,7 @@ is_dict_func(get(_)).
 is_dict_func(get(_,_)).
 is_dict_func(put(_)).
 is_dict_func(put(_,_)).
+is_dict_func(del(_)).
 
 
 %!  eval_dict_function(+Func, +Tag, +Dict, -Value)
@@ -98,6 +99,12 @@ eval_dict_function(put(Key, Value), _, Dict, NewDict) :-
 eval_dict_function(put(New), _, Dict, NewDict) :-
     !,
     put_dict(New, Dict, NewDict).
+eval_dict_function(del(Key), _, Dict, NewDict) :-
+  !,
+  ( atomic(Key)
+  -> del_dict(Key, Dict, _, NewDict)
+  ; del_dict_path(Key, Dict, NewDict)
+  ).
 eval_dict_function(Func, Tag, Dict, Value) :-
     call(Tag:Func, Dict, Value).
 
@@ -144,6 +151,19 @@ get_dict_path(Path, Dict, Value) :-
     get_dict(Key, Dict1, Value).
 get_dict_path(Key, Dict, Value) :-
     get_dict(Key, Dict, Value).
+
+del_dict_path(Path, Dict, NewDict) :-
+    compound(Path),
+    Path = (Path0/Key),
+    !,
+    '$dicts':get_dict_path(Path0, Dict, Subdict),
+    is_dict(Subdict),
+    del_dict(Key, Subdict, _, Subdict1),
+    '$dicts':put_dict_path(Path0, Dict, Subdict1, NewDict).
+
+del_dict_path(Key, Dict, NewDict) :-
+    del_dict(Key, Dict, _, NewDict).
+
 
 
                  /*******************************

--- a/tests/core/test_dict.pl
+++ b/tests/core/test_dict.pl
@@ -409,6 +409,14 @@ test(put2, Y =:= 4) :-
 	Y = X.y.
 test(metaarg, Out == [2]) :-
 	x_dict4(_{x:1}, [1], Out).
+test(del_nonexist, fail) :-
+	_{bar: 1}.del(foo).
+test(del_nonexist_nest, fail) :-
+	_{bar: _{baz: _{foo: 1}}}.del(bar/baz/foox).
+test(keypath_del_put, Out == a{foo: b{bar: c{buz: 3, bax: 2}}}) :-
+	Out = a{foo: b{bar: c{baz: 1, bax: 2}}}
+		.del(foo/bar/baz)
+		.put(foo/bar/buz, 3).
 
 :- end_tests(expand_functions).
 


### PR DESCRIPTION
This may need more work, but I just wanted to post this PR for discussion and see if this is something others may find useful. While working with dictionary based data structures, I've come to rely on `put(KeyPath, Value)`, but there is no "function" for deleting keys. This would add another predefined `del` consistent in naming with `del_dict/4` that also accepts a keypath.