### PR TITLE
Fix mixed engine test declaration

### DIFF
--- a/tests/engines/test_engines.pl
+++ b/tests/engines/test_engines.pl
@@ -46,7 +46,7 @@ test(error, Ex == foo) :-
 	engine_create(_, throw(foo), E),
 	catch(engine_next(E, _), Ex, true),
 	engine_destroy(E).
-text(mixed, all(R) == [1,aap,2,3]) :-
+test(mixed, all(R == [1,aap,2,3])) :-
 	mixed_yield_answers(R).
 test(no_data, error(existence_error(term, delivery, E))) :-
 	setup_call_cleanup(


### PR DESCRIPTION
## Summary

- fix the disabled mixed engine test by changing text/2 to test/2
- correct the plunit all/1 expectation so it validates the full answer sequence

## Validation

- build-test/src/swipl -f none --no-packs --on-error=status -s tests/engines/test_engines.pl -g "run_tests([engines]), halt" -t halt