### PR TITLE
FIXED: Include <poll.h> based on HAVE_POLL instead of HAVE_POLL_H

### DIFF
--- a/src/os/pl-file.c
+++ b/src/os/pl-file.c
@@ -69,7 +69,7 @@ handling times must be cleaned, but that not only holds for this module.
 #include "../pl-trace.h"
 #include <errno.h>
 
-#if defined(HAVE_POLL_H) && defined(HAVE_POLL)
+#if defined(HAVE_POLL)
 #include <poll.h>
 #elif defined(HAVE_SYS_SELECT_H)
 #include <sys/select.h>

--- a/src/os/pl-stream.c
+++ b/src/os/pl-stream.c
@@ -101,7 +101,7 @@ locking is required.
 #include <stdarg.h>
 #include <ctype.h>
 #include <sys/stat.h>
-#if defined(HAVE_POLL_H)
+#if defined(HAVE_POLL)
 #include <poll.h>
 #elif defined(HAVE_SYS_SELECT_H)
 #include <sys/select.h>

--- a/src/pl-fli.c
+++ b/src/pl-fli.c
@@ -5394,7 +5394,7 @@ PL_dispatch_hook(PL_dispatch_hook_t hook)
 
 
 #if defined(HAVE_SELECT) && !defined(__WINDOWS__)
-#if defined(HAVE_POLL_H) && defined(HAVE_POLL)
+#if defined(HAVE_POLL)
 #include <poll.h>
 #elif defined(HAVE_SYS_SELECT_H)
 #include <sys/select.h>


### PR DESCRIPTION
The streams/I/O code includes <poll.h> guarded by HAVE_POLL_H, but decides
whether to actually call poll() and use `struct pollfd` based on HAVE_POLL.
These come from two independent configure probes (check_include_file vs
check_function_exists). When they disagree -- e.g. the poll() function is
detected (HAVE_POLL) but the header probe for poll.h fails for an unrelated
reason -- <poll.h> is omitted while poll() is still compiled, producing:

  error: array has incomplete element type 'struct pollfd'
  error: use of undeclared identifier 'POLLIN'

in src/os/pl-stream.c, src/os/pl-file.c and src/pl-fli.c.

Gate the #include on the same HAVE_POLL symbol that gates its use, so the
header is included exactly when poll() is used. On any system providing
poll() the header is present; the Windows/WSAPoll path is unaffected since
HAVE_POLL is not defined at these include sites there.

Signed-off-by: Piotr Kubaj <pkubaj@FreeBSD.org>
