### PR TITLE
Exclude jvm.dll from CPack dependencies

### DIFF
--- a/cmake/RuntimeDependencies.cmake
+++ b/cmake/RuntimeDependencies.cmake
@@ -42,6 +42,7 @@ function(install_target_runtime_dependencies)
 	    PRE_EXCLUDE_REGEXES
 	      "api-ms-" "ext-ms-"
 	      "python[0-9]*\.dll"
+	      "jvm\.dll"
 	    POST_EXCLUDE_REGEXES
 	      ".*system32/.*"
 	    DIRECTORIES


### PR DESCRIPTION
Exclude jvm.dll from CPack runtime dependency resolution.