### PR TITLE
Fix uninitialized variable 'dts' in pl-trie.c

### DIFF
--- a/src/pl-trie.c
+++ b/src/pl-trie.c
@@ -2242,11 +2242,12 @@ add_choice(DECL_LD trie_gen_state *state, descent_state *dstate, trie_node *node
 
 	  if ( IS_TRIE_KEY_POP(children.key->key) && dstate->compound )
 	  { desc_tstate dts;
-	    popSegStack(&dstate->stack, &dts, desc_tstate);
-	    dstate->term = dts.term;
-	    dstate->size = dts.size;
-	    DEBUG(MSG_TRIE_GEN,
-		  Sdprintf("Popped %p, left %zd\n", dstate->term, dstate->size));
+	    if ( popSegStack(&dstate->stack, &dts, desc_tstate) )
+	    { dstate->term = dts.term;
+	      dstate->size = dts.size;
+	      DEBUG(MSG_TRIE_GEN,
+		    Sdprintf("Popped %p, left %zd\n", dstate->term, dstate->size));
+	    }
 	  }
 	  break;
 	} else


### PR DESCRIPTION
## Summary

Fixes MSVC Debug Runtime Check #3 error: "The variable 'dts' is being used without being initialized"

The issue occurs in `add_choice()` in `src/pl-trie.c` at lines 2243-2250, where `popSegStack()` return value was ignored. When the stack is empty at a `TN_KEY_POP` marker, `popSegStack` returns false and `dts` remains uninitialized, but the code was accessing `dts.term` and `dts.size` regardless.

## Changes

- Added conditional check around `dts` usage to only access fields when `popSegStack()` returns true
- This prevents undefined behavior when the stack is empty at a pop marker

## Tests Affected

Previously triggered MSVC Debug error dialog on:
- `xsb_sub:rrtc8` - Right-recursive transitive closure with compound terms
- `xsb_sub:drtc8` - Double-recursive transitive closure with compound terms

## Test Results

After fix, all 36 XSB subsumption tests pass without errors:

100% tests passed, 0 tests failed out of 1
Test #27: swipl:xsb/sub_tests ..............   Passed    1.88 sec

## Platform

- Windows 11
- MSVC (Visual Studio 2026)
- Debug build configuration
- All tests pass with no runtime check failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
