### PR TITLE
FIXED: Debug bootfile library autoload dependency

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -367,6 +367,13 @@ add_custom_command(
 )
 add_custom_target(bootfile DEPENDS ${SWIPL_BOOT_FILE} ${SWIPL_ABI_FILE})
 
+# Debug builds define O_DEBUG, which sets the prolog_debug flag,
+# causing boot/tabling.pl to autoload library(debug).  Without this
+# dependency, library files may not yet be copied to the build home
+# when the bootfile step runs.  PGO builds already add this via
+# add_pgo_dependency().
+add_dependencies(bootfile prolog_home)
+
 # Update library `INDEX.pl` files
 
 add_custom_target(library_index)


### PR DESCRIPTION
Adds prolog_home dependency to bootfile step. Fixes library autoload failures in Debug builds where O_DEBUG causes boot/tabling.pl to require library(debug).