### PR TITLE
PORT: Allow for shell scripts swipl.sh and swipl.bat in test_saved_states

### DIFF
--- a/tests/save/test_saved_states.pl
+++ b/tests/save/test_saved_states.pl
@@ -123,7 +123,7 @@ state_output(Id, State) :-
 
 %!  me(-Exe, -Args:list) is det.
 %
-%   True when Exe is the executable to   run  for creating a saved state
+%   True when Exe is the executable  to  run  for creating a saved state
 %   and Args is a  list  of  commandline   arguments  to  pass  to  Exe.
 %   Normally, this merely runs `swipl`, but it can be necessary to embed
 %   this into some sort of script.


### PR DESCRIPTION
So far, test_saved_states allows for a swipl.sh in the current folder as a replacement for swipl. I guess this has to do with embedded systems and actually comes in quite handy if swipl should be invoked with extra arguments. I have added the same functionality for a swipl.bat under Windows. Since process_create/3 cannot invoke swipl.bat directly, but has to call cmd.exe /c swipl.bat instead, me/2 now takes an extra argument.

You can see this patch in action here, https://github.com/mgondan/rswipl/blob/main/inst/patch/05-tests.patch