### PR TITLE
BUILD: add flag for building protoc plug-in

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,11 +111,32 @@ option(BUILD_TESTING
 option(SKIP_SSL_TESTS
        "Skip the SSL tests"
        OFF)
-# The following test requires installing protobuf-compiler python3-protobuf
-# libprotobuf-devel (or protobuf-devel)
-option(TEST_PROTOBUFS_PROTOC
-       "Run protobuf tests that require protoc, etc."
+
+# BUILD_PROTOBUFS_PROTOC is only needed if some new feature has been
+# added to the protobuf language. The details are given in
+# packages/protobufs/README.md and
+# packages/protobufs/bootstrap/README.md.
+
+# NOTE: as of 2026-05-04, the BUILD_PROTOBUFS_PROTOC flags is not used;
+#       it requires some changes to packages/protobufs.
+
+option(BUILD_PROTOBUFS_PROTOC
+       "Build protobuf with latest protoc"
        OFF)
+# TEST_PROTOBUFS_PROTOC runs optional tests on packages/protobufs that
+# test the plugin for protoc.  The test requires installing packages
+# protobuf-compiler python3-protobuf libprotobuf-devel (or
+# protobuf-devel):
+if(BUILD_PROTOBUFS_PROTOC)
+    option(TEST_PROTOBUFS_PROTOC
+           "Run protobuf tests that require protoc, etc."
+           ON)
+else()
+    option(TEST_PROTOBUFS_PROTOC
+           "Run protobuf tests that require protoc, etc."
+           OFF)
+endif()
+
 option(BUILD_SWIPL_LD
        "Create the swipl-ld utility"
        ON)


### PR DESCRIPTION
It'll be a little while before I finish the PR that uses this flag, but it'd be nice to have it already available when I finish the PR.