### PR TITLE
Avoid self-deadlock in engine_destroy/1

### DIFF
--- a/man/engines.plx
+++ b/man/engines.plx
@@ -316,8 +316,9 @@ The \arg{Engine} argument of engine_create/3 may be instantiated to an
 atom, creating an engine with the given alias.
 
     \predicate[det]{engine_destroy}{1}{+Engine}
-Destroy \arg{Engine}.  If the engine is still in use, this call blocks
-until the engine is free.
+Destroy \arg{Engine}.  If the engine is still in use by another thread,
+this call blocks until the engine is free.  Destroying the engine that
+is running this call raises a permission error.
 
     \predicate[semidet]{engine_next}{2}{+Engine, -Term}
 Ask the engine \arg{Engine} to produce a next answer.  On this first

--- a/src/pl-thread.c
+++ b/src/pl-thread.c
@@ -4166,7 +4166,10 @@ PRED_IMPL("engine_destroy", 1, engine_destroy, 0)
   thread_handle *th;
 
   if ( get_interactor(A1, &th, true) )
-  { simpleMutexLock(th->interactor.mutex);
+  { if ( th->info == LD->thread.info )
+      return PL_permission_error("destroy", "engine", A1);
+
+    simpleMutexLock(th->interactor.mutex);
     destroy_interactor(th, false, true);
 
     return true;

--- a/tests/engines/test_engines.pl
+++ b/tests/engines/test_engines.pl
@@ -46,6 +46,12 @@ test(error, Ex == foo) :-
 	engine_create(_, throw(foo), E),
 	catch(engine_next(E, _), Ex, true),
 	engine_destroy(E).
+test(self_destroy, [ error(permission_error(destroy, engine, _)),
+		     cleanup(ignore(engine_destroy(E))) ]) :-
+	engine_create(_, ( engine_self(E),
+			   engine_destroy(E)
+			 ), E),
+	engine_next(E, _).
 text(mixed, all(R) == [1,aap,2,3]) :-
 	mixed_yield_answers(R).
 test(no_data, error(existence_error(term, delivery, E))) :-


### PR DESCRIPTION
## Summary

- reject attempts to call engine_destroy/1 on the currently running engine with a permission error
- add a regression test for the self-destroy case
- document the new error behavior

## Root cause

engine_next/2 runs the engine goal while holding the engine interactor mutex. If that goal calls engine_destroy/1 on itself, the same thread tries to lock the non-recursive mutex again and deadlocks.

## Validation

- cmake --build build-test --target swipl -j 8
- build-test/src/swipl -f none --no-packs --on-error=status -s tests/engines/test_engines.pl -g "run_tests([engines]), halt" -t halt
- ctest --test-dir build-test -R '^swipl:engines$' --output-on-failure