### PR TITLE
Fix ms_snprintf null-termination bug for edge case

### DIFF
--- a/src/pl-nt.c
+++ b/src/pl-nt.c
@@ -948,7 +948,7 @@ ms_snprintf(char *buffer, size_t count, const char *fmt, ...)
   ret = _vsnprintf(buffer, count-1, fmt, ap);
   va_end(ap);
 
-  if ( ret < 0 || ret == count )
+  if ( ret < 0 || ret >= (int)(count-1) )
   { ret = (int)count;
     buffer[count-1] = '\0';
   }


### PR DESCRIPTION
## Problem

The `large_float_1` test was failing because `ms_snprintf()` in `src/pl-nt.c` had a null-termination bug when output exactly filled `count-1` bytes.

When formatting `1e100` with `~6f`, the test expected 108 characters but received 516 characters, reading uninitialized memory (0xCD pattern in debug builds) past the intended string end.

## Root Cause

According to [Microsoft's _vsnprintf documentation](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/vsnprintf-vsnprintf-vsnprintf-l-vsnwprintf-vsnwprintf-l), when output length equals `count`, the buffer is NOT null-terminated.

The function calls `_vsnprintf(buffer, count-1, fmt, ap)` to reserve space for null, but when output exactly equals `count-1`, the old condition `ret == count` was FALSE, leaving buffer without null-termination.

## Solution

Changed condition from `ret == count` to `ret >= (int)(count-1)` to catch the edge case.

**Before:**
```c
if ( ret < 0 || ret == count )  // Missed ret == count-1 case
After:


if ( ret < 0 || ret >= (int)(count-1) )  // Catches all non-terminated cases
Testing
Build succeeds with MSVC on Windows
large_float_1 test now passes (was failing with 516 chars, now correctly returns 108)
All format tests pass
Impact
This bug affects all MSVC Windows builds whenever output exactly fills the buffer. The fix ensures proper null-termination in all cases.