### PR TITLE
TEST: Verify clean process exit after HTTP server lifecycle

### DIFF
--- a/tests/thread/test_thread_exit.pl
+++ b/tests/thread/test_thread_exit.pl
@@ -1,0 +1,84 @@
+/*  Part of SWI-Prolog
+
+    Author:        Eric Taucher
+    E-mail:        eric.taucher@gmail.com
+    WWW:           http://www.swi-prolog.org
+    Copyright (c)  2026, SWI-Prolog Solutions b.v.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in
+       the documentation and/or other materials provided with the
+       distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+    ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+*/
+
+:- module(test_thread_exit,
+	  [ test_thread_exit/0
+	  ]).
+:- use_module(library(plunit)).
+:- use_module(library(process)).
+
+/** <module> Test clean process exit after thread usage
+
+Verify that a process using threads exits cleanly without crashing.
+On Windows with PThreads4W, the library's DllMain(DLL_PROCESS_DETACH)
+runs after PL_cleanup() has freed thread data.  Without explicit
+cleanup via pthread_win32_process_detach_np(), this causes
+ACCESS_VIOLATION in Debug builds where the CRT fills freed heap
+with 0xDD.
+
+The test spawns a subprocess that starts and stops an HTTP server,
+then halts.  The HTTP server creates worker threads and allocates
+enough memory that PL_cleanup() triggers the crash in Debug builds.
+The parent verifies the exit code is 0 (not a crash).
+
+@see pthread_win32_process_detach_np() in src/pl-init.c
+*/
+
+test_thread_exit :-
+	run_tests([thread_exit]).
+
+:- begin_tests(thread_exit,
+	       [ condition(current_prolog_flag(threads, true))
+	       ]).
+
+test(clean_exit) :-
+	Goal = 'use_module(library(http/thread_httpd)),\c
+	        use_module(library(http/http_dispatch)),\c
+	        http_server(http_dispatch,[port(Port)]),\c
+	        http_stop_server(Port,[]),\c
+	        halt(0)',
+	process_create(
+	    prolog(swipl),
+	    [ '-f', 'none',
+	      '-g', Goal
+	    ],
+	    [ process(Pid),
+	      stderr(pipe(Err))
+	    ]),
+	read_stream_to_codes(Err, _),
+	close(Err),
+	process_wait(Pid, Status),
+	assertion(Status == exit(0)).
+
+:- end_tests(thread_exit).


### PR DESCRIPTION
Uses HTTP server start/stop pattern to reliably reproduce threading cleanup issues. Details in commit message.