### PR TITLE
FIXED: Make cpu_count flag return number of online processors when available

### DIFF
--- a/src/os/pl-os.c
+++ b/src/os/pl-os.c
@@ -377,13 +377,23 @@ WallTime(void)
 
 #ifdef HAVE_SC_NPROCESSORS_CONF
 
+#ifdef _SC_NPROCESSORS_ONLN
+
+int
+CpuCount(void)
+{ return sysconf(_SC_NPROCESSORS_ONLN);
+}
+
+#else
+
 int
 CpuCount(void)
 { return sysconf(_SC_NPROCESSORS_CONF);
 }
 
-#else
+#endif
 
+#else
 #ifdef PROCFS_CPUINFO
 int
 CpuCount(void)
@@ -449,7 +459,6 @@ CpuCount(void)
 #endif /*PROCFS_CPUINFO*/
 
 #endif /*HAVE_SC_NPROCESSORS_CONF*/
-
 
 void
 setOSPrologFlags(void)


### PR DESCRIPTION
This patch improves cpu_count detection on POSIX systems.

Currently SWI-Prolog uses sysconf(_SC_NPROCESSORS_CONF) to determine the number of processors. On some systems, the number of *configured* processors may be higher than the number of *online* processors, which causes cpu_count to overestimate the available concurrency.

This change prefers sysconf(_SC_NPROCESSORS_ONLN) when the libc defines the corresponding constant. If the platform does not support _SC_NPROCESSORS_ONLN, SWI-Prolog falls back to the existing _SC_NPROCESSORS_CONF logic. No change in behaviour occurs on systems that lack ONLN.

The result is that cpu_count now reflects what the OS scheduler sees as active CPUs. On systems where CONF > ONLN this produces a more accurate cpu_count value and avoids unexpected oversubscription.
