### PR TITLE
UBSAN: check left and right != NULL

### DIFF
--- a/src/pl-variant.c
+++ b/src/pl-variant.c
@@ -115,8 +115,10 @@ next_arg(argPairs *a, Word *lp, Word *rp)   /* singular (not plural !) */
   *rp = a->work.right;
 
   a->work.arg++;
-  a->work.left++;
-  a->work.right++;
+  if( a->work.left )
+	  a->work.left++;
+  if ( a->work.right )
+	  a->work.right++;
 
   return true;
 }


### PR DESCRIPTION
I am unsure if "left" and "right" are actually allowed to be NULL, but in the runs of the unit tests, they sometimes are, and this causes an UBSAN error, see here:

win-builder.r-project.org/incoming_pretest/rswipl_10.1.0_20251218_005630/specialChecks/clang-san/process.txt

(3rd line): % [11-40/11] fast_heap:fast_heap ../home/hornik/tmp/CRAN_special_clang-san/rswipl.Rcheck/00_pkg_src/rswipl/src/swipl-devel/src/pl-variant.c:118:15: runtime error: applying non-zero offset 8 to null pointer