### PR TITLE
TEST: added tests for library(record)

### DIFF
--- a/library/record.pl
+++ b/library/record.pl
@@ -104,7 +104,17 @@ is_record(Name, M, X) :-
 %     * =|set_<constructor>_fields|=(+Fields, +Record0, -Record).
 %     * =|set_<constructor>_fields|=(+Fields, +Record0, -Record, -RestFields).
 %     * =|set_<constructor>_field|=(+Field, +Record0, -Record).
-%     * =|user:current_record|=(:<constructor>)
+%     * =|user:current_record|=(?<name>, :<constructor>).
+%
+%   In the above, the Fields arguments are a list of the form Name(Value).
+%   If a name appears more than once, the last value is used.
+%   For make_<constructor>/3, RestFields gets a list of Name(Value) that
+%   were not used; make_<constructor>/2 requires that all the names are
+%   in the record.
+%
+%   These predicates fail if there is an error (e.g., if make_<constructor>/2
+%   has a field name that isn't in the record); the exceptions are if
+%   type checking throws an exception.
 
 record(Record) :-
     Record == '<compiled>',
@@ -294,13 +304,11 @@ is_predicate(Constructor, Types) -->
       clean_body(Body0, Body),
       Term =.. [Constructor|Vars],
       atom_concat(is_, Constructor, Name),
-      Head1 =.. [Name,Var],
-      Head2 =.. [Name,Term]
+      Head =.. [Name,VarOrTerm]
     },
-    [   (Head1 :- var(Var), !, fail) ],
     (   { Body == true }
-    ->  [ Head2 ]
-    ;   [ (Head2 :- Body) ]
+    ->  [ (Head :- nonvar(VarOrTerm), VarOrTerm = Term) ]
+    ;   [ (Head :- nonvar(VarOrTerm), VarOrTerm = Term, Body) ]
     ).
 
 type_checks([], [], true).

--- a/tests/library/test_record.pl
+++ b/tests/library/test_record.pl
@@ -55,14 +55,66 @@ test_record :-
 :- record foo(x:integer).
 :- record bar(x:foo).
 :- record r(x:list(integer)).
+:- record zot(x).
 
 test(record_type, true) :-
 	make_foo([x(10)], Foo),
 	make_bar([x(Foo)], Bar),
 	is_bar(Bar).
+test(record_type, foo(1) == Foo) :-
+	default_foo(Foo),
+	foo_x(Foo, 1),
+	is_foo(Foo).
+test(record_type, fail) :-
+	default_foo(Foo),
+	is_foo(Foo).
 test(list_type, true) :-
 	make_r([x([1,2,3])], _).
 test(list_type, error(type_error(_,_))) :-
 	make_r([x([1,2,a])], _).
+test(record_no_type, zot(_) =@= Zot) :-
+	make_zot([], Zot),
+	is_zot(Zot).
+
+% Example from the documentation
+
+:- record point(x:integer=0, y:integer=0).
+
+test(point, R == point(1,2)) :-
+    make_point([y(2), x(1)], R),
+    is_point(R),
+    point_x(R, X), X==1,
+    point_y(R, Y), Y==2.
+test(point, R == point(0,2)) :-
+    make_point([y(2)], R),
+    is_point(R),
+    point_x(R, X), X==0,
+    point_y(R, Y), Y==2.
+test(point, fail) :-
+    is_point(_R).
+test(point, true) :-
+    is_point(point(1,2)).
+test(point, fail) :-
+    is_point(point(_,2)).
+test(point, error(instantiation_error)) :-
+    make_point([x(1),y(_)], _R).
+test(point, error(type_error(integer,foo))) :-
+    make_point([x(1),y(foo)], _R).
+test(point, fail) :-
+    make_point([x(1),z(3)], _R).
+
+test(point, P-R == point(1,10)-[z(123)]) :-
+    make_point([y(0), x(1), y(10), z(123)], P, R).
+test(point, P-R == point(1,10)-[z(123)]) :-
+    make_point([z(123), y(0), y(10), x(1)], P, R).
+
+test(point, M:T == plunit_record:point(x:integer=0,y:integer=0)) :-
+    current_record(point, M:T).
+test(point, set(M:T == [plunit_record:point(x:integer=0,y:integer=0)])) :-
+    current_record(N, M:T),
+    N = point.
+
+% No need for testing most of the remainder of the predicates bbecause
+% they're used in implementing the predicates tested above.
 
 :- end_tests(record).


### PR DESCRIPTION
I was going to add something to the module but realized it wasn't needed -- but by then I had added some tests.

I've also simplified the code generated for is_<constructor>/1 (I disassembled the two variations and count the same number of opcodes, if a backtrack is counted as an opcode)