### PR TITLE
attach after successful pack_rebuild

### DIFF
--- a/library/prolog_pack.pl
+++ b/library/prolog_pack.pl
@@ -2222,11 +2222,13 @@ pack_rebuild :-
 pack_rebuild(Pack) :-
     current_pack(Pack, PackDir),
     !,
-    post_install_foreign(Pack, PackDir, [rebuild(true)]).
+    post_install_foreign(Pack, PackDir, [rebuild(true)]),
+	pack_attach(PackDir, [duplicate(replace)]).
 pack_rebuild(Pack) :-
     unattached_pack(Pack, PackDir),
     !,
-    post_install_foreign(Pack, PackDir, [rebuild(true)]).
+    post_install_foreign(Pack, PackDir, [rebuild(true)]),
+	pack_attach(PackDir, [duplicate(replace)]).
 pack_rebuild(Pack) :-
     existence_error(pack, Pack).
 


### PR DESCRIPTION
To demonstrate, I forked pack "environ" and inserted a little typo into the C code.

````
$ swipl
?- pack_remove(environ). % to be sure
?- halt.
$ swipl
?- pack_install('https://github.com/mgondan/environ').
(error)
?- halt.
$ vim ~/.local/share/.../environ.c (remove the typo in line 7)
$ swipl
$ pack_rebuild(environ).
$ use_module(library(environ)). % this did not work before, one had to attach the pack or exit and enter swipl again
````

I completely agree that this is a very minor thing :-)