### PR TITLE
More robust check for `git` command

### DIFF
--- a/library/prolog_pack.pl
+++ b/library/prolog_pack.pl
@@ -2801,10 +2801,14 @@ version_part(Int) --> integer(Int).
 
 have_git :-
     process_which(path(git), _),
-    catch(run_process(path(man),['-w', 'git'],[output(_),error(_)]),  % silent
-          error(Err,_),
-          \+ Err = process_error(_,_)  % test succeeds if `man` cmd not present
-         ).
+    (process_which(path('xcode-select'), XSpath)  % MacOS -> check for "imposter"
+     -> catch(run_process(path('xcode-select'),['-p'],[output(_),error(_)]),  % silent
+              _Err,  % any error -> xcode not installed,
+                     % any `git` in same dir as `xcode-select` is an imposter
+              \+ (file_directory_name(Gpath,Gdir), file_directory_name(XSpath,Gdir))
+             )
+     ;  true         % no `xcode-select`, assume valid `git`
+    ).
 
 
 %!  git_url(+URL, -Pack) is semidet.


### PR DESCRIPTION
On MacOS the `git` command is only present after the (optional) xcode support has been installed. Prior to that there is an "imposter" `git` which outputs text and a dialog indicating how xcode can be acquired. 

For users with no need for xcode, this change provides a more robust check for an operational `git` by additionally checking for a man page. I think this change is platform agnostic but I haven't tested it on Unix or Windows.