### PR TITLE
handle UNC files in prolog_dll

### DIFF
--- a/library/qsave.pl
+++ b/library/qsave.pl
@@ -991,8 +991,9 @@ copy_foreign_libraries(_ExeFile, _Options) :-
 
 prolog_dll(DLL) :-
     file_base_name(DLL, File),
-    absolute_file_name(foreign(File), DLL,
+    absolute_file_name(foreign(File), Abs,
                        [ solutions(all) ]),
+	same_file(DLL, Abs),
     !.
 
 copy_dll(Dest, DLL) :-


### PR DESCRIPTION
win_process_modules returns UNC paths on some systems. This patch handles dlls with UNC paths correctly.
https://swi-prolog.discourse.group/t/ann-swi-prolog-9-3-30/9258/11