### PR TITLE
Clicking a pl-file in  Windows 11 Task Bar and current directory becomes c:\windows\system32 problem

### DIFF
--- a/cmake/Pack.cmake
+++ b/cmake/Pack.cmake
@@ -98,6 +98,9 @@ if(WIN32)
   set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS "
    WriteRegStr HKLM 'Software\\\\SWI\\\\Prolog' 'fileExtension' 'pl'
    WriteRegStr HKLM 'Software\\\\SWI\\\\Prolog' 'home' '$INSTDIR'
+   WriteRegStr HKCR '.pl' '' 'swipl_file'
+   WriteRegStr HKCR 'swipl_file' '' 'SWI-Prolog source file'
+   WriteRegStr HKCR 'swipl_file\\\\shell\\\\open\\\\command' '' '\"$INSTDIR\\\\bin\\\\swipl-win.exe\" --win_app \"%1\"'
    ")
   set(CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS "
    DeleteRegKey HKLM 'Software\\\\SWI\\\\Prolog'


### PR DESCRIPTION
Not sure if all Windows users have this problem but I do. The problem mentioned propably is a NSIS installer problem. I did chat with plain ChatGPT about this fix, and I am pretty convinced this would fix it. 

I am thinking of testing the installer  with the nightly build, so that I won't have to build the whole swipl to fix a small installer problem. 