### PR TITLE
Corrected argument for error message in pl-files.c

### DIFF
--- a/src/os/pl-files.c
+++ b/src/os/pl-files.c
@@ -869,7 +869,7 @@ PRED_IMPL("$tmp_file_stream", 4, tmp_file_stream, 0)
     { enc = ENC_OCTET;
       mode = "wb";
     } else
-    { return PL_error(NULL, 0, NULL, ERR_DOMAIN, ATOM_encoding, A1);
+    { return PL_error(NULL, 0, NULL, ERR_DOMAIN, ATOM_encoding, A2);
     }
   } else
   { mode = "w";


### PR DESCRIPTION
tmp_file_stream(F, S, [encoding(binary1), extension(txt)]). ERROR: Domain error: `encoding' expected, found `txt'

The txt does not make sense