### PR TITLE
FIXED: Prevent building the pack.pl app when there is no library_pack

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -253,8 +253,13 @@ list(APPEND SWIPL_DATA_library_dialect_sicstus4
 if(MULTI_THREADED)
   list(APPEND SWIPL_DATA_library_dialect_sicstus4 timeout.pl)
 endif()
+list(FIND SWIPL_DATA_library prolog_pack.pl HAS_PROLOG_PACK)
+if(NOT (HAS_PROLOG_PACK EQUALS -1))
 list(APPEND SWIPL_DATA_app
-     pack.pl splfr.pl)
+     pack.pl)
+endif()
+list(APPEND SWIPL_DATA_app
+     splfr.pl)
 endif()
 
 


### PR DESCRIPTION
The library is build conditionally starting from 2793ca547c3b185f50d2ce803c582874fc583b70, so the corresponding app needs to also be build conditionally based on the library presence.

The cmake check is slightly more expensive, but it does not rely on the fact that the inclusion of the library depends on the http package to be present.