### PR TITLE
wasm: support Emscripten 6.0.0 rename of arguments_ to programArgs

### DIFF
--- a/src/wasm/prolog.js
+++ b/src/wasm/prolog.js
@@ -2363,7 +2363,14 @@ class Query {
 		 *******************************/
 
 Module.onRuntimeInitialized = function()
-{ Module.prolog = new Prolog(Module, arguments_);
+{ // Emscripten 6.0.0 renamed its internal program-arguments variable from
+  // `arguments_` to `programArgs`.  Accept either so we keep working across
+  // Emscripten versions instead of throwing `ReferenceError: arguments_ is
+  // not defined` at startup.
+  const argv = typeof arguments_ !== "undefined" ? arguments_
+             : typeof programArgs !== "undefined" ? programArgs
+             : [];
+  Module.prolog = new Prolog(Module, argv);
 };
 
 		 /*******************************


### PR DESCRIPTION
## Problem

Building the WASM port with **Emscripten ≥ 6.0.0** produces a bundle that throws at startup:

```
ReferenceError: arguments_ is not defined
    at Module.onRuntimeInitialized (.../swipl-web.js)
```

Every query then fails because the Prolog instance is never created.

## Root cause

Emscripten 6.0.0 renamed its internal, module-scoped program-arguments variable from `arguments_` to `programArgs` (see [`emscripten-core/emscripten`, `src/shell.js`](https://github.com/emscripten-core/emscripten/blob/main/src/shell.js)):

| | Emscripten 5.x | Emscripten 6.0.0 |
|---|---|---|
| `src/shell.js` | `var arguments_ = [];` | `var programArgs = [];` |

`src/wasm/prolog.js` is injected into the same Emscripten module closure and still reads the old name in `Module.onRuntimeInitialized`:

```js
Module.onRuntimeInitialized = function()
{ Module.prolog = new Prolog(Module, arguments_);   // arguments_ no longer exists under Emscripten >= 6
};
```

The value is just the program `argv`, only used as `argv0 = this.args || []` in `Prolog.__initialize()` — effectively empty in the bundle — so it is safe to source from either variable.

## Fix

Read whichever variable the active Emscripten version defines, falling back to an empty `argv`. `typeof` is safe on an undeclared identifier, so this works on both old (≤ 5.x) and new (≥ 6.0.0) Emscripten with no version detection:

```js
const argv = typeof arguments_ !== "undefined" ? arguments_
           : typeof programArgs !== "undefined" ? programArgs
           : [];
Module.prolog = new Prolog(Module, argv);
```

## How this was found

Discovered while bumping emsdk 5.0.7 → 6.0.0 in the [`npm-swipl-wasm`](https://github.com/SWI-Prolog/npm-swipl-wasm) packaging repo, where the upgrade made the entire Node test suite fail with this `ReferenceError`.