### PR TITLE
UBSAN: Avoid bit shift == sizeof(x)

### DIFF
--- a/src/libbf/bf_gmp.c
+++ b/src/libbf/bf_gmp.c
@@ -826,7 +826,8 @@ mpz_export(void *ROP, size_t *COUNTP, int ORDER,
       int shift = (int)(bytes*8-OP->expn);
       limb_t mask = (1<<shift)-1;
       limb_t low = l&mask;
-      limb_t high = low<<(sizeof(limb_t)*8-shift);
+	  /* Test for shift avoids an UBSAN error that 64-bit low is shifted by expo 64 */  
+      limb_t high = shift ? low<<(sizeof(limb_t)*8-shift) : 0;
       l >>= shift;
 
       *COUNTP = bytes;
@@ -842,7 +843,7 @@ mpz_export(void *ROP, size_t *COUNTP, int ORDER,
 	    low = l&mask;
 	    l>>=shift;
 	    l |= high;
-	    high = low<<(sizeof(limb_t)*8-shift);
+	    high = shift ? low<<(sizeof(limb_t)*8-shift) : 0;
 	  }
 	} else
 	  byte--;


### PR DESCRIPTION
The proposed change is not pretty, but it avoids another UBSAN error if low (64 bit) is << by 64 bits. I assume that this particular piece of code does not need to run in constant time.