### PR TITLE
CLEANUP: Avoid unreferenced variable warning in blocked_unload_shared_objects()

### DIFF
--- a/src/pl-load.c
+++ b/src/pl-load.c
@@ -192,14 +192,18 @@ blocked_unload_shared_objects(void)
   if ( vg == -1 )
   {
 #ifdef __SANITIZE_ADDRESS__
-    char *s;
-
 #ifndef __WINDOWS__
-    if ( (s=getenv("ASAN_OPTIONS")) && strstr(s,"detect_leaks=1") )
-#endif
+    { char *s;
+      if ( (s=getenv("ASAN_OPTIONS")) && strstr(s,"detect_leaks=1") )
+      { vg = true;
+	return vg;
+      }
+    }
+#else
     { vg = true;
       return vg;
     }
+#endif
 #endif
 
     if ( RUNNING_ON_VALGRIND )


### PR DESCRIPTION
Scope 'char *s' inside #ifndef __WINDOWS__ where it is used, fixing MSVC warning C4101.
