### PR TITLE
ADDED: msvc_debug prolog flag for MSVC Debug builds

### DIFF
--- a/src/os/pl-prologflag.c
+++ b/src/os/pl-prologflag.c
@@ -2133,6 +2133,9 @@ initPrologFlags(void)
 
 #if defined(__WINDOWS__) && defined(_DEBUG)
   setPrologFlag("kernel_compile_mode", FT_ATOM|FF_READONLY, "debug");
+#if defined(_MSC_VER)
+  setPrologFlag("msvc_debug", FT_BOOL|FF_READONLY, true, 0);
+#endif
 #endif
 
 #if defined(BUILD_TIME) && defined(BUILD_DATE)

--- a/tests/GC/test_ch_shift.pl
+++ b/tests/GC/test_ch_shift.pl
@@ -43,6 +43,7 @@ test_ch_shift :-
 
 or_dept(Depth), current_prolog_flag(asan,true) => Depth = 1000.
 or_dept(Depth), current_prolog_flag(emscripten,true) => Depth = 1000.
+or_dept(Depth), current_prolog_flag(msvc_debug,true) => Depth = 1000.
 or_dept(Depth), current_prolog_flag(windows,true) => Depth = 5000.
 or_dept(Depth) => Depth = 10_000.
 


### PR DESCRIPTION
MSVC Debug builds have higher stack usage due to disabled optimizations. Reduce test depth when running on MSVC Debug to prevent stack overflow in test_ch_shift.