### PR TITLE
MSYS2: Fix unit test for saved states (PR incomplete, advice needed)

### DIFF
--- a/tests/save/test_saved_states.pl
+++ b/tests/save/test_saved_states.pl
@@ -157,13 +157,12 @@ set_windows_path.
 
 create_state(File, Output, Args) :-
     me(Me),
-    append(Args, ['-o', Output, '-c', File, '-f', none], AllArgs0),
     (   current_prolog_flag(msys2, true)
-    ->  append(AllArgs0, '--foreign=copy', AllArgs1)
-    ;   AllArgs1 = AllArgs0
+    ->  append(Args, ['-o', Output, '-c', File, '-f', none, '--foreign=copy'], AllArgs)
+    ;   append(Args, ['-o', Output, '-c', File, '-f', none], AllArgs)
     ),
     test_dir(TestDir),
-    debug(save, 'Creating state in ~q using ~q ~q', [TestDir, Me, AllArgs1]),
+    debug(save, 'Creating state in ~q using ~q ~q', [TestDir, Me, AllArgs]),
     process_create(Me, AllArgs,
                    [ cwd(TestDir),
                      stderr(pipe(Err))

--- a/tests/save/test_saved_states.pl
+++ b/tests/save/test_saved_states.pl
@@ -157,9 +157,13 @@ set_windows_path.
 
 create_state(File, Output, Args) :-
     me(Me),
-    append(Args, ['-o', Output, '-c', File, '-f', none], AllArgs),
+    append(Args, ['-o', Output, '-c', File, '-f', none], AllArgs0),
+    (   current_prolog_flag(msys2, true)
+    ->  append(AllArgs0, '--foreign=copy', AllArgs1)
+    ;   AllArgs1 = AllArgs0
+    ),
     test_dir(TestDir),
-    debug(save, 'Creating state in ~q using ~q ~q', [TestDir, Me, AllArgs]),
+    debug(save, 'Creating state in ~q using ~q ~q', [TestDir, Me, AllArgs1]),
     process_create(Me, AllArgs,
                    [ cwd(TestDir),
                      stderr(pipe(Err))


### PR DESCRIPTION
This adds --foreign=copy to the unit test for saved states. I am unsure if it is _really_ needed, but at least the test passes if test_installation is run outside of swipls "bin" folder.

So, this worked before:
```
cd swipl/bin
./swipl
?- test_installation.
```

Now, this also works:
```
cd swipl
bin/swipl
?- test_installation.
```

The flip side is that some of the dlls are copied to the current folder, and they remain there. Unsure how to clean up sensibly.